### PR TITLE
feat(#7): claude 코드 리뷰 설정

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,132 @@
+name: Claude PR Review
+
+on:
+  # dev 브랜치로 PR을 처음 열었을 때 자동 리뷰
+  # Draft PR은 리뷰하지 않고 Ready 전환 시 리뷰
+  pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - ready_for_review
+
+  # PR 일반 댓글에 @claude review 작성 시 재리뷰
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  # --------------------------------------------------
+  # 1. PR 최초 자동 리뷰
+  # --------------------------------------------------
+  automatic-review:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: PR 코드 체크아웃
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude 자동 코드 리뷰
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          include_fix_links: false
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            현재 Pull Request의 변경사항을 코드 리뷰하세요.
+
+            저장소 루트에 CLAUDE.md가 있다면 먼저 읽고,
+            해당 프로젝트의 규칙을 리뷰 기준으로 사용하세요.
+
+            다음 항목을 우선 검토하세요.
+
+            1. 실제 실행 오류 또는 예외 발생 가능성
+            2. 잘못된 비즈니스 로직
+            3. Null 처리와 경계값 누락
+            4. 트랜잭션과 데이터 정합성
+            5. 인증·인가 및 민감정보 노출
+            6. 중복 요청과 멱등성 문제
+            7. 예외 처리와 HTTP 상태 코드
+            8. 핵심 기능 테스트 누락
+
+            리뷰 규칙:
+
+            - 모든 코멘트는 한국어로 작성하세요.
+            - 이번 PR에서 변경된 코드만 검토하세요.
+            - 기존 코드에 이미 존재하던 문제는 지적하지 마세요.
+            - 단순 포맷, 취향, 사소한 네이밍은 지적하지 마세요.
+            - 실제 수정 가치가 있는 문제만 게시하세요.
+            - 문제 발생 상황과 수정 방향을 함께 설명하세요.
+            - 특정 줄의 문제는 반드시 해당 줄에 인라인 코멘트로 게시하세요.
+            - 인라인 코멘트 도구를 사용할 때 confirmed: true를 지정하세요.
+            - 전체적인 내용만 gh pr comment로 게시하세요.
+            - 리뷰 결과는 반드시 GitHub PR에 게시하세요.
+            - 문제가 없다면 "중대한 문제를 발견하지 못했습니다."라고 짧게 작성하세요.
+
+            심각도:
+
+            - [BLOCKER]&#58; 보안 사고, 실행 불가, 데이터 손실
+            - [HIGH]&#58; 핵심 로직 오류 또는 잘못된 결과
+            - [MEDIUM]&#58; 안정성이나 유지보수에 실질적인 영향
+            - [LOW]&#58; 수정 가치가 명확한 작은 개선
+
+          claude_args: |
+            --max-turns 15
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+  # --------------------------------------------------
+  # 2. @claude review 댓글 재리뷰
+  # --------------------------------------------------
+  manual-review:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
+      startsWith(github.event.comment.body, '@claude review') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: PR 최신 코드 체크아웃
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
+
+      - name: Claude 수동 재리뷰
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude review"
+          include_fix_links: false
+
+          claude_args: |
+            --max-turns 15
+            --append-system-prompt "현재 Pull Request의 최신 변경사항을 코드 리뷰하라. 모든 코멘트는 한국어로 작성하고, 이번 PR에서 변경된 코드만 검토하라. 단순 스타일이나 취향 차이는 지적하지 말고 실제 버그, 잘못된 로직, 데이터 정합성, 트랜잭션, 보안, 예외 처리, 테스트 누락을 우선 검토하라. 특정 코드 문제는 mcp__github_inline_comment__create_inline_comment를 사용해 해당 줄에 게시하고 confirmed: true를 지정하라. 문제가 없으면 중대한 문제를 발견하지 못했다고 짧게 작성하라."
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #1

## 🛠 작업 사항

- Claude Pro의 Oauth token을 이용하여 PR 시 최초 1회에만 코드 리뷰가 생성되도록 설정 (사용량 절감 목적)
- dev로 가는 모든 PR 대상에 대해 코드 리뷰 생성

## ✅ 테스트

- [ ] 로컬 서버 테스트 완료
- [ ] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 수정 후 수동으로 재 리뷰를 하기 위해서는 @claude review 를 코멘트에 작성하면 최신 코드 리뷰 기준으로 다시 리뷰 합니다.
- 단, 다음과 같은 조건이 필요합니다. 
   - PR이 아직 열려 있어야 함
   - 댓글 맨 앞이 @claude review여야 함
