### PR TITLE
feat(#38): 회원 토큰 기반 회원 조회 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/user/controller/UserController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/controller/UserController.java
@@ -7,13 +7,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.dto.response.UserResponse;
+import org.teamsai.saibackend.domain.user.dto.response.UserTokenLookupResponse;
 import org.teamsai.saibackend.domain.user.service.UserService;
 
 @Tag(
@@ -82,5 +82,42 @@ public class UserController {
             Long userId
     ) {
         userService.withdraw(userId);
+    }
+    @Operation(
+            summary = "토큰 기반 회원 정보 조회",
+            description = "회원 토큰을 이용하여 요청 회원 제외 타 회원을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "본인을 요청 대상으로 선택한 경우"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 정보"
+            )
+    })
+    @ResponseBody
+    @GetMapping("/api/users/by-token/{userToken}")
+    public ResponseEntity<UserTokenLookupResponse> findByUserToken(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId,
+            @Parameter(description = "요청 대상 회원 토큰", example = "SAI_ABCD1234")
+            @PathVariable String userToken
+    ){
+        UserDTO targetUser = userService.findRequestTarget(userId, userToken);
+
+        UserTokenLookupResponse response = UserTokenLookupResponse.from(targetUser);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserTokenLookupResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserTokenLookupResponse.java
@@ -1,0 +1,20 @@
+package org.teamsai.saibackend.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+
+@Getter
+@Builder
+public class UserTokenLookupResponse {
+
+    private String userToken;
+    private String name;
+
+    public static UserTokenLookupResponse from(UserDTO user){
+        return UserTokenLookupResponse.builder()
+                .userToken(user.getUserToken())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
@@ -39,6 +39,11 @@ public enum UserErrorCode
     USER_TOKEN_GENERATION_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "회원 초대 코드 생성에 실패했습니다."
+    ),
+
+    CANNOT_SELECT_SELF(
+            HttpStatus.BAD_REQUEST,
+        "본인은 요청 대상으로 선택할 수 없습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/user/service/UserService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.user.dto.response.UserResponse;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.dto.response.UserTokenLookupResponse;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
 import org.teamsai.saibackend.domain.user.mapper.UserMapper;
 
@@ -35,5 +36,15 @@ public class UserService {
                 .orElseThrow(
                         UserErrorCode.USER_NOT_FOUND::toException
                 );
+    }
+
+    public UserDTO findRequestTarget(Long requestUserId, String userToken){
+        UserDTO targetUser = userMapper.findByUserToken(userToken)
+                .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+        if(requestUserId.equals(targetUser.getUserId())){
+            throw UserErrorCode.CANNOT_SELECT_SELF.toException();
+        }
+        return targetUser;
     }
 }

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -84,7 +84,7 @@
 
     </select>
 
-    <!-- 정산 초대 코드 기반 회원 조회 -->
+    <!-- 초대 코드 기반 회원 조회 -->
     <select id="findByUserToken"
             resultMap="userResultMap">
 

--- a/src/test/java/org/teamsai/saibackend/domain/user/UserServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/user/UserServiceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 단위 테스트")
@@ -110,4 +111,78 @@ class UserServiceTest {
                 .birthDate(LocalDate.of(2002, 10, 22))
                 .build();
     }
+
+    @Test
+    @DisplayName("회원토큰으로 요청 대상 회원을 조회한다")
+    void findRequestTargetSuccess() {
+        Long requesterUserId = 1L;
+        String userToken = "USER-ABCD1234";
+
+        UserDTO targetUser = UserDTO.builder()
+                .userId(2L)
+                .userToken(userToken)
+                .name("김사이")
+                .build();
+
+        when(userMapper.findByUserToken(userToken))
+                .thenReturn(Optional.of(targetUser));
+
+        UserDTO result =
+                userService.findRequestTarget(
+                        requesterUserId,
+                        userToken
+                );
+
+
+        assertThat(result.getUserId()).isEqualTo(2L);
+        assertThat(result.getUserToken()).isEqualTo(userToken);
+        assertThat(result.getName()).isEqualTo("김사이");
+
+        verify(userMapper).findByUserToken(userToken);
+    }
+
+    @Test
+    @DisplayName("회원토큰과 일치하는 회원이 없으면 예외가 발생한다")
+    void findRequestTargetNotFound() {
+        Long requesterUserId = 1L;
+        String userToken = "UNKNOWN-TOKEN";
+
+        when(userMapper.findByUserToken(userToken))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> userService.findRequestTarget(
+                        requesterUserId,
+                        userToken
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(userMapper).findByUserToken(userToken);
+    }
+
+    @Test
+    @DisplayName("본인의 회원토큰을 요청 대상으로 선택하면 예외가 발생한다")
+    void findRequestTargetSelf() {
+        Long requesterUserId = 1L;
+        String userToken = "USER-MY-TOKEN";
+
+        UserDTO requester = UserDTO.builder()
+                .userId(requesterUserId)
+                .userToken(userToken)
+                .name("김사이")
+                .build();
+
+        when(userMapper.findByUserToken(userToken))
+                .thenReturn(Optional.of(requester));
+
+        assertThatThrownBy(
+                () -> userService.findRequestTarget(
+                        requesterUserId,
+                        userToken
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(userMapper).findByUserToken(userToken);
+    }
+
 }


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #38 

## 🛠 작업 사항
- 회원토큰 기반 요청 대상 회원 조회 API 구현
- 기존 findByUserToken Mapper를 활용한 회원 조회 로직 추가
- 존재하지 않는 회원토큰 및 본인 선택 예외 처리
- 이름과 회원토큰만 반환하는 전용 응답 DTO 추가
- 정산 초대·차용증 작성 요청에서 재사용 가능한 공통 서비스 구현
- 회원 조회 성공·실패·본인 선택 케이스 단위 테스트 작성

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
- 별도의 화면은 없습니다. 추후 정산/ 금전소비대차에서 각각 초대/요청 시 필요한 화면에서 사용합니다.