### PR TITLE
refactor(#22): userId 기반 회원 관리 로직으로 리팩토링

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/user/controller/UserController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/controller/UserController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,11 +53,10 @@ public class UserController {
     @GetMapping("/api/users/me")
     public UserResponse getMyInfo(
             @Parameter(hidden = true)
-            Authentication authentication
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId
     ) {
-        String userKey = authentication.getName();
-
-        return userService.getMyInfo(userKey);
+        return userService.getMyInfo(userId);
     }
 
     @Operation(
@@ -79,10 +78,9 @@ public class UserController {
     @DeleteMapping("/api/users/me")
     public void withdraw(
             @Parameter(hidden = true)
-            Authentication authentication
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId
     ) {
-        String userKey = authentication.getName();
-
-        userService.withdraw(userKey);
+        userService.withdraw(userId);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/UserDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/UserDTO.java
@@ -1,9 +1,6 @@
 package org.teamsai.saibackend.domain.user.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,7 +11,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class UserDTO {
     private Long userId;
-    private String userKey;
+    private String userToken; //회원가입할 때 발급
+    private String userKey; //계좌 연결할 때 발급
     private String email;
     private String password;
     private String name;

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserLoginResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserLoginResponse.java
@@ -13,7 +13,7 @@ import org.teamsai.saibackend.domain.user.dto.UserDTO;
 public class UserLoginResponse {
 
     private String accessToken;
-    private String userKey;
+    private String userToken;
     private String name;
 
     public static UserLoginResponse of(
@@ -22,7 +22,7 @@ public class UserLoginResponse {
     ) {
         return UserLoginResponse.builder()
                 .accessToken(accessToken)
-                .userKey(user.getUserKey())
+                .userToken(user.getUserToken())
                 .name(user.getName())
                 .build();
     }

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserResponse.java
@@ -13,14 +13,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserResponse {
 
-    private String userKey;
+    private String userToken;
     private String email;
     private String name;
     private LocalDate birthDate;
 
     public static UserResponse from(UserDTO user) {
         return UserResponse.builder()
-                .userKey(user.getUserKey())
+                .userToken(user.getUserToken())
                 .email(user.getEmail())
                 .name(user.getName())
                 .birthDate(user.getBirthDate())

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserSignUpResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserSignUpResponse.java
@@ -12,13 +12,13 @@ import org.teamsai.saibackend.domain.user.dto.UserDTO;
 @AllArgsConstructor
 public class UserSignUpResponse {
 
-    private String userKey;
+    private String userToken;
     private String email;
     private String name;
 
     public static UserSignUpResponse from(UserDTO user) {
         return new UserSignUpResponse(
-                user.getUserKey(),
+                user.getUserToken(),
                 user.getEmail(),
                 user.getName()
         );

--- a/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
@@ -36,9 +36,9 @@ public enum UserErrorCode
             "로그인이 필요하거나 토큰이 유효하지 않습니다."
     ),
 
-    USER_KEY_GENERATION_FAILED(
+    USER_TOKEN_GENERATION_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
-        "회원 초대 코드 생성에 실패했습니다."
+            "회원 초대 코드 생성에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/user/mapper/UserMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/mapper/UserMapper.java
@@ -16,17 +16,27 @@ public interface UserMapper {
             @Param("email") String email
     );
 
+    Optional<UserDTO> findById(
+            @Param("userId") Long userId
+    );
+
     Optional<UserDTO> findByEmail(
             @Param("email") String email
     );
 
-    Optional<UserDTO> findByUserKey(
-            @Param("userKey") String userKey
+    Optional<UserDTO> findByUserToken(
+            @Param("userToken") String userToken
     );
 
-    int deleteByUserKey(String userKey);
+    int deleteById(
+            @Param("userId") Long userId
+    );
 
-    boolean existsByUserKey(
-            @Param("userKey") String userKey
+    boolean existsByUserToken(
+            @Param("userToken") String userToken
+    );
+
+    String findUserKeyById(
+            @Param("userId") Long userId
     );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/service/AuthService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/service/AuthService.java
@@ -5,11 +5,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.dto.request.UserLoginRequest;
 import org.teamsai.saibackend.domain.user.dto.request.UserSignUpRequest;
 import org.teamsai.saibackend.domain.user.dto.response.UserLoginResponse;
 import org.teamsai.saibackend.domain.user.dto.response.UserSignUpResponse;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
 import org.teamsai.saibackend.domain.user.mapper.UserMapper;
 import org.teamsai.saibackend.global.jwt.JwtTokenProvider;
@@ -22,6 +22,17 @@ import java.util.Locale;
 @Transactional(readOnly = true)
 public class AuthService {
 
+    private static final String USER_TOKEN_PREFIX = "SAI-";
+
+    private static final String USER_TOKEN_CHARACTERS =
+            "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+    private static final int USER_TOKEN_LENGTH = 8;
+    private static final int USER_TOKEN_GENERATION_ATTEMPTS = 10;
+
+    private static final SecureRandom RANDOM =
+            new SecureRandom();
+
     private final UserMapper userMapper;
     private final AuthValidator authValidator;
     private final PasswordEncoder passwordEncoder;
@@ -31,12 +42,14 @@ public class AuthService {
     public UserSignUpResponse signUp(
             UserSignUpRequest request
     ) {
-        String email = normalizeEmail(request.getEmail());
+        String email =
+                normalizeEmail(request.getEmail());
 
         authValidator.validateSignUp(email);
 
         UserDTO user = UserDTO.builder()
-                .userKey(createUserKey())
+                .userToken(createUserToken())
+                .userKey(null)
                 .email(email)
                 .password(
                         passwordEncoder.encode(
@@ -49,9 +62,11 @@ public class AuthService {
 
         try {
             userMapper.insert(user);
+
         } catch (DataIntegrityViolationException exception) {
             if (isEmailUniqueConstraintViolation(exception)) {
-                throw UserErrorCode.DUPLICATE_EMAIL.toException();
+                throw UserErrorCode.DUPLICATE_EMAIL
+                        .toException();
             }
 
             throw exception;
@@ -60,20 +75,29 @@ public class AuthService {
         return UserSignUpResponse.from(user);
     }
 
-    public UserLoginResponse login(UserLoginRequest request) {
-        String email = normalizeEmail(request.getEmail());
+    public UserLoginResponse login(
+            UserLoginRequest request
+    ) {
+        String email =
+                normalizeEmail(request.getEmail());
 
         UserDTO user = userMapper.findByEmail(email)
                 .orElseThrow(
-                        UserErrorCode.INVALID_LOGIN_CREDENTIALS::toException
+                        UserErrorCode
+                                .INVALID_LOGIN_CREDENTIALS
+                                ::toException
                 );
+
         authValidator.validateLoginPassword(
                 request.getPassword(),
                 user.getPassword()
         );
 
+
         String accessToken =
-                jwtTokenProvider.createAccessToken(user.getUserKey());
+                jwtTokenProvider.createAccessToken(
+                        user.getUserId()
+                );
 
         return UserLoginResponse.of(
                 user,
@@ -81,52 +105,63 @@ public class AuthService {
         );
     }
 
-    private static final String USER_KEY_PREFIX = "SAI-";
+    private String createUserToken() {
+        for (
+                int attempt = 0;
+                attempt < USER_TOKEN_GENERATION_ATTEMPTS;
+                attempt++
+        ) {
+            StringBuilder token =
+                    new StringBuilder(USER_TOKEN_PREFIX);
 
-    private static final String USER_KEY_CHARACTERS =
-            "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+            for (int i = 0; i < USER_TOKEN_LENGTH; i++) {
+                int index =
+                        RANDOM.nextInt(
+                                USER_TOKEN_CHARACTERS.length()
+                        );
 
-    private static final int USER_KEY_LENGTH = 8;
-
-    private static final SecureRandom RANDOM = new SecureRandom();
-
-
-    private String createUserKey() {
-        for (int attempt = 0; attempt < 10; attempt++) {
-            StringBuilder key = new StringBuilder(USER_KEY_PREFIX);
-
-            for (int i = 0; i < USER_KEY_LENGTH; i++) {
-                int index = RANDOM.nextInt(USER_KEY_CHARACTERS.length());
-                key.append(USER_KEY_CHARACTERS.charAt(index));
+                token.append(
+                        USER_TOKEN_CHARACTERS.charAt(index)
+                );
             }
 
-            String userKey = key.toString();
+            String userToken =
+                    token.toString();
 
-            if (!userMapper.existsByUserKey(userKey)) {
-                return userKey;
+            if (!userMapper.existsByUserToken(userToken)) {
+                return userToken;
             }
         }
 
-        throw UserErrorCode.USER_KEY_GENERATION_FAILED.toException();
+        throw UserErrorCode
+                .USER_TOKEN_GENERATION_FAILED
+                .toException();
     }
 
     private String normalizeEmail(String email) {
-        return email.trim().toLowerCase(Locale.ROOT);
+        return email
+                .trim()
+                .toLowerCase(Locale.ROOT);
     }
+
     private boolean isEmailUniqueConstraintViolation(
             Throwable exception
     ) {
         Throwable cause = exception;
+
         while (cause != null) {
-            String message = cause.getMessage();
-            if (message != null && message.contains("uk_users_email")
-            ) {
+            String message =
+                    cause.getMessage();
+
+            if (message != null
+                    && message.contains("uk_users_email")) {
+
                 return true;
             }
+
             cause = cause.getCause();
         }
 
         return false;
     }
-
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/service/UserService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/service/UserService.java
@@ -15,23 +15,23 @@ public class UserService {
 
     private final UserMapper userMapper;
 
-    public UserResponse getMyInfo(String userKey) {
-        UserDTO user = getUser(userKey);
+    public UserResponse getMyInfo(Long userId) {
+        UserDTO user = getUser(userId);
 
         return UserResponse.from(user);
     }
 
     @Transactional
-    public void withdraw(String userKey) {
-        int deletedCount = userMapper.deleteByUserKey(userKey);
+    public void withdraw(Long userId) {
+        int deletedCount = userMapper.deleteById(userId);
 
         if (deletedCount == 0) {
             throw UserErrorCode.USER_NOT_FOUND.toException();
         }
     }
 
-    private UserDTO getUser(String userKey) {
-        return userMapper.findByUserKey(userKey)
+    private UserDTO getUser(Long userId) {
+        return userMapper.findById(userId)
                 .orElseThrow(
                         UserErrorCode.USER_NOT_FOUND::toException
                 );

--- a/src/main/java/org/teamsai/saibackend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/teamsai/saibackend/global/jwt/JwtAuthenticationFilter.java
@@ -15,9 +15,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.mapper.UserMapper;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Optional;
 
 @Component
@@ -50,29 +50,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token,
             HttpServletRequest request
     ) {
-        Optional<String> userKeyOptional =
-                jwtTokenProvider.getUserKeyIfValid(token);
+        Optional<Long> userIdOptional =
+                jwtTokenProvider.getUserIdIfValid(token);
 
-        if (userKeyOptional.isEmpty()) {
+        if (userIdOptional.isEmpty()) {
             return;
         }
 
-        String userKey = userKeyOptional.get();
+        Long userId = userIdOptional.get();
 
         Optional<UserDTO> userOptional =
-                userMapper.findByUserKey(userKey);
+                userMapper.findById(userId);
 
         if (userOptional.isEmpty()) {
             return;
         }
 
-        UserDTO user = userOptional.get();
+        CustomUserDetails userDetails = new CustomUserDetails(
+                        userOptional.get()
+        );
 
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(
-                        user.getUserKey(),
+                        userDetails,
                         null,
-                        Collections.emptyList()
+                        userDetails.getAuthorities()
                 );
 
         authentication.setDetails(

--- a/src/main/java/org/teamsai/saibackend/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/teamsai/saibackend/global/jwt/JwtTokenProvider.java
@@ -29,30 +29,30 @@ public class JwtTokenProvider {
         this.accessTokenExpirationMs = accessTokenExpirationMs;
     }
 
-    public String createAccessToken(String userKey) {
+    public String createAccessToken(Long userId) {
         Date issuedAt = new Date();
         Date expiration = new Date(
                 issuedAt.getTime() + accessTokenExpirationMs
         );
 
         return Jwts.builder()
-                .subject(userKey)
+                .subject(String.valueOf(userId))
                 .issuedAt(issuedAt)
                 .expiration(expiration)
                 .signWith(signingKey)
                 .compact();
     }
 
-    public Optional<String> getUserKeyIfValid(String token) {
+    public Optional<Long> getUserIdIfValid(String token) {
         try {
             Claims claims = parseClaims(token);
-            String userKey = claims.getSubject();
+            String subject = claims.getSubject();
 
-            if (userKey == null || userKey.isBlank()) {
+            if (subject == null || subject.isBlank()) {
                 return Optional.empty();
             }
 
-            return Optional.of(userKey);
+            return Optional.of(Long.valueOf(subject));
         } catch (JwtException | IllegalArgumentException exception) {
             return Optional.empty();
         }

--- a/src/main/java/org/teamsai/saibackend/global/security/CustomUserDetails.java
+++ b/src/main/java/org/teamsai/saibackend/global/security/CustomUserDetails.java
@@ -1,0 +1,50 @@
+package org.teamsai.saibackend.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final String userToken;
+    private final String userKey;
+    private final Long userId;
+
+    public CustomUserDetails(UserDTO user) {
+        this.userToken = user.getUserToken();
+        this.userKey = user.getUserKey();
+        this.userId = user.getUserId();
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(userId);
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/resources/db/user.sql
+++ b/src/main/resources/db/user.sql
@@ -41,6 +41,15 @@ WHERE user_token IS NOT NULL
   AND user_key = user_token
   AND user_token LIKE 'SAI-%';
 
+UPDATE users
+SET user_token = CONCAT(
+        'MIG-',
+        user_id,
+        '-',
+    LEFT(REPLACE(UUID(), '-', ''), 11)
+    )
+WHERE user_token IS NULL;
+
 ALTER TABLE users
     MODIFY COLUMN user_token VARCHAR(36) NOT NULL;
 

--- a/src/main/resources/db/user.sql
+++ b/src/main/resources/db/user.sql
@@ -1,6 +1,9 @@
 CREATE TABLE IF NOT EXISTS users (
                                      user_id BIGINT NOT NULL AUTO_INCREMENT,
-                                     user_key VARCHAR(36) NOT NULL,
+
+                                     user_token VARCHAR(36) NOT NULL,
+    user_key VARCHAR(100) NULL,
+
     email VARCHAR(100) NOT NULL,
     password VARCHAR(255) NOT NULL,
     name VARCHAR(50) NOT NULL,
@@ -10,8 +13,39 @@ CREATE TABLE IF NOT EXISTS users (
     ON UPDATE CURRENT_TIMESTAMP,
 
     PRIMARY KEY (user_id),
+    UNIQUE KEY uk_users_user_token (user_token),
     UNIQUE KEY uk_users_user_key (user_key),
     UNIQUE KEY uk_users_email (email)
     ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_unicode_ci;
+
+
+-- 기존 테이블 마이그레이션
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS user_token VARCHAR(36) NULL
+    AFTER user_id;
+
+ALTER TABLE users
+    MODIFY COLUMN user_key VARCHAR(100) NULL;
+
+UPDATE users
+SET user_token = user_key
+WHERE user_token IS NULL
+  AND user_key IS NOT NULL
+  AND user_key LIKE 'SAI-%';
+
+UPDATE users
+SET user_key = NULL
+WHERE user_token IS NOT NULL
+  AND user_key = user_token
+  AND user_token LIKE 'SAI-%';
+
+ALTER TABLE users
+    MODIFY COLUMN user_token VARCHAR(36) NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_users_user_token
+    ON users (user_token);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_users_user_key
+    ON users (user_key);

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -10,6 +10,7 @@
 
         <id property="userId" column="user_id"/>
 
+        <result property="userToken" column="user_token"/>
         <result property="userKey" column="user_key"/>
         <result property="email" column="email"/>
         <result property="password" column="password"/>
@@ -18,7 +19,6 @@
 
     </resultMap>
 
-    <!-- 이메일 중복 확인 -->
     <select id="existsByEmail"
             resultType="boolean">
         SELECT EXISTS (
@@ -28,7 +28,6 @@
         )
     </select>
 
-    <!-- 회원가입 -->
     <insert id="insert"
             parameterType="org.teamsai.saibackend.domain.user.dto.UserDTO"
             useGeneratedKeys="true"
@@ -36,14 +35,14 @@
             keyColumn="user_id">
 
         INSERT INTO users (
-        user_key,
+        user_token,
         email,
         password,
         name,
         birth_date
         )
         VALUES (
-        #{userKey},
+        #{userToken},
         #{email},
         #{password},
         #{name},
@@ -52,12 +51,12 @@
 
     </insert>
 
-    <!-- 로그인용 회원 조회 -->
     <select id="findByEmail"
             resultMap="userResultMap">
 
         SELECT
         user_id,
+        user_token,
         user_key,
         email,
         password,
@@ -68,37 +67,64 @@
 
     </select>
 
-    <!-- JWT 인증 및 내 정보 조회 -->
-    <select id="findByUserKey"
+    <!-- 내부 PK 기반 회원 조회 -->
+    <select id="findById"
             resultMap="userResultMap">
 
         SELECT
         user_id,
+        user_token,
         user_key,
         email,
         password,
         name,
         birth_date
         FROM users
-        WHERE user_key = #{userKey}
+        WHERE user_id = #{userId}
 
     </select>
 
-    <!-- 회원 탈퇴: 실제 데이터 삭제 -->
+    <!-- 정산 초대 코드 기반 회원 조회 -->
+    <select id="findByUserToken"
+            resultMap="userResultMap">
 
-    <delete id="deleteByUserKey">
+        SELECT
+        user_id,
+        user_token,
+        user_key,
+        email,
+        password,
+        name,
+        birth_date
+        FROM users
+        WHERE user_token = #{userToken}
+
+    </select>
+
+    <delete id="deleteById">
+
         DELETE FROM users
-        WHERE user_key = #{userKey}
+        WHERE user_id = #{userId}
+
     </delete>
 
-    <select id="existsByUserKey"
+    <select id="existsByUserToken"
             resultType="boolean">
 
         SELECT EXISTS (
         SELECT 1
         FROM users
-        WHERE user_key = #{userKey}
+        WHERE user_token = #{userToken}
         )
+
+    </select>
+
+    <select id="findUserKeyById"
+            resultType="string">
+
+        SELECT user_key
+        FROM users
+        WHERE user_id = #{userId}
 
     </select>
 

--- a/src/test/java/org/teamsai/saibackend/domain/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,134 @@
+package org.teamsai.saibackend.domain.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.global.jwt.JwtTokenProvider;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JwtTokenProvider 단위 테스트")
+class JwtTokenProviderTest {
+
+    private static final long ACCESS_TOKEN_EXPIRATION_MS =
+            60 * 60 * 1000L;
+
+    private static final Long USER_ID = 1L;
+
+    private String secret;
+    private SecretKey signingKey;
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        byte[] keyBytes =
+                "01234567890123456789012345678901"
+                        .getBytes(StandardCharsets.UTF_8);
+
+        secret = Encoders.BASE64.encode(keyBytes);
+        signingKey = Keys.hmacShaKeyFor(keyBytes);
+
+        jwtTokenProvider =
+                new JwtTokenProvider(
+                        secret,
+                        ACCESS_TOKEN_EXPIRATION_MS
+                );
+    }
+
+    @Test
+    @DisplayName("userId를 subject로 저장하고 다시 Long으로 반환한다")
+    void createAndParseUserIdToken() {
+        String token =
+                jwtTokenProvider.createAccessToken(USER_ID);
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdIfValid(token);
+
+        assertThat(parsedUserId)
+                .contains(USER_ID);
+    }
+
+    @Test
+    @DisplayName("subject가 숫자가 아니면 유효하지 않은 토큰으로 처리한다")
+    void nonNumericSubjectIsInvalid() {
+        String token = createToken(
+                "SAI-ABCDEFGH",
+                new Date(
+                        System.currentTimeMillis()
+                                + ACCESS_TOKEN_EXPIRATION_MS
+                ),
+                signingKey
+        );
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdIfValid(token);
+
+        assertThat(parsedUserId).isEmpty();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 유효하지 않은 토큰으로 처리한다")
+    void expiredTokenIsInvalid() {
+        String token = createToken(
+                String.valueOf(USER_ID),
+                new Date(
+                        System.currentTimeMillis()
+                                - 1000L
+                ),
+                signingKey
+        );
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdIfValid(token);
+
+        assertThat(parsedUserId).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명된 토큰은 유효하지 않은 토큰으로 처리한다")
+    void tokenSignedWithDifferentKeyIsInvalid() {
+        byte[] otherKeyBytes =
+                "abcdefghijklmnopqrstuvwxyz123456"
+                        .getBytes(StandardCharsets.UTF_8);
+
+        SecretKey otherSigningKey =
+                Keys.hmacShaKeyFor(otherKeyBytes);
+
+        String token = createToken(
+                String.valueOf(USER_ID),
+                new Date(
+                        System.currentTimeMillis()
+                                + ACCESS_TOKEN_EXPIRATION_MS
+                ),
+                otherSigningKey
+        );
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdIfValid(token);
+
+        assertThat(parsedUserId).isEmpty();
+    }
+
+    private String createToken(
+            String subject,
+            Date expiration,
+            SecretKey key
+    ) {
+        Date issuedAt = new Date();
+
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(issuedAt)
+                .expiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/user/AuthServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/user/AuthServiceTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -45,7 +46,10 @@ import static org.mockito.Mockito.verify;
 @DisplayName("AuthService 단위 테스트")
 class AuthServiceTest {
 
-    private static final String USER_KEY = "SAI-ABCDEFGH";
+    private static final Long USER_ID = 1L;
+    private static final String USER_TOKEN = "SAI-ABCDEFGH";
+    private static final String USER_KEY = "mock-bank-user-key";
+
     private static final String RAW_PASSWORD = "Password1!";
     private static final String ENCODED_PASSWORD = "encoded-password";
 
@@ -82,7 +86,7 @@ class AuthServiceTest {
                     LocalDate.of(2002, 10, 22)
             );
 
-            given(userMapper.existsByUserKey(anyString()))
+            given(userMapper.existsByUserToken(anyString()))
                     .willReturn(false);
 
             given(passwordEncoder.encode(RAW_PASSWORD))
@@ -108,8 +112,11 @@ class AuthServiceTest {
 
             UserDTO savedUser = userCaptor.getValue();
 
-            assertThat(savedUser.getUserKey())
+            assertThat(savedUser.getUserToken())
                     .matches("^SAI-[A-HJ-NP-Z2-9]{8}$");
+
+            assertThat(savedUser.getUserKey())
+                    .isNull();
 
             assertThat(savedUser.getEmail())
                     .isEqualTo("user@example.com");
@@ -123,8 +130,8 @@ class AuthServiceTest {
             assertThat(savedUser.getBirthDate())
                     .isEqualTo(LocalDate.of(2002, 10, 22));
 
-            assertThat(response.getUserKey())
-                    .isEqualTo(savedUser.getUserKey());
+            assertThat(response.getUserToken())
+                    .isEqualTo(savedUser.getUserToken());
 
             assertThat(response.getEmail())
                     .isEqualTo("user@example.com");
@@ -158,15 +165,15 @@ class AuthServiceTest {
                     .encode(anyString());
 
             verify(userMapper, never())
-                    .existsByUserKey(anyString());
+                    .existsByUserToken(anyString());
 
             verify(userMapper, never())
                     .insert(any(UserDTO.class));
         }
 
         @Test
-        @DisplayName("사용자 키를 10회 연속 생성하지 못하면 예외가 발생한다")
-        void signUpFailsWhenUserKeyGenerationFails() {
+        @DisplayName("사용자 토큰을 10회 연속 생성하지 못하면 예외가 발생한다")
+        void signUpFailsWhenUserTokenGenerationFails() {
             UserSignUpRequest request = createSignUpRequest(
                     "user@example.com",
                     RAW_PASSWORD,
@@ -174,7 +181,7 @@ class AuthServiceTest {
                     LocalDate.of(2002, 10, 22)
             );
 
-            given(userMapper.existsByUserKey(anyString()))
+            given(userMapper.existsByUserToken(anyString()))
                     .willReturn(true);
 
             assertThatThrownBy(
@@ -184,12 +191,12 @@ class AuthServiceTest {
                     exception -> assertThat(
                             exception.getErrorCode()
                     ).isEqualTo(
-                            UserErrorCode.USER_KEY_GENERATION_FAILED
+                            UserErrorCode.USER_TOKEN_GENERATION_FAILED
                     )
             );
 
             verify(userMapper, times(10))
-                    .existsByUserKey(anyString());
+                    .existsByUserToken(anyString());
 
             verify(passwordEncoder, never())
                     .encode(anyString());
@@ -208,7 +215,7 @@ class AuthServiceTest {
                     LocalDate.of(2002, 10, 22)
             );
 
-            given(userMapper.existsByUserKey(anyString()))
+            given(userMapper.existsByUserToken(anyString()))
                     .willReturn(false);
 
             given(passwordEncoder.encode(RAW_PASSWORD))
@@ -253,7 +260,7 @@ class AuthServiceTest {
                     .insert(any(UserDTO.class));
 
             verify(jwtTokenProvider, never())
-                    .createAccessToken(anyString());
+                    .createAccessToken(anyLong());
         }
     }
 
@@ -303,7 +310,7 @@ class AuthServiceTest {
     class Login {
 
         @Test
-        @DisplayName("회원 조회와 비밀번호 검증에 성공하면 JWT를 발급한다")
+        @DisplayName("회원 조회와 비밀번호 검증에 성공하면 userId 기반 JWT를 발급한다")
         void loginSuccess() {
             UserLoginRequest request = createLoginRequest(
                     "  USER@Example.COM  ",
@@ -315,7 +322,7 @@ class AuthServiceTest {
             given(userMapper.findByEmail("user@example.com"))
                     .willReturn(Optional.of(user));
 
-            given(jwtTokenProvider.createAccessToken(USER_KEY))
+            given(jwtTokenProvider.createAccessToken(USER_ID))
                     .willReturn("access-token");
 
             UserLoginResponse response =
@@ -328,13 +335,13 @@ class AuthServiceTest {
                     );
 
             verify(jwtTokenProvider)
-                    .createAccessToken(USER_KEY);
+                    .createAccessToken(USER_ID);
 
             assertThat(response.getAccessToken())
                     .isEqualTo("access-token");
 
-            assertThat(response.getUserKey())
-                    .isEqualTo(USER_KEY);
+            assertThat(response.getUserToken())
+                    .isEqualTo(USER_TOKEN);
 
             assertThat(response.getName())
                     .isEqualTo("김사이");
@@ -369,7 +376,7 @@ class AuthServiceTest {
                     );
 
             verify(jwtTokenProvider, never())
-                    .createAccessToken(anyString());
+                    .createAccessToken(anyLong());
         }
 
         @Test
@@ -402,7 +409,7 @@ class AuthServiceTest {
             ).isSameAs(expectedException);
 
             verify(jwtTokenProvider, never())
-                    .createAccessToken(anyString());
+                    .createAccessToken(anyLong());
         }
     }
 
@@ -466,7 +473,8 @@ class AuthServiceTest {
 
     private UserDTO createUser() {
         return UserDTO.builder()
-                .userId(1L)
+                .userId(USER_ID)
+                .userToken(USER_TOKEN)
                 .userKey(USER_KEY)
                 .email("user@example.com")
                 .password(ENCODED_PASSWORD)

--- a/src/test/java/org/teamsai/saibackend/domain/user/UserServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/user/UserServiceTest.java
@@ -1,4 +1,5 @@
 package org.teamsai.saibackend.domain.user;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,9 @@ import static org.mockito.Mockito.verify;
 @DisplayName("UserService 단위 테스트")
 class UserServiceTest {
 
-    private static final String USER_KEY = "SAI-ABCDEFGH";
+    private static final Long USER_ID = 1L;
+    private static final String USER_TOKEN = "SAI-ABCDEFGH";
+    private static final String USER_KEY = "mock-bank-user-key";
 
     @Mock
     private UserMapper userMapper;
@@ -38,14 +41,14 @@ class UserServiceTest {
     class GetMyInfo {
 
         @Test
-        @DisplayName("사용자 키로 회원을 조회해 응답 DTO로 반환한다")
+        @DisplayName("사용자 ID로 회원을 조회해 응답 DTO로 반환한다")
         void getMyInfoSuccess() {
-            given(userMapper.findByUserKey(USER_KEY))
+            given(userMapper.findById(USER_ID))
                     .willReturn(Optional.of(createUser()));
 
-            UserResponse response = userService.getMyInfo(USER_KEY);
+            UserResponse response = userService.getMyInfo(USER_ID);
 
-            assertThat(response.getUserKey()).isEqualTo(USER_KEY);
+            assertThat(response.getUserToken()).isEqualTo(USER_TOKEN);
             assertThat(response.getEmail()).isEqualTo("user@example.com");
             assertThat(response.getName()).isEqualTo("김사이");
             assertThat(response.getBirthDate())
@@ -53,12 +56,12 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("사용자 키에 해당하는 회원이 없으면 예외가 발생한다")
+        @DisplayName("사용자 ID에 해당하는 회원이 없으면 예외가 발생한다")
         void getMyInfoFailsWhenUserDoesNotExist() {
-            given(userMapper.findByUserKey(USER_KEY))
+            given(userMapper.findById(USER_ID))
                     .willReturn(Optional.empty());
 
-            assertUserNotFound(() -> userService.getMyInfo(USER_KEY));
+            assertUserNotFound(() -> userService.getMyInfo(USER_ID));
         }
     }
 
@@ -67,23 +70,23 @@ class UserServiceTest {
     class Withdraw {
 
         @Test
-        @DisplayName("사용자 키로 회원을 바로 삭제한다")
+        @DisplayName("사용자 ID로 회원을 바로 삭제한다")
         void withdrawSuccess() {
-            given(userMapper.deleteByUserKey(USER_KEY)).willReturn(1);
+            given(userMapper.deleteById(USER_ID)).willReturn(1);
 
-            userService.withdraw(USER_KEY);
+            userService.withdraw(USER_ID);
 
-            verify(userMapper).deleteByUserKey(USER_KEY);
+            verify(userMapper).deleteById(USER_ID);
         }
 
         @Test
         @DisplayName("삭제된 행이 0개이면 회원 없음 예외가 발생한다")
         void withdrawFailsWhenUserDoesNotExist() {
-            given(userMapper.deleteByUserKey(USER_KEY)).willReturn(0);
+            given(userMapper.deleteById(USER_ID)).willReturn(0);
 
-            assertUserNotFound(() -> userService.withdraw(USER_KEY));
+            assertUserNotFound(() -> userService.withdraw(USER_ID));
 
-            verify(userMapper).deleteByUserKey(USER_KEY);
+            verify(userMapper).deleteById(USER_ID);
         }
     }
 
@@ -98,7 +101,8 @@ class UserServiceTest {
 
     private UserDTO createUser() {
         return UserDTO.builder()
-                .userId(1L)
+                .userId(USER_ID)
+                .userToken(USER_TOKEN)
                 .userKey(USER_KEY)
                 .email("user@example.com")
                 .password("encoded-password")


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #22 

## 🛠 작업 사항

- 회원 초대용 식별값인 userToken 필드 추가
- 기존 userKey가 담당하던 회원 초대 코드 역할을 userToken으로 이전
- userKey는 Mock은행 계좌 연동키 용도로 분리
- JWT 사용자 식별 기준을 userKey에서 userId로 변경
- 내 정보 조회 및 회원 탈퇴를 userId 기준으로 변경
- 기존 회원 데이터의 userKey 값을 userToken으로 이전하는 스키마 마이그레이션 추가
- 회원가입 시 userToken을 생성하고, userKey는 계좌 연동 전까지 NULL로 관리
- 관련 Mapper, Service, 응답 DTO 및 테스트 코드 수정

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 현재 user 도메인 로직을 수정하고 있을 경우 pull 필요