### PR TITLE
feat(#15): 본인 인증 서비스 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
@@ -1,0 +1,61 @@
+package org.teamsai.saibackend.domain.identity.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.teamsai.saibackend.domain.identity.dto.request.IdentityPrepareRequest;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityCompleteResponse;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityPrepareResponse;
+import org.teamsai.saibackend.domain.identity.service.IdentityService;
+
+@RestController
+@RequestMapping("/api/identity-verifications")
+@RequiredArgsConstructor
+public class IdentityController {
+
+    private final IdentityService identityService;
+
+    @PostMapping
+    public ResponseEntity<IdentityPrepareResponse> prepare(
+            @AuthenticationPrincipal
+            Long userId,
+
+            @Valid
+            @RequestBody
+            IdentityPrepareRequest request
+    ) {
+        IdentityPrepareResponse response =
+                identityService.prepare(
+                        userId,
+                        request
+                );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @PostMapping("/{identityVerificationId}/complete")
+    public ResponseEntity<IdentityCompleteResponse> complete(
+            @AuthenticationPrincipal
+            Long userId,
+
+            @PathVariable
+            String identityVerificationId
+    ) {
+        IdentityCompleteResponse response =
+                identityService.complete(
+                        userId,
+                        identityVerificationId
+                );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
@@ -66,7 +66,6 @@ public class IdentityController {
             @RequestBody
             IdentityPrepareRequest request
     ) {
-        System.out.println("Identity principal userId = " + userId);
         IdentityPrepareResponse response =
                 identityService.prepare(userId, request);
 

--- a/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/controller/IdentityController.java
@@ -1,52 +1,127 @@
 package org.teamsai.saibackend.domain.identity.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.teamsai.saibackend.domain.identity.dto.request.IdentityPrepareRequest;
 import org.teamsai.saibackend.domain.identity.dto.response.IdentityCompleteResponse;
 import org.teamsai.saibackend.domain.identity.dto.response.IdentityPrepareResponse;
 import org.teamsai.saibackend.domain.identity.service.IdentityService;
 
-@RestController
-@RequestMapping("/api/identity-verifications")
+@Tag(
+        name = "본인인증 API",
+        description = "포트원 본인인증 요청 준비 및 결과 검증 API"
+)
+@Controller
 @RequiredArgsConstructor
 public class IdentityController {
 
     private final IdentityService identityService;
 
-    @PostMapping
+
+    @GetMapping("/identity-test")
+    public String identityTestPage() {
+        return "identity/identity-test";
+    }
+
+    @Operation(
+            summary = "본인인증 요청 준비",
+            description = "본인인증 요청을 생성하고 포트원 SDK 호출에 필요한 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "본인인증 요청 생성 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 본인인증 목적"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            )
+    })
+    @ResponseBody
+    @PostMapping("/api/identity-verifications")
     public ResponseEntity<IdentityPrepareResponse> prepare(
-            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
             Long userId,
 
             @Valid
             @RequestBody
             IdentityPrepareRequest request
     ) {
+        System.out.println("Identity principal userId = " + userId);
         IdentityPrepareResponse response =
-                identityService.prepare(
-                        userId,
-                        request
-                );
+                identityService.prepare(userId, request);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);
     }
 
-    @PostMapping("/{identityVerificationId}/complete")
+    @Operation(
+            summary = "본인인증 완료 처리",
+            description = "포트원 서버에서 인증 결과를 조회하고 현재 로그인 회원과 동일인인지 검증합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "본인인증 완료"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "본인인증 실패 또는 회원정보 불일치"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "다른 사용자의 본인인증 요청"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "본인인증 요청을 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "본인인증 미완료 또는 처리할 수 없는 상태"
+            ),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = "포트원 API 호출 실패"
+            )
+    })
+    @ResponseBody
+    @PostMapping(
+            "/api/identity-verifications/{identityVerificationId}/complete"
+    )
     public ResponseEntity<IdentityCompleteResponse> complete(
-            @AuthenticationPrincipal
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
             Long userId,
 
+            @Parameter(
+                    description = "본인인증 요청 식별값",
+                    example = "identity-verification-a1b2c3d4"
+            )
             @PathVariable
             String identityVerificationId
     ) {

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/IdentityDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/IdentityDTO.java
@@ -1,0 +1,31 @@
+package org.teamsai.saibackend.domain.identity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+import org.teamsai.saibackend.domain.identity.type.IdentityStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdentityDTO {
+
+    private Long identityId;
+    private String identityVerificationId;
+    private Long userId;
+
+    private IdentityPurpose purpose;
+    private IdentityStatus status;
+
+    private LocalDateTime requestedAt;
+    private LocalDateTime verifiedAt;
+    private LocalDateTime expiresAt;
+    private LocalDateTime usedAt;
+
+    private String failureReason;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/request/IdentityPrepareRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/request/IdentityPrepareRequest.java
@@ -1,7 +1,10 @@
 package org.teamsai.saibackend.domain.identity.dto.request;
 
-import lombok.NonNull;
+import jakarta.validation.constraints.NotNull;
 import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
 
-public record IdentityPrepareRequest(@NonNull IdentityPurpose purpose) {
+public record IdentityPrepareRequest(
+        @NotNull(message = "본인인증 목적은 필수입니다.")
+        IdentityPurpose purpose
+) {
 }

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/request/IdentityPrepareRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/request/IdentityPrepareRequest.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.identity.dto.request;
+
+import lombok.NonNull;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+
+public record IdentityPrepareRequest(@NonNull IdentityPurpose purpose) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/IdentityCompleteResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/IdentityCompleteResponse.java
@@ -1,0 +1,13 @@
+package org.teamsai.saibackend.domain.identity.dto.response;
+
+import org.teamsai.saibackend.domain.identity.type.IdentityStatus;
+
+import java.time.LocalDateTime;
+
+public record IdentityCompleteResponse(
+        String identityVerificationId,
+        IdentityStatus status,
+        LocalDateTime verifiedAt,
+        LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/IdentityPrepareResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/IdentityPrepareResponse.java
@@ -1,0 +1,8 @@
+package org.teamsai.saibackend.domain.identity.dto.response;
+
+public record IdentityPrepareResponse(
+        String identityVerificationId,
+        String storeId,
+        String channelKey
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/PortOneIdentityResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/PortOneIdentityResponse.java
@@ -10,13 +10,13 @@ public record PortOneIdentityResponse(
         String status,
         VerifiedCustomer verifiedCustomer,
         Failure failure
-
 ) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record VerifiedCustomer(
             String name,
-            LocalDate birthDate
+            LocalDate birthDate,
+            String ci
     ) {
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/PortOneIdentityResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/dto/response/PortOneIdentityResponse.java
@@ -1,0 +1,30 @@
+package org.teamsai.saibackend.domain.identity.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PortOneIdentityResponse(
+        String id,
+        String status,
+        VerifiedCustomer verifiedCustomer,
+        Failure failure
+
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record VerifiedCustomer(
+            String name,
+            LocalDate birthDate
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Failure(
+            String reason,
+            String pgCode,
+            String pgMessage
+    ) {
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/exception/IdentityErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/exception/IdentityErrorCode.java
@@ -69,6 +69,20 @@ public enum IdentityErrorCode
     PORTONE_API_INVALID_RESPONSE(
             HttpStatus.BAD_GATEWAY,
             "포트원 본인인증 서버에서 올바르지 않은 응답을 받았습니다."
+    ),
+    IDENTITY_VERIFICATION_NOT_COMPLETED(
+            HttpStatus.CONFLICT,
+            "본인인증이 아직 완료되지 않았습니다."
+    ),
+
+    IDENTITY_USER_INFORMATION_MISSING(
+            HttpStatus.CONFLICT,
+            "회원의 이름 또는 생년월일 정보가 없습니다."
+    ),
+
+    IDENTITY_INFORMATION_MISMATCH(
+            HttpStatus.BAD_REQUEST,
+            "회원정보와 본인인증 정보가 일치하지 않습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/identity/exception/IdentityErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/exception/IdentityErrorCode.java
@@ -1,0 +1,81 @@
+package org.teamsai.saibackend.domain.identity.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.teamsai.saibackend.global.exception.BaseErrorCode;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+@Getter
+@RequiredArgsConstructor
+public enum IdentityErrorCode
+        implements BaseErrorCode<DomainException> {
+
+    UNAUTHENTICATED_USER(
+            HttpStatus.UNAUTHORIZED,
+            "로그인이 필요하거나 토큰이 유효하지 않습니다."
+    ),
+
+    INVALID_IDENTITY_VERIFICATION_ID(
+            HttpStatus.BAD_REQUEST,
+            "본인인증 식별값이 올바르지 않습니다."
+    ),
+
+    INVALID_IDENTITY_PURPOSE(
+            HttpStatus.BAD_REQUEST,
+            "본인인증 목적이 올바르지 않습니다."
+    ),
+
+    IDENTITY_VERIFICATION_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "본인인증 요청을 찾을 수 없습니다."
+    ),
+
+    IDENTITY_VERIFICATION_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "해당 본인인증 요청에 접근할 권한이 없습니다."
+    ),
+
+    INVALID_IDENTITY_VERIFICATION_STATUS(
+            HttpStatus.CONFLICT,
+            "현재 상태에서는 본인인증을 완료할 수 없습니다."
+    ),
+
+    IDENTITY_VERIFICATION_CREATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "본인인증 요청 생성에 실패했습니다."
+    ),
+
+    IDENTITY_VERIFICATION_UPDATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "본인인증 결과 저장에 실패했습니다."
+    ),
+
+    IDENTITY_VERIFICATION_CONSUME_FAILED(
+            HttpStatus.CONFLICT,
+            "사용할 수 없는 본인인증 정보입니다."
+    ),
+
+    PORTONE_VERIFICATION_NOT_VERIFIED(
+            HttpStatus.BAD_REQUEST,
+            "포트원 본인인증이 정상적으로 완료되지 않았습니다."
+    ),
+
+    PORTONE_API_CALL_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "포트원 본인인증 서버 호출에 실패했습니다."
+    ),
+
+    PORTONE_API_INVALID_RESPONSE(
+            HttpStatus.BAD_GATEWAY,
+            "포트원 본인인증 서버에서 올바르지 않은 응답을 받았습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/mapper/IdentityMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/mapper/IdentityMapper.java
@@ -1,0 +1,33 @@
+package org.teamsai.saibackend.domain.identity.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.identity.dto.IdentityDTO;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface IdentityMapper {
+    int insert(IdentityDTO identityVerificationDTO);
+
+    IdentityDTO findByIdentityVerificationId(
+            @Param("identityVerificationId") String identityVerificationId);
+
+    int updateVerified(
+            @Param("identityVerificationId") String identityVerificationId,
+            @Param("verifiedAt") LocalDateTime verifiedAt,
+            @Param("expiresAt") LocalDateTime expiresAt
+    );
+
+    int updateFailed(
+            @Param("identityVerificationId") String identityVerificationId,
+            @Param("failureReason") String failureReason
+    );
+
+    int consume(
+            @Param("identityVerificationId") String identityVerificationId,
+            @Param("userId") Long userId,
+            @Param("purpose")IdentityPurpose purpose
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityService.java
@@ -1,0 +1,382 @@
+package org.teamsai.saibackend.domain.identity.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.teamsai.saibackend.domain.identity.dto.IdentityDTO;
+import org.teamsai.saibackend.domain.identity.dto.request.IdentityPrepareRequest;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityCompleteResponse;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityPrepareResponse;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.identity.mapper.IdentityMapper;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+import org.teamsai.saibackend.domain.identity.type.IdentityStatus;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+public class IdentityService {
+
+    private static final String PORTONE_API_BASE_URL =
+            "https://api.portone.io";
+
+    private static final String PORTONE_STATUS_VERIFIED =
+            "VERIFIED";
+
+    private static final String PORTONE_STATUS_FAILED =
+            "FAILED";
+
+    private static final String IDENTITY_VERIFICATION_ID_PREFIX =
+            "identity-verification-";
+
+    private final IdentityMapper identityMapper;
+    private final RestClient portOneRestClient;
+
+    private final String storeId;
+    private final String channelKey;
+    private final String apiSecret;
+    private final long validMinutes;
+
+    public IdentityService(
+            IdentityMapper identityMapper,
+
+            @Value("${portone.store-id}")
+            String storeId,
+
+            @Value("${portone.channel-key}")
+            String channelKey,
+
+            @Value("${portone.api-secret}")
+            String apiSecret,
+
+            @Value("${portone.identity-valid-minutes:10}")
+            long validMinutes
+    ) {
+        this.identityMapper = identityMapper;
+        this.storeId = storeId;
+        this.channelKey = channelKey;
+        this.apiSecret = apiSecret;
+        this.validMinutes = validMinutes;
+
+        this.portOneRestClient = RestClient.builder()
+                .baseUrl(PORTONE_API_BASE_URL)
+                .build();
+    }
+
+    /**
+     * 본인인증 요청 준비
+     *
+     * 1. 포트원 인증 식별값 생성
+     * 2. REQUESTED 상태로 DB 저장
+     * 3. 프론트엔드 SDK 호출에 필요한 값 반환
+     */
+    @Transactional
+    public IdentityPrepareResponse prepare(
+            Long userId,
+            IdentityPrepareRequest request
+    ) {
+        validateUserId(userId);
+        validatePrepareRequest(request);
+
+        String identityVerificationId =
+                generateIdentityVerificationId();
+
+        LocalDateTime requestedAt =
+                LocalDateTime.now();
+
+        IdentityDTO identity = IdentityDTO.builder()
+                .identityVerificationId(identityVerificationId)
+                .userId(userId)
+                .purpose(request.purpose())
+                .status(IdentityStatus.REQUESTED)
+                .requestedAt(requestedAt)
+                .build();
+
+        int insertedCount =
+                identityMapper.insert(identity);
+
+        if (insertedCount != 1) {
+            throw IdentityErrorCode
+                    .IDENTITY_VERIFICATION_CREATE_FAILED
+                    .toException();
+        }
+
+        return new IdentityPrepareResponse(
+                identityVerificationId,
+                storeId,
+                channelKey
+        );
+    }
+
+    /**
+     * 본인인증 완료 처리
+     *
+     * 프론트엔드의 인증 성공 응답을 그대로 신뢰하지 않고,
+     * 포트원 서버에서 인증 결과를 다시 조회한다.
+     */
+    public IdentityCompleteResponse complete(
+            Long userId,
+            String identityVerificationId
+    ) {
+        validateUserId(userId);
+        validateIdentityVerificationId(identityVerificationId);
+
+        IdentityDTO identity =
+                findIdentity(identityVerificationId);
+
+        validateOwner(identity, userId);
+
+        if (identity.getStatus() == IdentityStatus.VERIFIED) {
+            return toCompleteResponse(identity);
+        }
+
+        if (identity.getStatus() == IdentityStatus.FAILED) {
+            throw IdentityErrorCode
+                    .PORTONE_VERIFICATION_NOT_VERIFIED
+                    .toException();
+        }
+
+        if (identity.getStatus() != IdentityStatus.REQUESTED) {
+            throw IdentityErrorCode
+                    .INVALID_IDENTITY_VERIFICATION_STATUS
+                    .toException();
+        }
+
+        PortOneIdentityResponse portOneResponse =
+                requestPortOneVerification(identityVerificationId);
+
+        String portOneStatus =
+                portOneResponse.status();
+
+        if (PORTONE_STATUS_FAILED.equals(portOneStatus)) {
+            processFailure(identityVerificationId);
+
+            throw IdentityErrorCode
+                    .PORTONE_VERIFICATION_NOT_VERIFIED
+                    .toException();
+        }
+
+        /*
+         * READY 등 아직 인증 완료 상태가 아닌 경우
+         * 로컬 상태를 FAILED로 변경하지 않는다.
+         */
+        if (!PORTONE_STATUS_VERIFIED.equals(portOneStatus)) {
+            throw IdentityErrorCode
+                    .PORTONE_VERIFICATION_NOT_VERIFIED
+                    .toException();
+        }
+
+        LocalDateTime verifiedAt =
+                LocalDateTime.now();
+
+        LocalDateTime expiresAt =
+                verifiedAt.plusMinutes(validMinutes);
+
+        int updatedCount =
+                identityMapper.updateVerified(
+                        identityVerificationId,
+                        verifiedAt,
+                        expiresAt
+                );
+
+        if (updatedCount != 1) {
+            return handleConcurrentCompletion(
+                    userId,
+                    identityVerificationId
+            );
+        }
+
+        return new IdentityCompleteResponse(
+                identityVerificationId,
+                IdentityStatus.VERIFIED,
+                verifiedAt,
+                expiresAt
+        );
+    }
+
+    /**
+     * 완료된 본인인증 건을 특정 기능에서 1회 사용 처리한다.
+     *
+     * 차용증 확정 등 본인인증이 필요한 실제 기능에서 호출한다.
+     */
+    @Transactional
+    public void consume(
+            Long userId,
+            String identityVerificationId,
+            IdentityPurpose purpose
+    ) {
+        validateUserId(userId);
+        validateIdentityVerificationId(identityVerificationId);
+
+        if (purpose == null) {
+            throw IdentityErrorCode
+                    .INVALID_IDENTITY_PURPOSE
+                    .toException();
+        }
+
+        int updatedCount =
+                identityMapper.consume(
+                        identityVerificationId,
+                        userId,
+                        purpose
+                );
+
+        if (updatedCount != 1) {
+            throw IdentityErrorCode
+                    .IDENTITY_VERIFICATION_CONSUME_FAILED
+                    .toException();
+        }
+    }
+
+    /**
+     * 포트원 본인인증 단건 조회 API 호출
+     */
+    private PortOneIdentityResponse requestPortOneVerification(
+            String identityVerificationId
+    ) {
+        try {
+            PortOneIdentityResponse response =
+                    portOneRestClient.get()
+                            .uri(
+                                    "/identity-verifications/{identityVerificationId}",
+                                    identityVerificationId
+                            )
+                            .header(
+                                    HttpHeaders.AUTHORIZATION,
+                                    "PortOne " + apiSecret
+                            )
+                            .retrieve()
+                            .body(PortOneIdentityResponse.class);
+
+            if (response == null
+                    || response.status() == null
+                    || response.status().isBlank()) {
+
+                throw IdentityErrorCode
+                        .PORTONE_API_INVALID_RESPONSE
+                        .toException();
+            }
+
+            return response;
+
+        } catch (RestClientException exception) {
+            throw IdentityErrorCode
+                    .PORTONE_API_CALL_FAILED
+                    .toException();
+        }
+    }
+
+    private IdentityDTO findIdentity(
+            String identityVerificationId
+    ) {
+        IdentityDTO identity =
+                identityMapper.findByIdentityVerificationId(
+                        identityVerificationId
+                );
+
+        if (identity == null) {
+            throw IdentityErrorCode
+                    .IDENTITY_VERIFICATION_NOT_FOUND
+                    .toException();
+        }
+
+        return identity;
+    }
+
+    private void validateOwner(
+            IdentityDTO identity,
+            Long userId
+    ) {
+        if (!Objects.equals(identity.getUserId(), userId)) {
+            throw IdentityErrorCode
+                    .IDENTITY_VERIFICATION_FORBIDDEN
+                    .toException();
+        }
+    }
+
+    private void processFailure(
+            String identityVerificationId
+    ) {
+        identityMapper.updateFailed(
+                identityVerificationId,
+                PORTONE_STATUS_FAILED
+        );
+    }
+
+    /**
+     * 완료 요청이 동시에 들어온 경우 최신 DB 상태를 다시 확인한다.
+     */
+    private IdentityCompleteResponse handleConcurrentCompletion(
+            Long userId,
+            String identityVerificationId
+    ) {
+        IdentityDTO latestIdentity =
+                findIdentity(identityVerificationId);
+
+        validateOwner(latestIdentity, userId);
+
+        if (latestIdentity.getStatus()
+                == IdentityStatus.VERIFIED) {
+
+            return toCompleteResponse(latestIdentity);
+        }
+
+        throw IdentityErrorCode
+                .IDENTITY_VERIFICATION_UPDATE_FAILED
+                .toException();
+    }
+
+    private IdentityCompleteResponse toCompleteResponse(
+            IdentityDTO identity
+    ) {
+        return new IdentityCompleteResponse(
+                identity.getIdentityVerificationId(),
+                identity.getStatus(),
+                identity.getVerifiedAt(),
+                identity.getExpiresAt()
+        );
+    }
+
+    private String generateIdentityVerificationId() {
+        return IDENTITY_VERIFICATION_ID_PREFIX
+                + UUID.randomUUID()
+                .toString()
+                .replace("-", "");
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null) {
+            throw IdentityErrorCode
+                    .UNAUTHENTICATED_USER
+                    .toException();
+        }
+    }
+
+    private void validatePrepareRequest(
+            IdentityPrepareRequest request
+    ) {
+        if (request == null || request.purpose() == null) {
+            throw IdentityErrorCode
+                    .INVALID_IDENTITY_PURPOSE
+                    .toException();
+        }
+    }
+
+    private void validateIdentityVerificationId(
+            String identityVerificationId
+    ) {
+        if (identityVerificationId == null
+                || identityVerificationId.isBlank()) {
+
+            throw IdentityErrorCode
+                    .INVALID_IDENTITY_VERIFICATION_ID
+                    .toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityService.java
@@ -1,11 +1,9 @@
 package org.teamsai.saibackend.domain.identity.service;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
+import org.springframework.util.StringUtils;
 import org.teamsai.saibackend.domain.identity.dto.IdentityDTO;
 import org.teamsai.saibackend.domain.identity.dto.request.IdentityPrepareRequest;
 import org.teamsai.saibackend.domain.identity.dto.response.IdentityCompleteResponse;
@@ -15,16 +13,19 @@ import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
 import org.teamsai.saibackend.domain.identity.mapper.IdentityMapper;
 import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
 import org.teamsai.saibackend.domain.identity.type.IdentityStatus;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
+import org.teamsai.saibackend.domain.user.mapper.UserMapper;
+import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 @Service
 public class IdentityService {
-
-    private static final String PORTONE_API_BASE_URL =
-            "https://api.portone.io";
 
     private static final String PORTONE_STATUS_VERIFIED =
             "VERIFIED";
@@ -35,47 +36,44 @@ public class IdentityService {
     private static final String IDENTITY_VERIFICATION_ID_PREFIX =
             "identity-verification-";
 
+    private static final int FAILURE_REASON_MAX_LENGTH =
+            255;
+
     private final IdentityMapper identityMapper;
-    private final RestClient portOneRestClient;
+    private final UserMapper userMapper;
+
+    private final PortOneIdentityService portOneIdentityService;
+    private final IdentityValidator identityValidator;
 
     private final String storeId;
     private final String channelKey;
-    private final String apiSecret;
     private final long validMinutes;
 
     public IdentityService(
             IdentityMapper identityMapper,
+            UserMapper userMapper,
+            PortOneIdentityService portOneIdentityService,
+            IdentityValidator identityValidator,
 
-            @Value("${portone.store-id}")
+            @Value("${portone.identity.store-id}")
             String storeId,
 
-            @Value("${portone.channel-key}")
+            @Value("${portone.identity.channel-key}")
             String channelKey,
 
-            @Value("${portone.api-secret}")
-            String apiSecret,
-
-            @Value("${portone.identity-valid-minutes:10}")
+            @Value("${portone.identity.valid-minutes:10}")
             long validMinutes
     ) {
         this.identityMapper = identityMapper;
+        this.userMapper = userMapper;
+        this.portOneIdentityService = portOneIdentityService;
+        this.identityValidator = identityValidator;
+
         this.storeId = storeId;
         this.channelKey = channelKey;
-        this.apiSecret = apiSecret;
         this.validMinutes = validMinutes;
-
-        this.portOneRestClient = RestClient.builder()
-                .baseUrl(PORTONE_API_BASE_URL)
-                .build();
     }
 
-    /**
-     * 본인인증 요청 준비
-     *
-     * 1. 포트원 인증 식별값 생성
-     * 2. REQUESTED 상태로 DB 저장
-     * 3. 프론트엔드 SDK 호출에 필요한 값 반환
-     */
     @Transactional
     public IdentityPrepareResponse prepare(
             Long userId,
@@ -114,12 +112,6 @@ public class IdentityService {
         );
     }
 
-    /**
-     * 본인인증 완료 처리
-     *
-     * 프론트엔드의 인증 성공 응답을 그대로 신뢰하지 않고,
-     * 포트원 서버에서 인증 결과를 다시 조회한다.
-     */
     public IdentityCompleteResponse complete(
             Long userId,
             String identityVerificationId
@@ -149,27 +141,62 @@ public class IdentityService {
         }
 
         PortOneIdentityResponse portOneResponse =
-                requestPortOneVerification(identityVerificationId);
+                portOneIdentityService.getIdentityVerification(
+                        identityVerificationId
+                );
 
-        String portOneStatus =
-                portOneResponse.status();
+        identityValidator.validatePortOneResponse(
+                identityVerificationId,
+                portOneResponse
+        );
 
-        if (PORTONE_STATUS_FAILED.equals(portOneStatus)) {
-            processFailure(identityVerificationId);
+        if (PORTONE_STATUS_FAILED.equals(
+                portOneResponse.status()
+        )) {
+            processFailure(
+                    identityVerificationId,
+                    createFailureReason(portOneResponse)
+            );
 
             throw IdentityErrorCode
                     .PORTONE_VERIFICATION_NOT_VERIFIED
                     .toException();
         }
 
-        /*
-         * READY 등 아직 인증 완료 상태가 아닌 경우
-         * 로컬 상태를 FAILED로 변경하지 않는다.
-         */
-        if (!PORTONE_STATUS_VERIFIED.equals(portOneStatus)) {
+        if (!PORTONE_STATUS_VERIFIED.equals(
+                portOneResponse.status()
+        )) {
             throw IdentityErrorCode
-                    .PORTONE_VERIFICATION_NOT_VERIFIED
+                    .IDENTITY_VERIFICATION_NOT_COMPLETED
                     .toException();
+        }
+
+        UserDTO user =
+                userMapper.findById(userId)
+                        .orElseThrow(
+                                UserErrorCode
+                                        .USER_NOT_FOUND
+                                        ::toException
+                        );
+
+        try {
+            identityValidator.validateSameUser(
+                    user,
+                    portOneResponse.verifiedCustomer()
+            );
+
+        } catch (DomainException exception) {
+
+            if (exception.getErrorCode()
+                    == IdentityErrorCode.IDENTITY_INFORMATION_MISMATCH) {
+
+                processFailure(
+                        identityVerificationId,
+                        "IDENTITY_INFORMATION_MISMATCH"
+                );
+            }
+
+            throw exception;
         }
 
         LocalDateTime verifiedAt =
@@ -200,11 +227,6 @@ public class IdentityService {
         );
     }
 
-    /**
-     * 완료된 본인인증 건을 특정 기능에서 1회 사용 처리한다.
-     *
-     * 차용증 확정 등 본인인증이 필요한 실제 기능에서 호출한다.
-     */
     @Transactional
     public void consume(
             Long userId,
@@ -234,44 +256,6 @@ public class IdentityService {
         }
     }
 
-    /**
-     * 포트원 본인인증 단건 조회 API 호출
-     */
-    private PortOneIdentityResponse requestPortOneVerification(
-            String identityVerificationId
-    ) {
-        try {
-            PortOneIdentityResponse response =
-                    portOneRestClient.get()
-                            .uri(
-                                    "/identity-verifications/{identityVerificationId}",
-                                    identityVerificationId
-                            )
-                            .header(
-                                    HttpHeaders.AUTHORIZATION,
-                                    "PortOne " + apiSecret
-                            )
-                            .retrieve()
-                            .body(PortOneIdentityResponse.class);
-
-            if (response == null
-                    || response.status() == null
-                    || response.status().isBlank()) {
-
-                throw IdentityErrorCode
-                        .PORTONE_API_INVALID_RESPONSE
-                        .toException();
-            }
-
-            return response;
-
-        } catch (RestClientException exception) {
-            throw IdentityErrorCode
-                    .PORTONE_API_CALL_FAILED
-                    .toException();
-        }
-    }
-
     private IdentityDTO findIdentity(
             String identityVerificationId
     ) {
@@ -293,7 +277,10 @@ public class IdentityService {
             IdentityDTO identity,
             Long userId
     ) {
-        if (!Objects.equals(identity.getUserId(), userId)) {
+        if (!Objects.equals(
+                identity.getUserId(),
+                userId
+        )) {
             throw IdentityErrorCode
                     .IDENTITY_VERIFICATION_FORBIDDEN
                     .toException();
@@ -301,17 +288,32 @@ public class IdentityService {
     }
 
     private void processFailure(
-            String identityVerificationId
+            String identityVerificationId,
+            String failureReason
     ) {
-        identityMapper.updateFailed(
-                identityVerificationId,
-                PORTONE_STATUS_FAILED
-        );
+        int updatedCount =
+                identityMapper.updateFailed(
+                        identityVerificationId,
+                        truncateFailureReason(failureReason)
+                );
+
+        if (updatedCount == 1) {
+            return;
+        }
+
+        IdentityDTO latestIdentity =
+                findIdentity(identityVerificationId);
+
+        if (latestIdentity.getStatus()
+                == IdentityStatus.FAILED) {
+            return;
+        }
+
+        throw IdentityErrorCode
+                .IDENTITY_VERIFICATION_UPDATE_FAILED
+                .toException();
     }
 
-    /**
-     * 완료 요청이 동시에 들어온 경우 최신 DB 상태를 다시 확인한다.
-     */
     private IdentityCompleteResponse handleConcurrentCompletion(
             Long userId,
             String identityVerificationId
@@ -343,6 +345,75 @@ public class IdentityService {
         );
     }
 
+    private String createFailureReason(
+            PortOneIdentityResponse response
+    ) {
+        PortOneIdentityResponse.Failure failure =
+                response.failure();
+
+        if (failure == null) {
+            return PORTONE_STATUS_FAILED;
+        }
+
+        List<String> reasonParts =
+                new ArrayList<>();
+
+        addFailureReason(
+                reasonParts,
+                failure.reason()
+        );
+
+        addFailureReason(
+                reasonParts,
+                failure.pgCode()
+        );
+
+        addFailureReason(
+                reasonParts,
+                failure.pgMessage()
+        );
+
+        if (reasonParts.isEmpty()) {
+            return PORTONE_STATUS_FAILED;
+        }
+
+        return String.join(
+                " | ",
+                reasonParts
+        );
+    }
+
+    private void addFailureReason(
+            List<String> reasonParts,
+            String value
+    ) {
+        if (StringUtils.hasText(value)) {
+            reasonParts.add(value.trim());
+        }
+    }
+
+    private String truncateFailureReason(
+            String failureReason
+    ) {
+        if (!StringUtils.hasText(failureReason)) {
+            return PORTONE_STATUS_FAILED;
+        }
+
+        String normalizedReason =
+                failureReason.trim();
+
+        if (normalizedReason.length()
+                <= FAILURE_REASON_MAX_LENGTH) {
+
+            return normalizedReason;
+        }
+
+        return normalizedReason.substring(
+                0,
+                FAILURE_REASON_MAX_LENGTH
+        );
+    }
+
     private String generateIdentityVerificationId() {
         return IDENTITY_VERIFICATION_ID_PREFIX
                 + UUID.randomUUID()
@@ -350,7 +421,9 @@ public class IdentityService {
                 .replace("-", "");
     }
 
-    private void validateUserId(Long userId) {
+    private void validateUserId(
+            Long userId
+    ) {
         if (userId == null) {
             throw IdentityErrorCode
                     .UNAUTHENTICATED_USER
@@ -361,7 +434,9 @@ public class IdentityService {
     private void validatePrepareRequest(
             IdentityPrepareRequest request
     ) {
-        if (request == null || request.purpose() == null) {
+        if (request == null
+                || request.purpose() == null) {
+
             throw IdentityErrorCode
                     .INVALID_IDENTITY_PURPOSE
                     .toException();
@@ -371,9 +446,9 @@ public class IdentityService {
     private void validateIdentityVerificationId(
             String identityVerificationId
     ) {
-        if (identityVerificationId == null
-                || identityVerificationId.isBlank()) {
-
+        if (!StringUtils.hasText(
+                identityVerificationId
+        )) {
             throw IdentityErrorCode
                     .INVALID_IDENTITY_VERIFICATION_ID
                     .toException();

--- a/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/service/IdentityValidator.java
@@ -1,0 +1,112 @@
+package org.teamsai.saibackend.domain.identity.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+
+import java.text.Normalizer;
+import java.util.Objects;
+import java.util.Set;
+
+@Component
+public class IdentityValidator {
+
+    private static final Set<String> PORTONE_STATUSES =
+            Set.of(
+                    "READY",
+                    "VERIFIED",
+                    "FAILED"
+            );
+
+    public void validatePortOneResponse(
+            String expectedIdentityVerificationId,
+            PortOneIdentityResponse response
+    ) {
+        if (response == null
+                || !StringUtils.hasText(response.id())
+                || !StringUtils.hasText(response.status())) {
+
+            throw IdentityErrorCode
+                    .PORTONE_API_INVALID_RESPONSE
+                    .toException();
+        }
+
+        if (!Objects.equals(
+                expectedIdentityVerificationId,
+                response.id()
+        )) {
+            throw IdentityErrorCode
+                    .PORTONE_API_INVALID_RESPONSE
+                    .toException();
+        }
+
+        if (!PORTONE_STATUSES.contains(response.status())) {
+            throw IdentityErrorCode
+                    .PORTONE_API_INVALID_RESPONSE
+                    .toException();
+        }
+    }
+
+    public void validateSameUser(
+            UserDTO user,
+            PortOneIdentityResponse.VerifiedCustomer verifiedCustomer
+    ) {
+        validateUserInformation(user);
+        validateVerifiedCustomer(verifiedCustomer);
+
+        boolean sameName =
+                Objects.equals(
+                        normalizeName(user.getName()),
+                        normalizeName(verifiedCustomer.name())
+                );
+
+        boolean sameBirthDate =
+                Objects.equals(
+                        user.getBirthDate(),
+                        verifiedCustomer.birthDate()
+                );
+
+        if (!sameName || !sameBirthDate) {
+            throw IdentityErrorCode
+                    .IDENTITY_INFORMATION_MISMATCH
+                    .toException();
+        }
+    }
+
+    private void validateUserInformation(
+            UserDTO user
+    ) {
+        if (user == null
+                || !StringUtils.hasText(user.getName())
+                || user.getBirthDate() == null) {
+
+            throw IdentityErrorCode
+                    .IDENTITY_USER_INFORMATION_MISSING
+                    .toException();
+        }
+    }
+
+    private void validateVerifiedCustomer(
+            PortOneIdentityResponse.VerifiedCustomer verifiedCustomer
+    ) {
+        if (verifiedCustomer == null
+                || !StringUtils.hasText(verifiedCustomer.name())
+                || verifiedCustomer.birthDate() == null) {
+
+            throw IdentityErrorCode
+                    .PORTONE_API_INVALID_RESPONSE
+                    .toException();
+        }
+    }
+
+    private String normalizeName(
+            String name
+    ) {
+        return Normalizer.normalize(
+                name.strip(),
+                Normalizer.Form.NFC
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/service/PortOneIdentityService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/service/PortOneIdentityService.java
@@ -65,23 +65,19 @@ public class PortOneIdentityService {
 
         } catch (RestClientResponseException exception) {
             log.warn(
-                    "포트원 본인인증 조회 실패: id={}, status={}, body={}",
+                    "포트원 본인인증 조회 실패: id={}, status={}",
                     identityVerificationId,
-                    exception.getStatusCode(),
-                    exception.getResponseBodyAsString()
+                    exception.getStatusCode()
             );
 
             throw IdentityErrorCode
                     .PORTONE_API_CALL_FAILED
                     .toException();
-
         } catch (RestClientException exception) {
             log.warn(
-                    "포트원 본인인증 통신 오류: id={}, type={}, message={}",
+                    "포트원 본인인증 통신 오류: id={}, type={}",
                     identityVerificationId,
-                    exception.getClass().getSimpleName(),
-                    exception.getMessage(),
-                    exception
+                    exception.getClass().getSimpleName()
             );
 
             throw IdentityErrorCode

--- a/src/main/java/org/teamsai/saibackend/domain/identity/service/PortOneIdentityService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/service/PortOneIdentityService.java
@@ -1,0 +1,92 @@
+package org.teamsai.saibackend.domain.identity.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+
+@Slf4j
+@Service
+public class PortOneIdentityService {
+
+    private final RestClient restClient;
+    private final String apiSecret;
+
+    public PortOneIdentityService(
+            @Value("${portone.identity.base-url:https://api.portone.io}")
+            String apiBaseUrl,
+
+            @Value("${portone.identity.api-secret}")
+            String apiSecret
+    ) {
+        if (!StringUtils.hasText(apiSecret)) {
+            throw new IllegalStateException(
+                    "포트원 V2 API Secret이 설정되지 않았습니다."
+            );
+        }
+
+        this.restClient = RestClient.builder()
+                .baseUrl(apiBaseUrl)
+                .build();
+
+        this.apiSecret = apiSecret;
+    }
+
+    public PortOneIdentityResponse getIdentityVerification(
+            String identityVerificationId
+    ) {
+        try {
+            PortOneIdentityResponse response =
+                    restClient.get()
+                            .uri(
+                                    "/identity-verifications/{identityVerificationId}",
+                                    identityVerificationId
+                            )
+                            .header(
+                                    HttpHeaders.AUTHORIZATION,
+                                    "PortOne " + apiSecret
+                            )
+                            .retrieve()
+                            .body(PortOneIdentityResponse.class);
+
+            if (response == null) {
+                throw IdentityErrorCode
+                        .PORTONE_API_INVALID_RESPONSE
+                        .toException();
+            }
+
+            return response;
+
+        } catch (RestClientResponseException exception) {
+            log.warn(
+                    "포트원 본인인증 조회 실패: id={}, status={}, body={}",
+                    identityVerificationId,
+                    exception.getStatusCode(),
+                    exception.getResponseBodyAsString()
+            );
+
+            throw IdentityErrorCode
+                    .PORTONE_API_CALL_FAILED
+                    .toException();
+
+        } catch (RestClientException exception) {
+            log.warn(
+                    "포트원 본인인증 통신 오류: id={}, type={}, message={}",
+                    identityVerificationId,
+                    exception.getClass().getSimpleName(),
+                    exception.getMessage(),
+                    exception
+            );
+
+            throw IdentityErrorCode
+                    .PORTONE_API_CALL_FAILED
+                    .toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityPurpose.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityPurpose.java
@@ -2,5 +2,5 @@ package org.teamsai.saibackend.domain.identity.type;
 
 public enum IdentityPurpose {
     LOAN_CONTRACT,
-    ACCOUNT_LINK
+    SETTLEMENT
 }

--- a/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityPurpose.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityPurpose.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.identity.type;
+
+public enum IdentityPurpose {
+    LOAN_CONTRACT,
+    ACCOUNT_LINK
+}

--- a/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/identity/type/IdentityStatus.java
@@ -1,0 +1,14 @@
+package org.teamsai.saibackend.domain.identity.type;
+
+public enum IdentityStatus {
+    // 인증 요청 & 인증 완료는 아닌 상태
+    REQUESTED,
+    // 인증 성공 및 회원 정보 비교까지 완료된 상태
+    VERIFIED,
+    // 인증이 사용된 상태
+    USED,
+    // 인증 실패 또는 회원 정보 불일치 상태
+    FAILED,
+    // 인증 사용 가능 시간이 지난 상태
+    EXPIRED
+}

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                                         "/login",
                                         "/signup",
                                         "/mypage",
-                                        "/mypage/"
+                                        "/mypage/",
+                                        "/identity-test"
                                 )
                                 .permitAll()
 

--- a/src/main/resources/db/identity.sql
+++ b/src/main/resources/db/identity.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS identity_verification (
+                                       identity_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                       identity_verification_id VARCHAR(100) NOT NULL UNIQUE,
+                                       user_id BIGINT NOT NULL,
+                                       purpose VARCHAR(30) NOT NULL,
+                                       status VARCHAR(20) NOT NULL,
+                                       requested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       verified_at DATETIME NULL,
+                                       expires_at DATETIME NULL,
+                                       used_at DATETIME NULL,
+
+                                       failure_reason VARCHAR(255) NULL,
+
+                                       INDEX idx_identity_user_purpose_status (
+        user_id,
+        purpose,
+        status
+    )
+);

--- a/src/main/resources/db/identity.sql
+++ b/src/main/resources/db/identity.sql
@@ -1,19 +1,29 @@
-CREATE TABLE IF NOT EXISTS identity_verification (
-                                       identity_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                                       identity_verification_id VARCHAR(100) NOT NULL UNIQUE,
-                                       user_id BIGINT NOT NULL,
-                                       purpose VARCHAR(30) NOT NULL,
-                                       status VARCHAR(20) NOT NULL,
-                                       requested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                                       verified_at DATETIME NULL,
-                                       expires_at DATETIME NULL,
-                                       used_at DATETIME NULL,
+CREATE TABLE IF NOT EXISTS identity (
+    identity_id BIGINT NOT NULL AUTO_INCREMENT,
+    identity_verification_id VARCHAR(100) NOT NULL,
+    user_id BIGINT NOT NULL,
+    purpose VARCHAR(30) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    requested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    verified_at DATETIME NULL,
+    expires_at DATETIME NULL,
+    used_at DATETIME NULL,
+    failure_reason VARCHAR(255) NULL,
+    PRIMARY KEY (identity_id),
+    UNIQUE KEY uk_identity_verification_id (
+        identity_verification_id
+    ),
 
-                                       failure_reason VARCHAR(255) NULL,
-
-                                       INDEX idx_identity_user_purpose_status (
+    INDEX idx_identity_user_purpose_status (
         user_id,
         purpose,
         status
-    )
-);
+    ),
+
+    CONSTRAINT fk_identity_verification_user
+    FOREIGN KEY (user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE
+    ) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4
+    COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/identity/IdentityVerificationMapper.xml
+++ b/src/main/resources/mapper/identity/IdentityVerificationMapper.xml
@@ -45,7 +45,7 @@
             useGeneratedKeys="true"
             keyProperty="identityId">
 
-        INSERT INTO identity_verification (
+        INSERT INTO identity (
         identity_verification_id,
         user_id,
         purpose,
@@ -76,14 +76,14 @@
         expires_at,
         used_at,
         failure_reason
-        FROM identity_verification
+        FROM identity
         WHERE identity_verification_id = #{identityVerificationId}
 
     </select>
 
     <update id="updateVerified">
 
-        UPDATE identity_verification
+        UPDATE identity
         SET status = 'VERIFIED',
         verified_at = #{verifiedAt},
         expires_at = #{expiresAt},
@@ -95,7 +95,7 @@
 
     <update id="updateFailed">
 
-        UPDATE identity_verification
+        UPDATE identity
         SET status = 'FAILED',
         failure_reason = #{failureReason}
         WHERE identity_verification_id = #{identityVerificationId}
@@ -105,7 +105,7 @@
 
     <update id="consume">
 
-        UPDATE identity_verification
+        UPDATE identity
         SET status = 'USED',
         used_at = NOW()
         WHERE identity_verification_id = #{identityVerificationId}

--- a/src/main/resources/mapper/identity/IdentityVerificationMapper.xml
+++ b/src/main/resources/mapper/identity/IdentityVerificationMapper.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.identity.mapper.IdentityMapper">
+
+    <resultMap id="identityResultMap"
+               type="org.teamsai.saibackend.domain.identity.dto.IdentityDTO">
+
+        <id property="identityId"
+            column="identity_id"/>
+
+        <result property="identityVerificationId"
+                column="identity_verification_id"/>
+
+        <result property="userId"
+                column="user_id"/>
+
+        <result property="purpose"
+                column="purpose"/>
+
+        <result property="status"
+                column="status"/>
+
+        <result property="requestedAt"
+                column="requested_at"/>
+
+        <result property="verifiedAt"
+                column="verified_at"/>
+
+        <result property="expiresAt"
+                column="expires_at"/>
+
+        <result property="usedAt"
+                column="used_at"/>
+
+        <result property="failureReason"
+                column="failure_reason"/>
+
+    </resultMap>
+
+    <insert id="insert"
+            parameterType="org.teamsai.saibackend.domain.identity.dto.IdentityDTO"
+            useGeneratedKeys="true"
+            keyProperty="identityId">
+
+        INSERT INTO identity_verification (
+        identity_verification_id,
+        user_id,
+        purpose,
+        status,
+        requested_at
+        )
+        VALUES (
+        #{identityVerificationId},
+        #{userId},
+        #{purpose},
+        #{status},
+        #{requestedAt}
+        )
+
+    </insert>
+
+    <select id="findByIdentityVerificationId"
+            resultMap="identityResultMap">
+
+        SELECT
+        identity_id,
+        identity_verification_id,
+        user_id,
+        purpose,
+        status,
+        requested_at,
+        verified_at,
+        expires_at,
+        used_at,
+        failure_reason
+        FROM identity_verification
+        WHERE identity_verification_id = #{identityVerificationId}
+
+    </select>
+
+    <update id="updateVerified">
+
+        UPDATE identity_verification
+        SET status = 'VERIFIED',
+        verified_at = #{verifiedAt},
+        expires_at = #{expiresAt},
+        failure_reason = NULL
+        WHERE identity_verification_id = #{identityVerificationId}
+        AND status = 'REQUESTED'
+
+    </update>
+
+    <update id="updateFailed">
+
+        UPDATE identity_verification
+        SET status = 'FAILED',
+        failure_reason = #{failureReason}
+        WHERE identity_verification_id = #{identityVerificationId}
+        AND status = 'REQUESTED'
+
+    </update>
+
+    <update id="consume">
+
+        UPDATE identity_verification
+        SET status = 'USED',
+        used_at = NOW()
+        WHERE identity_verification_id = #{identityVerificationId}
+        AND user_id = #{userId}
+        AND purpose = #{purpose}
+        AND status = 'VERIFIED'
+        AND expires_at > NOW()
+        AND used_at IS NULL
+
+    </update>
+
+</mapper>

--- a/src/main/resources/static/js/identity/identity-test.js
+++ b/src/main/resources/static/js/identity/identity-test.js
@@ -1,0 +1,283 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const resultBox =
+        document.getElementById("result");
+
+    const purposeSelect =
+        document.getElementById("purpose");
+
+    const verificationButton =
+        document.getElementById("verification-button");
+
+    verificationButton.addEventListener(
+        "click",
+        startVerification
+    );
+
+    async function startVerification() {
+        const accessToken = getAccessToken();
+
+        if (!accessToken) {
+            printResult(
+                "로그인 정보가 없습니다. 먼저 로그인해 주세요."
+            );
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            printResult(
+                "본인인증 요청을 준비하고 있습니다."
+            );
+
+            const prepare =
+                await prepareIdentityVerification(
+                    accessToken,
+                    purposeSelect.value
+                );
+
+            printResult(
+                "본인인증 창을 여는 중입니다."
+            );
+
+            await requestPortOneVerification(prepare);
+
+            printResult(
+                "인증 결과를 확인하고 있습니다."
+            );
+
+            const completeResult =
+                await completeIdentityVerification(
+                    accessToken,
+                    prepare.identityVerificationId
+                );
+
+            if (completeResult.status !== "VERIFIED") {
+                throw new Error(
+                    "본인인증 완료 상태를 확인할 수 없습니다."
+                );
+            }
+
+            printResult(
+                "본인인증이 완료되었습니다."
+            );
+
+        } catch (error) {
+            console.error(error);
+
+            printResult({
+                step: "FAILED",
+                message:
+                    error.message
+                    ?? "본인인증 처리 중 오류가 발생했습니다."
+            });
+
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function prepareIdentityVerification(
+        accessToken,
+        purpose
+    ) {
+        const response = await fetch(
+            "/api/identity-verifications",
+            {
+                method: "POST",
+
+                headers: {
+                    "Authorization":
+                        `Bearer ${accessToken}`,
+
+                    "Content-Type":
+                        "application/json"
+                },
+
+                body: JSON.stringify({
+                    purpose
+                })
+            }
+        );
+
+        const result = await readResponse(response);
+
+        if (!response.ok) {
+            throw new Error(
+                result.message
+                ?? `준비 요청 실패: ${response.status}`
+            );
+        }
+
+        validatePrepareResponse(result);
+
+        return result;
+    }
+
+    async function requestPortOneVerification(prepare) {
+        if (
+            typeof PortOne === "undefined"
+            || typeof PortOne.requestIdentityVerification
+            !== "function"
+        ) {
+            throw new Error(
+                "포트원 SDK를 불러오지 못했습니다."
+            );
+        }
+
+        const response =
+            await PortOne.requestIdentityVerification({
+                storeId:
+                prepare.storeId,
+
+                channelKey:
+                prepare.channelKey,
+
+                identityVerificationId:
+                prepare.identityVerificationId
+            });
+
+        if (response.code != null) {
+            throw new Error(
+                response.message
+                ?? "포트원 본인인증에 실패했습니다."
+            );
+        }
+
+        if (
+            response.identityVerificationId
+            && response.identityVerificationId
+            !== prepare.identityVerificationId
+        ) {
+            throw new Error(
+                "본인인증 요청 식별값이 일치하지 않습니다."
+            );
+        }
+    }
+
+    async function completeIdentityVerification(
+        accessToken,
+        identityVerificationId
+    ) {
+        const encodedId =
+            encodeURIComponent(identityVerificationId);
+
+        const response = await fetch(
+            `/api/identity-verifications/${encodedId}/complete`,
+            {
+                method: "POST",
+
+                headers: {
+                    "Authorization":
+                        `Bearer ${accessToken}`
+                }
+            }
+        );
+
+        const result = await readResponse(response);
+
+        if (!response.ok) {
+            throw new Error(
+                result.message
+                ?? `완료 요청 실패: ${response.status}`
+            );
+        }
+
+        return result;
+    }
+
+    function validatePrepareResponse(prepare) {
+        if (
+            !prepare.identityVerificationId
+            || !prepare.storeId
+            || !prepare.channelKey
+        ) {
+            throw new Error(
+                "본인인증 준비 응답이 올바르지 않습니다."
+            );
+        }
+    }
+
+    function getAccessToken() {
+        const directToken =
+            sessionStorage.getItem("accessToken")
+            ?? sessionStorage.getItem(
+                "saiwonjangAccessToken"
+            );
+
+        if (directToken) {
+            return removeBearerPrefix(directToken);
+        }
+
+        const authJson =
+            sessionStorage.getItem("saiwonjangAuth");
+
+        if (!authJson) {
+            return null;
+        }
+
+        try {
+            const auth = JSON.parse(authJson);
+
+            const token =
+                auth.accessToken
+                ?? auth.token
+                ?? null;
+
+            return token
+                ? removeBearerPrefix(token)
+                : null;
+
+        } catch (error) {
+            console.error(
+                "로그인 정보 파싱 실패",
+                error
+            );
+
+            return null;
+        }
+    }
+
+    function removeBearerPrefix(token) {
+        return token
+            .trim()
+            .replace(/^Bearer\s+/i, "");
+    }
+
+    async function readResponse(response) {
+        const text = await response.text();
+
+        if (!text) {
+            return {};
+        }
+
+        try {
+            return JSON.parse(text);
+
+        } catch {
+            return {
+                raw: text
+            };
+        }
+    }
+
+    function setLoading(loading) {
+        verificationButton.disabled = loading;
+
+        verificationButton.textContent =
+            loading
+                ? "본인인증 처리 중..."
+                : "본인인증 시작";
+    }
+
+    function printResult(value) {
+        resultBox.textContent =
+            typeof value === "string"
+                ? value
+                : JSON.stringify(
+                    value,
+                    null,
+                    2
+                );
+    }
+});

--- a/src/main/resources/templates/identity/identity-test.html
+++ b/src/main/resources/templates/identity/identity-test.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1">
+
+    <title>본인인증 테스트</title>
+
+    <link rel="stylesheet"
+          href="/css/identity/identity-test.css"
+          th:href="@{/css/identity/identity-test.css}">
+
+    <script src="https://cdn.portone.io/v2/browser-sdk.js"></script>
+
+    <script defer
+            src="/js/identity/identity-test.js"
+            th:src="@{/js/identity/identity-test.js}">
+    </script>
+</head>
+
+<body>
+<main class="identity-container">
+
+    <section class="identity-card">
+
+        <header class="identity-header">
+            <span class="identity-badge">
+                PortOne Test
+            </span>
+
+            <h1>본인인증 테스트</h1>
+
+            <p>
+                본인인증 목적을 선택한 후 인증을 진행해 주세요.
+            </p>
+        </header>
+
+        <div class="identity-form">
+            <label for="purpose">
+                본인인증 목적
+            </label>
+
+            <select id="purpose">
+                <option value="LOAN_CONTRACT">
+                    금전소비대차 계약
+                </option>
+
+                <option value="SETTLEMENT">
+                    정산
+                </option>
+            </select>
+
+            <button id="verification-button"
+                    type="button">
+                본인인증 시작
+            </button>
+        </div>
+
+        <div class="identity-result">
+            <strong>처리 결과</strong>
+            <pre id="result">대기 중</pre>
+        </div>
+
+    </section>
+
+</main>
+</body>
+</html>

--- a/src/test/java/org/teamsai/saibackend/domain/identity/IdentityServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/identity/IdentityServiceTest.java
@@ -1,0 +1,723 @@
+package org.teamsai.saibackend.domain.identity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.identity.dto.IdentityDTO;
+import org.teamsai.saibackend.domain.identity.dto.request.IdentityPrepareRequest;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityCompleteResponse;
+import org.teamsai.saibackend.domain.identity.dto.response.IdentityPrepareResponse;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.identity.mapper.IdentityMapper;
+import org.teamsai.saibackend.domain.identity.service.IdentityService;
+import org.teamsai.saibackend.domain.identity.service.IdentityValidator;
+import org.teamsai.saibackend.domain.identity.service.PortOneIdentityService;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+import org.teamsai.saibackend.domain.identity.type.IdentityStatus;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
+import org.teamsai.saibackend.domain.user.mapper.UserMapper;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IdentityService 단위 테스트")
+class IdentityServiceTest {
+
+    private static final Long USER_ID = 2L;
+    private static final Long OTHER_USER_ID = 3L;
+
+    private static final String STORE_ID = "store-test";
+    private static final String CHANNEL_KEY = "channel-test";
+    private static final long VALID_MINUTES = 10L;
+
+    private static final String VERIFICATION_ID =
+            "identity-verification-test1234";
+
+    private static final String USER_NAME = "김사이";
+
+    private static final LocalDate BIRTH_DATE =
+            LocalDate.of(2000, 01, 01);
+
+    @Mock
+    private IdentityMapper identityMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private PortOneIdentityService portOneIdentityService;
+
+    @Mock
+    private IdentityValidator identityValidator;
+
+    private IdentityService identityService;
+
+    @BeforeEach
+    void setUp() {
+        identityService = new IdentityService(
+                identityMapper,
+                userMapper,
+                portOneIdentityService,
+                identityValidator,
+                STORE_ID,
+                CHANNEL_KEY,
+                VALID_MINUTES
+        );
+    }
+
+    @Nested
+    @DisplayName("본인인증 요청 준비")
+    class Prepare {
+
+        @Test
+        @DisplayName("REQUESTED 상태의 인증 요청을 저장하고 SDK 정보를 반환한다")
+        void prepareSuccess() {
+            IdentityPrepareRequest request =
+                    new IdentityPrepareRequest(
+                            IdentityPurpose.LOAN_CONTRACT
+                    );
+
+            given(identityMapper.insert(any(IdentityDTO.class)))
+                    .willReturn(1);
+
+            IdentityPrepareResponse response =
+                    identityService.prepare(
+                            USER_ID,
+                            request
+                    );
+
+            ArgumentCaptor<IdentityDTO> captor =
+                    ArgumentCaptor.forClass(IdentityDTO.class);
+
+            verify(identityMapper)
+                    .insert(captor.capture());
+
+            IdentityDTO savedIdentity =
+                    captor.getValue();
+
+            assertThat(savedIdentity.getUserId())
+                    .isEqualTo(USER_ID);
+
+            assertThat(savedIdentity.getPurpose())
+                    .isEqualTo(
+                            IdentityPurpose.LOAN_CONTRACT
+                    );
+
+            assertThat(savedIdentity.getStatus())
+                    .isEqualTo(
+                            IdentityStatus.REQUESTED
+                    );
+
+            assertThat(savedIdentity.getRequestedAt())
+                    .isNotNull();
+
+            assertThat(savedIdentity.getIdentityVerificationId())
+                    .startsWith("identity-verification-");
+
+            assertThat(response.identityVerificationId())
+                    .isEqualTo(
+                            savedIdentity.getIdentityVerificationId()
+                    );
+
+            assertThat(response.storeId())
+                    .isEqualTo(STORE_ID);
+
+            assertThat(response.channelKey())
+                    .isEqualTo(CHANNEL_KEY);
+        }
+
+        @Test
+        @DisplayName("인증 요청 저장 결과가 1건이 아니면 예외가 발생한다")
+        void prepareFailsWhenInsertFails() {
+            IdentityPrepareRequest request =
+                    new IdentityPrepareRequest(
+                            IdentityPurpose.LOAN_CONTRACT
+                    );
+
+            given(identityMapper.insert(any(IdentityDTO.class)))
+                    .willReturn(0);
+
+            assertIdentityError(
+                    () -> identityService.prepare(
+                            USER_ID,
+                            request
+                    ),
+                    IdentityErrorCode
+                            .IDENTITY_VERIFICATION_CREATE_FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("userId가 없으면 인증 요청을 생성하지 않는다")
+        void prepareFailsWithoutUserId() {
+            IdentityPrepareRequest request =
+                    new IdentityPrepareRequest(
+                            IdentityPurpose.LOAN_CONTRACT
+                    );
+
+            assertIdentityError(
+                    () -> identityService.prepare(
+                            null,
+                            request
+                    ),
+                    IdentityErrorCode.UNAUTHENTICATED_USER
+            );
+
+            verify(identityMapper, never())
+                    .insert(any(IdentityDTO.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("본인인증 완료")
+    class Complete {
+
+        @Test
+        @DisplayName("포트원 인증자와 회원정보가 일치하면 VERIFIED로 변경한다")
+        void completeSuccess() {
+            IdentityDTO identity =
+                    createRequestedIdentity(USER_ID);
+
+            UserDTO user = createUser();
+
+            PortOneIdentityResponse response =
+                    createVerifiedPortOneResponse();
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            given(
+                    portOneIdentityService
+                            .getIdentityVerification(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(response);
+
+            given(userMapper.findById(USER_ID))
+                    .willReturn(Optional.of(user));
+
+            given(
+                    identityMapper.updateVerified(
+                            eq(VERIFICATION_ID),
+                            any(LocalDateTime.class),
+                            any(LocalDateTime.class)
+                    )
+            ).willReturn(1);
+
+            IdentityCompleteResponse result =
+                    identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    );
+
+            ArgumentCaptor<LocalDateTime> verifiedAtCaptor =
+                    ArgumentCaptor.forClass(
+                            LocalDateTime.class
+                    );
+
+            ArgumentCaptor<LocalDateTime> expiresAtCaptor =
+                    ArgumentCaptor.forClass(
+                            LocalDateTime.class
+                    );
+
+            verify(identityValidator)
+                    .validatePortOneResponse(
+                            VERIFICATION_ID,
+                            response
+                    );
+
+            verify(identityValidator)
+                    .validateSameUser(
+                            user,
+                            response.verifiedCustomer()
+                    );
+
+            verify(identityMapper)
+                    .updateVerified(
+                            eq(VERIFICATION_ID),
+                            verifiedAtCaptor.capture(),
+                            expiresAtCaptor.capture()
+                    );
+
+            assertThat(result.status())
+                    .isEqualTo(IdentityStatus.VERIFIED);
+
+            assertThat(result.identityVerificationId())
+                    .isEqualTo(VERIFICATION_ID);
+
+            assertThat(expiresAtCaptor.getValue())
+                    .isEqualTo(
+                            verifiedAtCaptor
+                                    .getValue()
+                                    .plusMinutes(VALID_MINUTES)
+                    );
+        }
+
+        @Test
+        @DisplayName("다른 회원의 인증 요청에는 접근할 수 없다")
+        void completeFailsWhenOwnerIsDifferent() {
+            IdentityDTO identity =
+                    createRequestedIdentity(
+                            OTHER_USER_ID
+                    );
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            assertIdentityError(
+                    () -> identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    ),
+                    IdentityErrorCode
+                            .IDENTITY_VERIFICATION_FORBIDDEN
+            );
+
+            verifyNoInteractions(
+                    portOneIdentityService,
+                    identityValidator,
+                    userMapper
+            );
+        }
+
+        @Test
+        @DisplayName("이미 VERIFIED인 인증은 기존 결과를 반환한다")
+        void completeReturnsExistingVerifiedResult() {
+            LocalDateTime verifiedAt =
+                    LocalDateTime.of(
+                            2026,
+                            8,
+                            2,
+                            18,
+                            0
+                    );
+
+            LocalDateTime expiresAt =
+                    verifiedAt.plusMinutes(
+                            VALID_MINUTES
+                    );
+
+            IdentityDTO identity =
+                    IdentityDTO.builder()
+                            .identityVerificationId(
+                                    VERIFICATION_ID
+                            )
+                            .userId(USER_ID)
+                            .purpose(
+                                    IdentityPurpose.LOAN_CONTRACT
+                            )
+                            .status(
+                                    IdentityStatus.VERIFIED
+                            )
+                            .verifiedAt(verifiedAt)
+                            .expiresAt(expiresAt)
+                            .build();
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            IdentityCompleteResponse result =
+                    identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    );
+
+            assertThat(result.status())
+                    .isEqualTo(IdentityStatus.VERIFIED);
+
+            assertThat(result.verifiedAt())
+                    .isEqualTo(verifiedAt);
+
+            assertThat(result.expiresAt())
+                    .isEqualTo(expiresAt);
+
+            verifyNoInteractions(
+                    portOneIdentityService,
+                    identityValidator,
+                    userMapper
+            );
+        }
+
+        @Test
+        @DisplayName("포트원 상태가 FAILED이면 로컬 인증도 FAILED로 변경한다")
+        void completeFailsWhenPortOneStatusIsFailed() {
+            IdentityDTO identity =
+                    createRequestedIdentity(USER_ID);
+
+            PortOneIdentityResponse response =
+                    new PortOneIdentityResponse(
+                            VERIFICATION_ID,
+                            "FAILED",
+                            null,
+                            new PortOneIdentityResponse.Failure(
+                                    "인증 실패",
+                                    "PG-001",
+                                    "사용자 인증 실패"
+                            )
+                    );
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            given(
+                    portOneIdentityService
+                            .getIdentityVerification(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(response);
+
+            given(
+                    identityMapper.updateFailed(
+                            VERIFICATION_ID,
+                            "인증 실패 | PG-001 | 사용자 인증 실패"
+                    )
+            ).willReturn(1);
+
+            assertIdentityError(
+                    () -> identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    ),
+                    IdentityErrorCode
+                            .PORTONE_VERIFICATION_NOT_VERIFIED
+            );
+
+            verify(identityMapper)
+                    .updateFailed(
+                            VERIFICATION_ID,
+                            "인증 실패 | PG-001 | 사용자 인증 실패"
+                    );
+
+            verify(identityMapper, never())
+                    .updateVerified(
+                            any(),
+                            any(),
+                            any()
+                    );
+
+            verifyNoInteractions(userMapper);
+        }
+
+        @Test
+        @DisplayName("포트원 상태가 READY이면 DB 상태를 변경하지 않는다")
+        void completeFailsWhenVerificationIsNotCompleted() {
+            IdentityDTO identity =
+                    createRequestedIdentity(USER_ID);
+
+            PortOneIdentityResponse response =
+                    new PortOneIdentityResponse(
+                            VERIFICATION_ID,
+                            "READY",
+                            null,
+                            null
+                    );
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            given(
+                    portOneIdentityService
+                            .getIdentityVerification(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(response);
+
+            assertIdentityError(
+                    () -> identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    ),
+                    IdentityErrorCode
+                            .IDENTITY_VERIFICATION_NOT_COMPLETED
+            );
+
+            verify(identityMapper, never())
+                    .updateFailed(
+                            any(),
+                            any()
+                    );
+
+            verify(identityMapper, never())
+                    .updateVerified(
+                            any(),
+                            any(),
+                            any()
+                    );
+
+            verifyNoInteractions(userMapper);
+        }
+
+        @Test
+        @DisplayName("회원정보와 인증정보가 다르면 FAILED로 변경한다")
+        void completeFailsWhenIdentityInformationDoesNotMatch() {
+            IdentityDTO identity =
+                    createRequestedIdentity(USER_ID);
+
+            UserDTO user = createUser();
+
+            PortOneIdentityResponse response =
+                    createVerifiedPortOneResponse();
+
+            DomainException mismatchException =
+                    IdentityErrorCode
+                            .IDENTITY_INFORMATION_MISMATCH
+                            .toException();
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            given(
+                    portOneIdentityService
+                            .getIdentityVerification(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(response);
+
+            given(userMapper.findById(USER_ID))
+                    .willReturn(Optional.of(user));
+
+            doThrow(mismatchException)
+                    .when(identityValidator)
+                    .validateSameUser(
+                            user,
+                            response.verifiedCustomer()
+                    );
+
+            given(
+                    identityMapper.updateFailed(
+                            VERIFICATION_ID,
+                            "IDENTITY_INFORMATION_MISMATCH"
+                    )
+            ).willReturn(1);
+
+            assertThatThrownBy(
+                    () -> identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    )
+            ).isSameAs(mismatchException);
+
+            verify(identityMapper)
+                    .updateFailed(
+                            VERIFICATION_ID,
+                            "IDENTITY_INFORMATION_MISMATCH"
+                    );
+
+            verify(identityMapper, never())
+                    .updateVerified(
+                            any(),
+                            any(),
+                            any()
+                    );
+        }
+
+        @Test
+        @DisplayName("JWT의 userId에 해당하는 회원이 없으면 예외가 발생한다")
+        void completeFailsWhenUserDoesNotExist() {
+            IdentityDTO identity =
+                    createRequestedIdentity(USER_ID);
+
+            PortOneIdentityResponse response =
+                    createVerifiedPortOneResponse();
+
+            given(
+                    identityMapper
+                            .findByIdentityVerificationId(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(identity);
+
+            given(
+                    portOneIdentityService
+                            .getIdentityVerification(
+                                    VERIFICATION_ID
+                            )
+            ).willReturn(response);
+
+            given(userMapper.findById(USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(
+                    () -> identityService.complete(
+                            USER_ID,
+                            VERIFICATION_ID
+                    )
+            ).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(
+                            exception.getErrorCode()
+                    ).isEqualTo(
+                            UserErrorCode.USER_NOT_FOUND
+                    )
+            );
+
+            verify(identityValidator, never())
+                    .validateSameUser(
+                            any(),
+                            any()
+                    );
+
+            verify(identityMapper, never())
+                    .updateVerified(
+                            any(),
+                            any(),
+                            any()
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("본인인증 사용 처리")
+    class Consume {
+
+        @Test
+        @DisplayName("사용 가능한 인증 건을 USED 상태로 변경한다")
+        void consumeSuccess() {
+            given(
+                    identityMapper.consume(
+                            VERIFICATION_ID,
+                            USER_ID,
+                            IdentityPurpose.LOAN_CONTRACT
+                    )
+            ).willReturn(1);
+
+            identityService.consume(
+                    USER_ID,
+                    VERIFICATION_ID,
+                    IdentityPurpose.LOAN_CONTRACT
+            );
+
+            verify(identityMapper)
+                    .consume(
+                            VERIFICATION_ID,
+                            USER_ID,
+                            IdentityPurpose.LOAN_CONTRACT
+                    );
+        }
+
+        @Test
+        @DisplayName("인증 건을 사용할 수 없으면 예외가 발생한다")
+        void consumeFailsWhenVerificationIsUnavailable() {
+            given(
+                    identityMapper.consume(
+                            VERIFICATION_ID,
+                            USER_ID,
+                            IdentityPurpose.LOAN_CONTRACT
+                    )
+            ).willReturn(0);
+
+            assertIdentityError(
+                    () -> identityService.consume(
+                            USER_ID,
+                            VERIFICATION_ID,
+                            IdentityPurpose.LOAN_CONTRACT
+                    ),
+                    IdentityErrorCode
+                            .IDENTITY_VERIFICATION_CONSUME_FAILED
+            );
+        }
+    }
+
+    private IdentityDTO createRequestedIdentity(
+            Long ownerUserId
+    ) {
+        return IdentityDTO.builder()
+                .identityVerificationId(
+                        VERIFICATION_ID
+                )
+                .userId(ownerUserId)
+                .purpose(
+                        IdentityPurpose.LOAN_CONTRACT
+                )
+                .status(
+                        IdentityStatus.REQUESTED
+                )
+                .requestedAt(
+                        LocalDateTime.now()
+                )
+                .build();
+    }
+
+    private UserDTO createUser() {
+        return UserDTO.builder()
+                .userId(USER_ID)
+                .userToken("SAI-ABCDEFGH")
+                .userKey(null)
+                .email("user@example.com")
+                .password("encoded-password")
+                .name(USER_NAME)
+                .birthDate(BIRTH_DATE)
+                .build();
+    }
+
+    private PortOneIdentityResponse
+    createVerifiedPortOneResponse() {
+        return new PortOneIdentityResponse(
+                VERIFICATION_ID,
+                "VERIFIED",
+                new PortOneIdentityResponse.VerifiedCustomer(
+                        USER_NAME,
+                        BIRTH_DATE,
+                        "ci-test"
+                ),
+                null
+        );
+    }
+
+    private void assertIdentityError(
+            Runnable operation,
+            IdentityErrorCode expectedErrorCode
+    ) {
+        assertThatThrownBy(operation::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(
+                                exception.getErrorCode()
+                        ).isEqualTo(expectedErrorCode)
+                );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/identity/IdentityValidatorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/identity/IdentityValidatorTest.java
@@ -1,0 +1,270 @@
+package org.teamsai.saibackend.domain.identity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.identity.service.IdentityValidator;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("IdentityValidator 단위 테스트")
+class IdentityValidatorTest {
+
+    private static final String VERIFICATION_ID =
+            "identity-verification-test1234";
+
+    private static final LocalDate BIRTH_DATE =
+            LocalDate.of(2002, 10, 22);
+
+    private final IdentityValidator identityValidator =
+            new IdentityValidator();
+
+    @Nested
+    @DisplayName("포트원 응답 검증")
+    class ValidatePortOneResponse {
+
+        @Test
+        @DisplayName("요청 ID와 상태가 정상적이면 검증을 통과한다")
+        void validResponse() {
+            PortOneIdentityResponse response =
+                    new PortOneIdentityResponse(
+                            VERIFICATION_ID,
+                            "VERIFIED",
+                            null,
+                            null
+                    );
+
+            assertThatCode(
+                    () -> identityValidator
+                            .validatePortOneResponse(
+                                    VERIFICATION_ID,
+                                    response
+                            )
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("포트원 응답이 null이면 예외가 발생한다")
+        void nullResponse() {
+            assertIdentityError(
+                    () -> identityValidator
+                            .validatePortOneResponse(
+                                    VERIFICATION_ID,
+                                    null
+                            ),
+                    IdentityErrorCode
+                            .PORTONE_API_INVALID_RESPONSE
+            );
+        }
+
+        @Test
+        @DisplayName("포트원 응답의 인증 ID가 다르면 예외가 발생한다")
+        void differentVerificationId() {
+            PortOneIdentityResponse response =
+                    new PortOneIdentityResponse(
+                            "different-id",
+                            "VERIFIED",
+                            null,
+                            null
+                    );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validatePortOneResponse(
+                                    VERIFICATION_ID,
+                                    response
+                            ),
+                    IdentityErrorCode
+                            .PORTONE_API_INVALID_RESPONSE
+            );
+        }
+
+        @Test
+        @DisplayName("알 수 없는 상태값이면 예외가 발생한다")
+        void unknownStatus() {
+            PortOneIdentityResponse response =
+                    new PortOneIdentityResponse(
+                            VERIFICATION_ID,
+                            "UNKNOWN",
+                            null,
+                            null
+                    );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validatePortOneResponse(
+                                    VERIFICATION_ID,
+                                    response
+                            ),
+                    IdentityErrorCode
+                            .PORTONE_API_INVALID_RESPONSE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("동일인 검증")
+    class ValidateSameUser {
+
+        @Test
+        @DisplayName("이름과 생년월일이 같으면 검증을 통과한다")
+        void sameUser() {
+            UserDTO user = createUser(
+                    " 김사이 ",
+                    BIRTH_DATE
+            );
+
+            PortOneIdentityResponse.VerifiedCustomer customer =
+                    createCustomer(
+                            "김사이",
+                            BIRTH_DATE
+                    );
+
+            assertThatCode(
+                    () -> identityValidator
+                            .validateSameUser(
+                                    user,
+                                    customer
+                            )
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("이름이 다르면 동일인 검증에 실패한다")
+        void differentName() {
+            UserDTO user = createUser(
+                    "김사이",
+                    BIRTH_DATE
+            );
+
+            PortOneIdentityResponse.VerifiedCustomer customer =
+                    createCustomer(
+                            "박사이",
+                            BIRTH_DATE
+                    );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validateSameUser(
+                                    user,
+                                    customer
+                            ),
+                    IdentityErrorCode
+                            .IDENTITY_INFORMATION_MISMATCH
+            );
+        }
+
+        @Test
+        @DisplayName("생년월일이 다르면 동일인 검증에 실패한다")
+        void differentBirthDate() {
+            UserDTO user = createUser(
+                    "김사이",
+                    BIRTH_DATE
+            );
+
+            PortOneIdentityResponse.VerifiedCustomer customer =
+                    createCustomer(
+                            "김사이",
+                            LocalDate.of(2001, 10, 22)
+                    );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validateSameUser(
+                                    user,
+                                    customer
+                            ),
+                    IdentityErrorCode
+                            .IDENTITY_INFORMATION_MISMATCH
+            );
+        }
+
+        @Test
+        @DisplayName("회원의 이름 또는 생년월일이 없으면 예외가 발생한다")
+        void missingUserInformation() {
+            UserDTO user = createUser(
+                    null,
+                    BIRTH_DATE
+            );
+
+            PortOneIdentityResponse.VerifiedCustomer customer =
+                    createCustomer(
+                            "김사이",
+                            BIRTH_DATE
+                    );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validateSameUser(
+                                    user,
+                                    customer
+                            ),
+                    IdentityErrorCode
+                            .IDENTITY_USER_INFORMATION_MISSING
+            );
+        }
+
+        @Test
+        @DisplayName("포트원 인증자 정보가 없으면 잘못된 응답으로 처리한다")
+        void missingVerifiedCustomer() {
+            UserDTO user = createUser(
+                    "김사이",
+                    BIRTH_DATE
+            );
+
+            assertIdentityError(
+                    () -> identityValidator
+                            .validateSameUser(
+                                    user,
+                                    null
+                            ),
+                    IdentityErrorCode
+                            .PORTONE_API_INVALID_RESPONSE
+            );
+        }
+    }
+
+    private UserDTO createUser(
+            String name,
+            LocalDate birthDate
+    ) {
+        return UserDTO.builder()
+                .userId(2L)
+                .name(name)
+                .birthDate(birthDate)
+                .build();
+    }
+
+    private PortOneIdentityResponse.VerifiedCustomer
+    createCustomer(
+            String name,
+            LocalDate birthDate
+    ) {
+        return new PortOneIdentityResponse.VerifiedCustomer(
+                name,
+                birthDate,
+                "ci-test"
+        );
+    }
+
+    private void assertIdentityError(
+            Runnable operation,
+            IdentityErrorCode expectedErrorCode
+    ) {
+        assertThatThrownBy(operation::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(
+                                exception.getErrorCode()
+                        ).isEqualTo(expectedErrorCode)
+                );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/identity/PortOneIdentityServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/identity/PortOneIdentityServiceTest.java
@@ -1,0 +1,211 @@
+package org.teamsai.saibackend.domain.identity;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.domain.identity.dto.response.PortOneIdentityResponse;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.identity.service.PortOneIdentityService;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PortOneIdentityService 단위 테스트")
+class PortOneIdentityServiceTest {
+
+    private static final String VERIFICATION_ID =
+            "identity-verification-test1234";
+
+    private static final String API_SECRET =
+            "test-api-secret";
+
+    private HttpServer httpServer;
+    private PortOneIdentityService portOneIdentityService;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        httpServer = HttpServer.create(
+                new InetSocketAddress(0),
+                0
+        );
+
+        String baseUrl =
+                "http://localhost:"
+                        + httpServer.getAddress().getPort();
+
+        portOneIdentityService =
+                new PortOneIdentityService(
+                        baseUrl,
+                        API_SECRET
+                );
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (httpServer != null) {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더를 전송하고 인증 결과를 조회한다")
+    void getIdentityVerificationSuccess() {
+        httpServer.createContext(
+                "/identity-verifications/"
+                        + VERIFICATION_ID,
+                exchange -> {
+                    String authorization =
+                            exchange
+                                    .getRequestHeaders()
+                                    .getFirst("Authorization");
+
+                    if (!("PortOne " + API_SECRET)
+                            .equals(authorization)) {
+
+                        respond(
+                                exchange,
+                                401,
+                                """
+                                {
+                                  "type": "UNAUTHORIZED"
+                                }
+                                """
+                        );
+
+                        return;
+                    }
+
+                    respond(
+                            exchange,
+                            200,
+                            """
+                            {
+                              "id": "%s",
+                              "status": "VERIFIED",
+                              "verifiedCustomer": {
+                                "name": "김사이",
+                                "birthDate": "2002-10-22",
+                                "ci": "ci-test"
+                              }
+                            }
+                            """.formatted(VERIFICATION_ID)
+                    );
+                }
+        );
+
+        httpServer.start();
+
+        PortOneIdentityResponse result =
+                portOneIdentityService
+                        .getIdentityVerification(
+                                VERIFICATION_ID
+                        );
+
+        assertThat(result.id())
+                .isEqualTo(VERIFICATION_ID);
+
+        assertThat(result.status())
+                .isEqualTo("VERIFIED");
+
+        assertThat(result.verifiedCustomer().name())
+                .isEqualTo("김사이");
+    }
+
+    @Test
+    @DisplayName("포트원 서버가 401을 반환하면 API 호출 실패 예외가 발생한다")
+    void getIdentityVerificationFailsWhenUnauthorized() {
+        httpServer.createContext(
+                "/identity-verifications/"
+                        + VERIFICATION_ID,
+                exchange -> respond(
+                        exchange,
+                        401,
+                        """
+                        {
+                          "type": "UNAUTHORIZED"
+                        }
+                        """
+                )
+        );
+
+        httpServer.start();
+
+        assertThatThrownBy(
+                () -> portOneIdentityService
+                        .getIdentityVerification(
+                                VERIFICATION_ID
+                        )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(
+                        exception.getErrorCode()
+                ).isEqualTo(
+                        IdentityErrorCode
+                                .PORTONE_API_CALL_FAILED
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("포트원 서버 응답 본문이 없으면 잘못된 응답 예외가 발생한다")
+    void getIdentityVerificationFailsWhenBodyIsEmpty() {
+        httpServer.createContext(
+                "/identity-verifications/"
+                        + VERIFICATION_ID,
+                exchange -> respond(
+                        exchange,
+                        200,
+                        ""
+                )
+        );
+
+        httpServer.start();
+
+        assertThatThrownBy(
+                () -> portOneIdentityService
+                        .getIdentityVerification(
+                                VERIFICATION_ID
+                        )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(
+                        exception.getErrorCode()
+                ).isEqualTo(
+                        IdentityErrorCode
+                                .PORTONE_API_INVALID_RESPONSE
+                )
+        );
+    }
+
+    private void respond(
+            HttpExchange exchange,
+            int status,
+            String body
+    ) throws IOException {
+        byte[] responseBody =
+                body.getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().set(
+                "Content-Type",
+                "application/json; charset=UTF-8"
+        );
+
+        exchange.sendResponseHeaders(
+                status,
+                responseBody.length
+        );
+
+        exchange.getResponseBody()
+                .write(responseBody);
+
+        exchange.close();
+    }
+}


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #15 

## 🛠 작업 사항

-포트원 V2 기반 본인인증 기능 구현
- 본인인증 요청 준비 및 완료 API 추가
    - POST /api/identity-verifications
    - POST /api/identity-verifications/{identityVerificationId}/complete
- 회원정보의 이름·생년월일과 포트원 인증정보 동일인 검증
- 인증 실패 및 회원정보 불일치 사유 저장

- 본인인증 연동 확인용 테스트 화면 구현
- 본인인증 Service·Validator·포트원 API 호출 단위 테스트 추가
- 인증 요청 생성, 동일인 검증, 실패 처리, 사용 처리 테스트 작성
## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- application-dev.yml portone 환경 변수 설정으로 인한 변화 있습니다. (2026-08-02)
- 현재 identity-test.html로 본인인증 테스트가 가능합니다. 추후 계약서 작성 직전 사용할 때에는 로직을 활용하고 필요한 화면을 구현하여 적용하시면 됩니다.
- identity 테이블 생성으로 인한 ERD 변경 있습니다.
- bank에서 계좌 연동시 본인인증은 bank 서버에서 별도로 구현하여 사용하는 것이 좋을 것 같아, 정산 쪽에서 사용할 가능성만 염두해두고 purpose ENUM에 추가해두었습니다.