### PR TITLE
refactor(#39): 계약서 변경 시 계약테이블에 저장 및 차용증 작성 시 본인인증 검증

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
@@ -14,6 +14,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
@@ -74,6 +75,39 @@ public class LoanContractController {
     ) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         return contractService.createContract(request, userDetails.getUserId());
+    }
+
+    @Operation(
+            summary = "채무자 계약 합류",
+            description = "본인인증을 완료한 채무자가 차용증에 채무자로 연결됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "채무자 연결 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "차용증을 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 채무자가 연결되었거나 본인인증이 완료되지 않음"
+            )
+    })
+    @ResponseBody
+    @PatchMapping("/{contractId}/debtor")
+    public void linkDebtor(
+            @PathVariable Long contractId,
+            @Valid @RequestBody LoanContractDebtorLinkRequest request,
+            @Parameter(hidden = true) Authentication authentication
+    ) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        contractService.linkDebtor(contractId, userDetails.getUserId(), request);
     }
 
     @Operation(

--- a/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
@@ -45,23 +45,6 @@ public class LoanContractController {
         return "contract/contract-signature";
     }
 
-    //채무자 차용증 확인 페이지
-    @Operation(hidden = true)
-    @GetMapping("/{contractId}/approve")
-    public String contractDebtorApprovePage(@PathVariable Long contractId, Model model) {
-        model.addAttribute("contractId", contractId);
-        return "contract/contract-debtor-approve";
-    }
-
-    //채무자 전자서명 페이지
-    @Operation(hidden = true)
-    @GetMapping("/{contractId}/approve/signature")
-    public String contractDebtorSignaturePage(@PathVariable Long contractId, Model model) {
-        model.addAttribute("contractId", contractId);
-        return "contract/contract-debtor-signature";
-    }
-
-
     @Operation(
             summary = "차용증 최초 생성",
             description = "채권자가 입력한 정보로 차용증 계약서를 최초 생성합니다."
@@ -82,7 +65,7 @@ public class LoanContractController {
 
     })
 
-
+    //차용증 작성 시 본인인증 후 작성
     @ResponseBody
     @PostMapping("/write")
     public Long createContract(
@@ -124,6 +107,21 @@ public class LoanContractController {
         return contractService.submitDebtorSignature(contractId, userDetails.getUserId(), debtorAddress, signature);
     }
 
+    //채무자 차용증 확인 페이지
+    @Operation(hidden = true)
+    @GetMapping("/{contractId}/approve")
+    public String contractDebtorApprovePage(@PathVariable Long contractId, Model model) {
+        model.addAttribute("contractId", contractId);
+        return "contract/contract-debtor-approve";
+    }
+
+    //채무자 전자서명 페이지
+    @Operation(hidden = true)
+    @GetMapping("/{contractId}/approve/signature")
+    public String contractDebtorSignaturePage(@PathVariable Long contractId, Model model) {
+        model.addAttribute("contractId", contractId);
+        return "contract/contract-debtor-signature";
+    }
 
     @Operation(
             summary = "차용증 상세 조회",

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/LoanContractDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/LoanContractDTO.java
@@ -1,5 +1,6 @@
 package org.teamsai.saibackend.domain.contract.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/ContractStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/ContractStatus.java
@@ -2,6 +2,6 @@ package org.teamsai.saibackend.domain.contract.dto.request;
 
 public enum ContractStatus {
     DRAFT, // 최초 생성 시 기본 상태
-    PENDING, // 상대방에게 전송
+    PENDING, // 전송 후 서명 기다리는 상태
     COMPLETED // 채권자와 채무자 둘 다 서명 완료 후 저장
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractDebtorLinkRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractDebtorLinkRequest.java
@@ -1,0 +1,9 @@
+package org.teamsai.saibackend.domain.contract.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoanContractDebtorLinkRequest(
+        @NotBlank(message = "본인인증 식별값은 필수입니다.")
+        String identityVerificationId
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
@@ -13,10 +13,10 @@ import java.time.LocalDate;
 @Builder
 public class LoanContractRequest {
 
-    private Long contractId;
-
     @NotBlank(message = "본인인증 식별값은 필수입니다.")
     private String identityVerificationId;
+
+    private Long contractId;
 
     @NotNull(message = "대출원금을 입력해주세요.")
     @Positive(message = "대출원금은 0보다 커야 합니다.")

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
@@ -15,6 +15,9 @@ public class LoanContractRequest {
 
     private Long contractId;
 
+    @NotBlank(message = "본인인증 식별값은 필수입니다.")
+    private String identityVerificationId;
+
     @NotNull(message = "대출원금을 입력해주세요.")
     @Positive(message = "대출원금은 0보다 커야 합니다.")
     private BigDecimal principalAmount;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/response/ChangeLoanContractResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/response/ChangeLoanContractResponse.java
@@ -30,7 +30,7 @@ public class ChangeLoanContractResponse {
     private LocalDate startDate;
     private LocalDate maturityDate;
 
-    private LocalDate repaymentDay;
+    private Integer repaymentDay;
 
     private String creditorAddress;
     private String debtorAddress;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/response/ChangeLoanContractResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/response/ChangeLoanContractResponse.java
@@ -1,0 +1,43 @@
+package org.teamsai.saibackend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeLoanContractResponse {
+
+    private Long contractId;
+
+    private Long previousContractId;
+    private Long creditorId;
+    private Long debtorId;
+
+    private BigDecimal principalAmount;
+    private BigDecimal interestRate;
+    private RepaymentMethod repaymentType;
+
+    private LocalDate startDate;
+    private LocalDate maturityDate;
+
+    private LocalDate repaymentDay;
+
+    private String creditorAddress;
+    private String debtorAddress;
+    private String contractAlias;
+    private String terms;
+
+    private ContractStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contract/exception/LoanContractErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/exception/LoanContractErrorCode.java
@@ -23,6 +23,16 @@ public enum LoanContractErrorCode implements BaseErrorCode<DomainException> {
     CONTRACT_ACCESS_DENIED(
             HttpStatus.FORBIDDEN,
             "해당 차용증에 접근할 권한이 없습니다."
+    ),
+
+    CANNOT_CREATE_CONTRACT_TO_SELF(
+            HttpStatus.FORBIDDEN,
+            "채무자와 채권자는 동일인이 될 수 없습니다."
+    ),
+
+    DEBTOR_ALREADY_LINKED(
+            HttpStatus.CONFLICT,
+            "이미 채무자가 연결된 계약서입니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
@@ -1,5 +1,6 @@
 package org.teamsai.saibackend.domain.contract.mapper;
 
+import jakarta.validation.constraints.*;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.contract.dto.LoanContractDTO;
@@ -8,6 +9,9 @@ import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 
@@ -35,5 +39,22 @@ public interface LoanContractMapper {
 
     Optional<LoanContractResponse> findContractById(@Param("contractId") Long contractId);
 
+    void insertChangedContract(
+            @Param("previousContractId") Long previousContractId,
+            @Param("creditorId") Long creditorId,
+            @Param("debtorId") Long debtorId,
+            @Param("principalAmount") BigDecimal principalAmount,
+            @Param("interestRate") BigDecimal interestRate,
+            @Param("repaymentType") String repaymentType,
+            @Param("maturityDate") LocalDate maturityDate,
+            @Param("repaymentDay") Integer repaymentDay,
+            @Param("creditorAddress") String creditorAddress,
+            @Param("debtorAddress") String debtorAddress,
+            @Param("contractAlias") String contractAlias,
+            @Param("terms") String terms,
+            @Param("status") ContractStatus status,
+            @Param("createdAt") LocalDateTime createdAt,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
@@ -46,6 +46,7 @@ public interface LoanContractMapper {
             @Param("principalAmount") BigDecimal principalAmount,
             @Param("interestRate") BigDecimal interestRate,
             @Param("repaymentType") String repaymentType,
+            @Param("startDate") LocalDate startDate,
             @Param("maturityDate") LocalDate maturityDate,
             @Param("repaymentDay") Integer repaymentDay,
             @Param("creditorAddress") String creditorAddress,

--- a/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.contract.dto.LoanContractDTO;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
+import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
 
@@ -39,23 +40,6 @@ public interface LoanContractMapper {
 
     Optional<LoanContractResponse> findContractById(@Param("contractId") Long contractId);
 
-    void insertChangedContract(
-            @Param("previousContractId") Long previousContractId,
-            @Param("creditorId") Long creditorId,
-            @Param("debtorId") Long debtorId,
-            @Param("principalAmount") BigDecimal principalAmount,
-            @Param("interestRate") BigDecimal interestRate,
-            @Param("repaymentType") String repaymentType,
-            @Param("startDate") LocalDate startDate,
-            @Param("maturityDate") LocalDate maturityDate,
-            @Param("repaymentDay") Integer repaymentDay,
-            @Param("creditorAddress") String creditorAddress,
-            @Param("debtorAddress") String debtorAddress,
-            @Param("contractAlias") String contractAlias,
-            @Param("terms") String terms,
-            @Param("status") ContractStatus status,
-            @Param("createdAt") LocalDateTime createdAt,
-            @Param("updatedAt") LocalDateTime updatedAt
-    );
+    int insertChangedContract(ChangeLoanContractResponse contract);
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
@@ -8,7 +8,6 @@ import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -21,8 +20,12 @@ public interface LoanContractMapper {
 
     void insertByContract(
             @Param("request") LoanContractRequest request,
-            @Param("user") UserDTO user,
-            @Param("debtor") UserDTO debtor
+            @Param("creditorId") Long creditorId
+    );
+
+    void updateDebtorId(
+            @Param("contractId") Long contractId,
+            @Param("debtorId") Long debtorId
     );
 
     void updateCreditorSignature(

--- a/src/main/java/org/teamsai/saibackend/domain/contract/service/contract/LoanContractService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/service/contract/LoanContractService.java
@@ -8,13 +8,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
+import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
 import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
-import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
-import org.teamsai.saibackend.domain.user.mapper.UserMapper;
+import org.teamsai.saibackend.domain.identity.service.IdentityService;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+import org.teamsai.saibackend.domain.user.service.UserService;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -22,18 +26,45 @@ import org.teamsai.saibackend.domain.user.mapper.UserMapper;
 public class LoanContractService {
     private final LoanContractMapper contractMapper;
     private final LoanContractFileService fileService;
-    private final UserMapper userMapper;
+    private final UserService userService;
+    private final IdentityService identityService;
 
     @Transactional
     public Long createContract(LoanContractRequest request, Long userId) {
-        UserDTO currentUser = userMapper.findById(userId)
-                .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
 
-        UserDTO debtor = userMapper.findByEmail(request.getDebtorEmail())
-                .orElseThrow(LoanContractErrorCode.DEBTOR_NOT_FOUND::toException);
+        identityService.consume(
+                userId,
+                request.getIdentityVerificationId(),
+                IdentityPurpose.LOAN_CONTRACT
+        );
 
-        contractMapper.insertByContract(request, currentUser, debtor);
+        userService.getMyInfo(userId);
+
+        contractMapper.insertByContract(request, userId);
+
         return request.getContractId();
+    }
+
+    @Transactional
+    public void linkDebtor(Long contractId, Long userId, LoanContractDebtorLinkRequest request) {
+        LoanContractResponse contract = contractMapper.findContractById(contractId)
+                .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
+
+        if (contract.getDebtorId() != null) {
+            throw LoanContractErrorCode.DEBTOR_ALREADY_LINKED.toException();
+        }
+
+        if (userId.equals(contract.getCreditorId())) {
+            throw LoanContractErrorCode.CANNOT_CREATE_CONTRACT_TO_SELF.toException();
+        }
+
+        identityService.consume(
+                userId,
+                request.identityVerificationId(),
+                IdentityPurpose.LOAN_CONTRACT
+        );
+
+        contractMapper.updateDebtorId(contractId, userId);
     }
 
     @Transactional
@@ -58,7 +89,7 @@ public class LoanContractService {
         LoanContractResponse contract = contractMapper.findContractById(contractId)
                 .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
 
-        if (!contract.getDebtorId().equals(userId)) {
+        if (!Objects.equals(contract.getDebtorId(), userId)) {
             throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
         }
 
@@ -72,7 +103,7 @@ public class LoanContractService {
         LoanContractResponse contract = contractMapper.findContractById(contractId)
                 .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
 
-        boolean isParty = contract.getCreditorId().equals(userId) || contract.getDebtorId().equals(userId);
+        boolean isParty = contract.getCreditorId().equals(userId) || Objects.equals(contract.getDebtorId(), userId);
         if (!isParty) {
             throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
         }
@@ -80,5 +111,9 @@ public class LoanContractService {
         return contract;
     }
 
+    @Transactional
+    public void insertChangedContract(ChangeLoanContractResponse changedContract) {
+        contractMapper.insertChangedContract(changedContract);
+    }
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/ChangeRequestStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/ChangeRequestStatus.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.contractchange.dto;
+
+public enum ChangeRequestStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
@@ -3,6 +3,7 @@ package org.teamsai.saibackend.domain.contractchange.dto;
 
 import lombok.*;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -18,9 +19,9 @@ public class LoanContractChangeDTO {
     private String changeReason;
     private LocalDate newMaturityDate;
     private BigDecimal newInterestRate;
-    private String newRepaymentType;
+    private RepaymentMethod newRepaymentType;
     private LocalDate newRepaymentDate;
-    private ContractStatus status;
+    private ChangeRequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long contractId;

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
@@ -2,8 +2,6 @@ package org.teamsai.saibackend.domain.contractchange.dto;
 
 
 import lombok.*;
-import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
-import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -19,8 +17,8 @@ public class LoanContractChangeDTO {
     private String changeReason;
     private LocalDate newMaturityDate;
     private BigDecimal newInterestRate;
-    private RepaymentMethod newRepaymentType;
-    private LocalDate newRepaymentDate;
+    private String newRepaymentType;
+    private Integer newRepaymentDate;
     private ChangeRequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
@@ -2,6 +2,7 @@ package org.teamsai.saibackend.domain.contractchange.dto;
 
 
 import lombok.*;
+import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -19,7 +20,7 @@ public class LoanContractChangeDTO {
     private BigDecimal newInterestRate;
     private String newRepaymentType;
     private LocalDate newRepaymentDate;
-    private String status;
+    private ContractStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long contractId;

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -28,11 +30,8 @@ public class ContractChangeRequest {
     private BigDecimal newInterestRate;
 
     @NotBlank(message = "상환 방식은 필수입니다.")
-    @Pattern(
-            regexp = "원리금균등상환|원금균등상환|만기일시상환",
-            message = "상환 방식은 원리금균등상환, 원금균등상환, 만기일시상환 중 하나여야 합니다."
-    )
-    private String newRepaymentType;
+    @NotNull(message = "상환 방식은 필수입니다.")
+    private RepaymentMethod newRepaymentType;
 
     @NotNull(message = "변경 상환일은 필수입니다.")
     @Future(message = "변경 상환일은 오늘 이후 날짜여야 합니다.")

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.cglib.core.Local;
-import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -30,12 +29,11 @@ public class ContractChangeRequest {
     private BigDecimal newInterestRate;
 
     @NotBlank(message = "상환 방식은 필수입니다.")
-    @NotNull(message = "상환 방식은 필수입니다.")
-    private RepaymentMethod newRepaymentType;
+    private String newRepaymentType;
 
     @NotNull(message = "변경 상환일은 필수입니다.")
     @Future(message = "변경 상환일은 오늘 이후 날짜여야 합니다.")
-    private LocalDate newRepaymentDate;
+    private Integer newRepaymentDate;
 
 
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
@@ -11,7 +11,7 @@ import org.teamsai.saibackend.global.exception.DomainException;
 @RequiredArgsConstructor
 public enum ContractChangeErrorCode implements BaseErrorCode<DomainException> {
 
-    ONLY_CREDITOR_CAN_REQUEST_CHANGE(HttpStatus.FORBIDDEN, "계약 변경 요청은 채권자만 보낼 수 있습니다."),
+    NOT_CONTRACT_PARTY(HttpStatus.FORBIDDEN, "계약 변경 요청은 로그인된 사용자만 요청할 수 있습니다."),
     CONTRACT_NOT_COMPLETED(HttpStatus.BAD_REQUEST,"완료된 계약만 변경 요청 할 수 있습니다."),
     DUPLICATE_PENDING_REQUEST(HttpStatus.CONFLICT, "이미 처리 대기 중인 변경 요청이 있습니다.");
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
@@ -12,6 +12,7 @@ import org.teamsai.saibackend.global.exception.DomainException;
 public enum ContractChangeErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_CONTRACT_PARTY(HttpStatus.FORBIDDEN, "계약 변경 요청은 로그인된 사용자만 요청할 수 있습니다."),
+    NOT_CREDITOR(HttpStatus.FORBIDDEN, "계약 변경 요청은 채권자만 할 수 있습니다."),
     CONTRACT_NOT_COMPLETED(HttpStatus.BAD_REQUEST,"완료된 계약만 변경 요청 할 수 있습니다."),
     DUPLICATE_PENDING_REQUEST(HttpStatus.CONFLICT, "이미 처리 대기 중인 변경 요청이 있습니다.");
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -6,14 +6,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
+import org.teamsai.saibackend.domain.contractchange.dto.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.exception.ContractChangeErrorCode;
 import org.teamsai.saibackend.domain.contractchange.mapper.ContractChangeMapper;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -53,7 +56,7 @@ public class ContractChangeService {
         }
 
         boolean hasPendingRequest = contractChangeMapper.findByContractId(contractId).stream()
-                .anyMatch(changeRequest -> ContractStatus.PENDING.equals(changeRequest.getStatus()));
+                .anyMatch(changeRequest -> ChangeRequestStatus.PENDING.equals(changeRequest.getStatus()));
 
         if (hasPendingRequest) {
             throw ContractChangeErrorCode.DUPLICATE_PENDING_REQUEST.toException();
@@ -69,31 +72,33 @@ public class ContractChangeService {
                 .newRepaymentDate(request.getNewRepaymentDate())
                 .userId(userId)
                 .contractId(contractId)
-                .status(ContractStatus.PENDING)
+                .status(ChangeRequestStatus.PENDING)
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
 
         contractChangeMapper.insert(changeDTO);
 
-        loanContractMapper.insertChangedContract(
-                contractId,
-                contract.getCreditorId(),
-                contract.getDebtorId(),
-                contract.getPrincipalAmount(),
-                request.getNewInterestRate(),
-                request.getNewRepaymentType(),
-                contract.getStartDate(),
-                request.getNewMaturityDate(),
-                contract.getRepaymentDay(),
-                contract.getCreditorAddress(),
-                contract.getDebtorAddress(),
-                contract.getContractAlias(),
-                contract.getTerms(),
-                ContractStatus.PENDING,
-                now,
-                now
-        );
+        ChangeLoanContractResponse newContractDTO = ChangeLoanContractResponse.builder()
+                .previousContractId(contractId)
+                .creditorId(contract.getCreditorId())
+                .debtorId(contract.getDebtorId())
+                .principalAmount(contract.getPrincipalAmount())
+                .interestRate(request.getNewInterestRate())
+                .repaymentType(request.getNewRepaymentType())
+                .startDate(contract.getStartDate())
+                .maturityDate(request.getNewMaturityDate())
+                .repaymentDay(request.getNewRepaymentDate())
+                .creditorAddress(contract.getCreditorAddress())
+                .debtorAddress(contract.getDebtorAddress())
+                .contractAlias(contract.getContractAlias())
+                .terms(contract.getTerms())
+                .status(ContractStatus.PENDING)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        loanContractMapper.insertChangedContract(newContractDTO);
 
         log.info("계약 변경 요청 생성 및 차용증 재저장 완료: contractId={}, userId={}",
                 contractId, userId);

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -83,6 +83,7 @@ public class ContractChangeService {
                 contract.getPrincipalAmount(),
                 request.getNewInterestRate(),
                 request.getNewRepaymentType(),
+                contract.getStartDate(),
                 request.getNewMaturityDate(),
                 contract.getRepaymentDay(),
                 contract.getCreditorAddress(),

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -6,9 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
-import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
@@ -26,7 +26,6 @@ import java.time.LocalDateTime;
 public class ContractChangeService {
 
     private final ContractChangeMapper contractChangeMapper;
-    private final LoanContractMapper loanContractMapper;
     private final LoanContractService loanContractService;
 
     public LoanContractResponse getContract(Long contractId, Long userID) {
@@ -49,6 +48,10 @@ public class ContractChangeService {
 
         if (!isCreditor && !isDebtor) {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
+        }
+
+        if (!isCreditor) {
+            throw ContractChangeErrorCode.NOT_CREDITOR.toException();
         }
 
         if (contract.getStatus() != ContractStatus.COMPLETED) {
@@ -85,7 +88,7 @@ public class ContractChangeService {
                 .debtorId(contract.getDebtorId())
                 .principalAmount(contract.getPrincipalAmount())
                 .interestRate(request.getNewInterestRate())
-                .repaymentType(request.getNewRepaymentType())
+                .repaymentType(RepaymentMethod.valueOf(request.getNewRepaymentType()))
                 .startDate(contract.getStartDate())
                 .maturityDate(request.getNewMaturityDate())
                 .repaymentDay(request.getNewRepaymentDate())
@@ -98,7 +101,7 @@ public class ContractChangeService {
                 .updatedAt(now)
                 .build();
 
-        loanContractMapper.insertChangedContract(newContractDTO);
+        loanContractService.insertChangedContract(newContractDTO);
 
         log.info("계약 변경 요청 생성 및 차용증 재저장 완료: contractId={}, userId={}",
                 contractId, userId);

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 public class ContractChangeService {
 
     private final ContractChangeMapper contractChangeMapper;
+    private final LoanContractMapper loanContractMapper;
     private final LoanContractService loanContractService;
 
     public LoanContractResponse getContract(Long contractId, Long userID) {
@@ -33,27 +35,31 @@ public class ContractChangeService {
         return contract;
     }
 
+    //차용증 변경 요청 후 계약서 테이블에 저장
     @Transactional
     public LoanContractChangeDTO requestChange(Long contractId, ContractChangeRequest request, Long userId) {
 
-
-
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
-        if(!contract.getCreditorId().equals(userId)) {
-            throw ContractChangeErrorCode.ONLY_CREDITOR_CAN_REQUEST_CHANGE.toException();
+        boolean isCreditor = contract.getCreditorId().equals(userId);
+        boolean isDebtor = contract.getDebtorId().equals(userId);
+
+        if (!isCreditor && !isDebtor) {
+            throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
         }
 
-        if(contract.getStatus() != ContractStatus.COMPLETED) {
+        if (contract.getStatus() != ContractStatus.COMPLETED) {
             throw ContractChangeErrorCode.CONTRACT_NOT_COMPLETED.toException();
         }
 
         boolean hasPendingRequest = contractChangeMapper.findByContractId(contractId).stream()
-                .anyMatch(changeRequest -> "PENDING".equals(changeRequest.getStatus()));
+                .anyMatch(changeRequest -> ContractStatus.PENDING.equals(changeRequest.getStatus()));
 
         if (hasPendingRequest) {
             throw ContractChangeErrorCode.DUPLICATE_PENDING_REQUEST.toException();
         }
+
+        LocalDateTime now = LocalDateTime.now();
 
         LoanContractChangeDTO changeDTO = LoanContractChangeDTO.builder()
                 .changeReason(request.getChangeReason())
@@ -63,15 +69,34 @@ public class ContractChangeService {
                 .newRepaymentDate(request.getNewRepaymentDate())
                 .userId(userId)
                 .contractId(contractId)
-                .status("PENDING")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
+                .status(ContractStatus.PENDING)
+                .createdAt(now)
+                .updatedAt(now)
                 .build();
 
         contractChangeMapper.insert(changeDTO);
 
-        log.info("계약 변경 요청 생성: contractId={}, userId={}, changeReason={}",
-                contractId, userId, request.getChangeReason());
+        loanContractMapper.insertChangedContract(
+                contractId,
+                contract.getCreditorId(),
+                contract.getDebtorId(),
+                contract.getPrincipalAmount(),
+                request.getNewInterestRate(),
+                request.getNewRepaymentType(),
+                request.getNewMaturityDate(),
+                contract.getRepaymentDay(),
+                contract.getCreditorAddress(),
+                contract.getDebtorAddress(),
+                contract.getContractAlias(),
+                contract.getTerms(),
+                ContractStatus.PENDING,
+                now,
+                now
+        );
+
+        log.info("계약 변경 요청 생성 및 차용증 재저장 완료: contractId={}, userId={}",
+                contractId, userId);
+
         return changeDTO;
     }
 }

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.teamsai.saibackend.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -77,7 +78,6 @@ public class SecurityConfig {
                                         "/error"
                                 )
                                 .permitAll()
-
                                 .anyRequest()
                                 .authenticated()
                 )

--- a/src/main/resources/db/01_loancontract.sql
+++ b/src/main/resources/db/01_loancontract.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS loan_contract (
     previous_contract_id BIGINT NULL,
 
     creditor_id          BIGINT NOT NULL,
-    debtor_id            BIGINT NOT NULL,
+    debtor_id            BIGINT NULL,
 
     principal_amount     DECIMAL(15,2) NOT NULL,
     interest_rate        DECIMAL(5,2) NOT NULL,

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -44,7 +44,6 @@
         INSERT INTO loan_contract (
         creditor_id,
         creditor_address,
-        debtor_id,
         principal_amount,
         interest_rate,
         repayment_type,
@@ -57,9 +56,8 @@
         created_at,
         updated_at
         ) VALUES (
-        #{user.userId},
+        #{creditorId},
         #{request.creditorAddress},
-        #{debtor.userId},
         #{request.principalAmount},
         #{request.interestRate},
         #{request.repaymentType},
@@ -117,9 +115,17 @@
         lc.status             AS status
         FROM loan_contract lc
         JOIN users creditor ON creditor.user_id = lc.creditor_id
-        JOIN users debtor ON debtor.user_id = lc.debtor_id
+        LEFT JOIN users debtor ON debtor.user_id = lc.debtor_id
         WHERE lc.contract_id = #{contractId}
     </select>
+
+    <update id="updateDebtorId">
+        UPDATE loan_contract
+        SET
+        debtor_id = #{debtorId},
+        updated_at = NOW()
+        WHERE contract_id = #{contractId}
+    </update>
 
     <insert id="insertChangedContract" useGeneratedKeys="true" keyProperty="contractId">
         INSERT INTO loan_contract (

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -121,5 +121,40 @@
         WHERE lc.contract_id = #{contractId}
     </select>
 
+    <insert id="insertChangedContract" useGeneratedKeys="true" keyProperty="contractId">
+        INSERT INTO loan_contracts (
+        previous_contract_id,
+        creditor_id,
+        debtor_id,
+        principal_amount,
+        interest_rate,
+        repayment_type,
+        maturity_date,
+        repayment_day,
+        creditor_address,
+        debtor_address,
+        contract_alias,
+        terms,
+        status,
+        created_at,
+        updated_at
+        ) VALUES (
+        #{previousContractId},
+        #{creditorId},
+        #{debtorId},
+        #{principalAmount},
+        #{interestRate},
+        #{repaymentType},
+        #{maturityDate},
+        #{repaymentDay},
+        #{creditorAddress},
+        #{debtorAddress},
+        #{contractAlias},
+        #{terms},
+        #{status},
+        #{createdAt},
+        #{updatedAt}
+        )
+    </insert>
 
 </mapper>

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -122,13 +122,14 @@
     </select>
 
     <insert id="insertChangedContract" useGeneratedKeys="true" keyProperty="contractId">
-        INSERT INTO loan_contracts (
+        INSERT INTO loan_contract (
         previous_contract_id,
         creditor_id,
         debtor_id,
         principal_amount,
         interest_rate,
         repayment_type,
+        start_date,
         maturity_date,
         repayment_day,
         creditor_address,
@@ -145,6 +146,7 @@
         #{principalAmount},
         #{interestRate},
         #{repaymentType},
+        #{startDate},
         #{maturityDate},
         #{repaymentDay},
         #{creditorAddress},

--- a/src/main/resources/static/css/contract/contract-form.css
+++ b/src/main/resources/static/css/contract/contract-form.css
@@ -295,6 +295,44 @@ button { font-family: inherit; }
 .doc__inline-input--day { width: 44px; }
 .doc__inline-input--alias { width: 100%; text-align: left; }
 
+/* ---- identity verification panel ---- */
+.identity-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 24px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+
+.identity-panel__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.identity-panel__status {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+.identity-panel__status.is-error {
+  color: var(--error);
+}
+
+.identity-panel.is-verified {
+  border-color: var(--primary);
+  background: rgba(0, 200, 83, 0.05);
+}
+
+.identity-panel.is-verified .identity-panel__status {
+  color: var(--primary);
+  font-weight: 600;
+}
+
 /* ---- read-only document values (filled from the logged-in user's account) ---- */
 .doc__readonly {
   color: var(--primary);

--- a/src/main/resources/static/js/contract/contract-debtor-approve.js
+++ b/src/main/resources/static/js/contract/contract-debtor-approve.js
@@ -12,6 +12,9 @@
   const statusBanner = document.getElementById("statusBanner");
   const debtorAddressInput = document.getElementById("debtorAddress");
   const nextBtn = document.getElementById("btnNext");
+  const identityPanel = document.getElementById("identityPanel");
+  const identityStatusText = document.getElementById("identityStatusText");
+  const btnIdentityVerify = document.getElementById("btnIdentityVerify");
 
   const REPAYMENT_TYPE_LABEL = {
     EQUAL_PRINCIPAL_AND_INTEREST: "원리금균등상환",
@@ -24,6 +27,8 @@
     PENDING: "전송됨 (채무자 확인 대기중)",
     COMPLETED: "완료",
   };
+
+  if (nextBtn) nextBtn.disabled = true;
 
   function authHeaders(extra) {
     const token = sessionStorage.getItem("accessToken");
@@ -49,48 +54,127 @@
     if (message) showStatus(message, false);
   }
 
+  function setIdentityStatus(message, isError) {
+    if (!identityStatusText) return;
+    identityStatusText.textContent = message;
+    identityStatusText.classList.toggle("is-error", Boolean(isError));
+  }
+
+  function setIdentityVerifying(loading) {
+    if (!btnIdentityVerify) return;
+    btnIdentityVerify.disabled = loading;
+    btnIdentityVerify.textContent = loading ? "본인인증 처리 중..." : "본인인증 시작";
+  }
+
+  function hideIdentityPanel() {
+    if (identityPanel) identityPanel.hidden = true;
+  }
+
   async function loadContract() {
-    try {
-      const response = await fetch(`/api/contracts/${contractId}/listdetails`, {
-        method: "GET",
-        headers: authHeaders({ Accept: "application/json" }),
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = await response.json();
+    const response = await fetch(`/api/contracts/${contractId}/listdetails`, {
+      method: "GET",
+      headers: authHeaders({ Accept: "application/json" }),
+    });
+    if (!response.ok) {
+      const error = new Error(`HTTP ${response.status}`);
+      error.status = response.status;
+      throw error;
+    }
+    const data = await response.json();
 
-      // 채권자/채무자 인적사항은 모두 로그인 계정(users 테이블)에서 자동으로 채워지며, 이 화면에서 직접 입력받지 않는다.
-      document.getElementById("creditorAddress").textContent = data.creditorAddress || "-";
-      document.getElementById("creditorNameDisplay").textContent = data.creditorName || "-";
-      document.getElementById("creditorNameCell").textContent = data.creditorName || "-";
-      document.getElementById("creditorBirthDateCell").textContent = data.creditorBirthDate || "-";
-      document.getElementById("debtorName").textContent = data.debtorName || "-";
-      document.getElementById("debtorBirthDate").textContent = data.debtorBirthDate || "-";
-      debtorAddressInput.value = data.debtorAddress || "";
+    document.getElementById("creditorAddress").textContent = data.creditorAddress || "-";
+    document.getElementById("creditorNameDisplay").textContent = data.creditorName || "-";
+    document.getElementById("creditorNameCell").textContent = data.creditorName || "-";
+    document.getElementById("creditorBirthDateCell").textContent = data.creditorBirthDate || "-";
+    document.getElementById("debtorName").textContent = data.debtorName || "-";
+    document.getElementById("debtorBirthDate").textContent = data.debtorBirthDate || "-";
+    debtorAddressInput.value = data.debtorAddress || "";
 
-      document.getElementById("principalAmount").textContent =
-        data.principalAmount != null ? Number(data.principalAmount).toLocaleString("ko-KR") : "-";
-      document.getElementById("interestRate").textContent =
-        data.interestRate != null ? data.interestRate : "-";
-      document.getElementById("repaymentType").textContent =
-        REPAYMENT_TYPE_LABEL[data.repaymentType] || data.repaymentType || "-";
-      document.getElementById("startDate").textContent = data.startDate || "-";
-      document.getElementById("maturityDate").textContent = data.maturityDate || "-";
-      document.getElementById("repaymentDay").textContent = data.repaymentDay ?? "-";
-      document.getElementById("contractAlias").textContent = data.contractAlias || "-";
-      document.getElementById("terms").textContent = data.terms || "특약사항 없음";
+    document.getElementById("principalAmount").textContent =
+      data.principalAmount != null ? Number(data.principalAmount).toLocaleString("ko-KR") : "-";
+    document.getElementById("interestRate").textContent =
+      data.interestRate != null ? data.interestRate : "-";
+    document.getElementById("repaymentType").textContent =
+      REPAYMENT_TYPE_LABEL[data.repaymentType] || data.repaymentType || "-";
+    document.getElementById("startDate").textContent = data.startDate || "-";
+    document.getElementById("maturityDate").textContent = data.maturityDate || "-";
+    document.getElementById("repaymentDay").textContent = data.repaymentDay ?? "-";
+    document.getElementById("contractAlias").textContent = data.contractAlias || "-";
+    document.getElementById("terms").textContent = data.terms || "특약사항 없음";
 
-      showBanner(`현재 상태: ${STATUS_LABEL[data.status] || data.status}`);
+    showBanner(`현재 상태: ${STATUS_LABEL[data.status] || data.status}`);
 
-      if (data.status === "COMPLETED") {
-        lockForm("이미 서명이 완료된 계약입니다.");
-      } else if (data.status === "DRAFT") {
-        lockForm("채권자가 아직 계약서를 전송하지 않았습니다. 전송 후 다시 확인해 주세요.");
-      }
-    } catch (err) {
-      showStatus("계약서를 불러오지 못했습니다.", true);
-      lockForm();
+    if (data.status === "COMPLETED") {
+      lockForm("이미 서명이 완료된 계약입니다.");
+    } else if (data.status === "DRAFT") {
+      lockForm("채권자가 아직 계약서를 전송하지 않았습니다. 전송 후 다시 확인해 주세요.");
+    } else if (nextBtn) {
+      nextBtn.disabled = false;
     }
   }
+
+  async function startIdentityVerification() {
+    if (typeof PortOne === "undefined" || typeof PortOne.requestIdentityVerification !== "function") {
+      setIdentityStatus("포트원 SDK를 불러오지 못했습니다.", true);
+      return;
+    }
+
+    setIdentityVerifying(true);
+    setIdentityStatus("본인인증 요청을 준비하고 있습니다.");
+
+    try {
+      const prepareResponse = await fetch("/api/identity-verifications", {
+        method: "POST",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ purpose: "LOAN_CONTRACT" }),
+      });
+      const prepare = await prepareResponse.json().catch(() => null);
+      if (!prepareResponse.ok || !prepare?.identityVerificationId || !prepare?.storeId || !prepare?.channelKey) {
+        throw new Error(prepare?.message || "본인인증 준비에 실패했습니다.");
+      }
+
+      setIdentityStatus("본인인증 창을 여는 중입니다.");
+      const verifyResult = await PortOne.requestIdentityVerification({
+        storeId: prepare.storeId,
+        channelKey: prepare.channelKey,
+        identityVerificationId: prepare.identityVerificationId,
+      });
+
+      if (verifyResult?.code != null) {
+        throw new Error(verifyResult.message || "본인인증에 실패했습니다.");
+      }
+
+      setIdentityStatus("인증 결과를 확인하고 있습니다.");
+      const completeResponse = await fetch(
+        `/api/identity-verifications/${encodeURIComponent(prepare.identityVerificationId)}/complete`,
+        { method: "POST", headers: authHeaders() }
+      );
+      const completeResult = await completeResponse.json().catch(() => null);
+      if (!completeResponse.ok || completeResult?.status !== "VERIFIED") {
+        throw new Error(completeResult?.message || "본인인증 완료 확인에 실패했습니다.");
+      }
+
+      setIdentityStatus("계약서에 채무자로 연결하는 중입니다.");
+      const linkResponse = await fetch(`/api/contracts/${contractId}/debtor`, {
+        method: "PATCH",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ identityVerificationId: prepare.identityVerificationId }),
+      });
+      if (!linkResponse.ok) {
+        const body = await linkResponse.json().catch(() => null);
+        throw new Error(body?.message || "계약서에 채무자로 연결하지 못했습니다.");
+      }
+
+      hideIdentityPanel();
+      await loadContract();
+    } catch (err) {
+      setIdentityStatus(err.message || "본인인증 처리 중 오류가 발생했습니다.", true);
+    } finally {
+      setIdentityVerifying(false);
+    }
+  }
+
+  btnIdentityVerify?.addEventListener("click", startIdentityVerification);
 
   nextBtn?.addEventListener("click", () => {
     const debtorAddress = debtorAddressInput.value.trim();
@@ -110,5 +194,16 @@
     window.location.href = `/api/contracts/${contractId}/approve/signature`;
   });
 
-  loadContract();
+  loadContract()
+    .then(hideIdentityPanel)
+    .catch((err) => {
+      if (err.status === 403) {
+        // 아직 채무자로 연결되지 않음 - 본인인증 패널을 통해 연결을 진행한다.
+        setIdentityStatus("본인인증 후 계약 내용을 확인할 수 있습니다.");
+        return;
+      }
+      showStatus("계약서를 불러오지 못했습니다.", true);
+      hideIdentityPanel();
+      lockForm();
+    });
 })();

--- a/src/main/resources/static/js/contract/contract-form.js
+++ b/src/main/resources/static/js/contract/contract-form.js
@@ -7,12 +7,18 @@
   const statusEl = document.getElementById("formStatus");
   const statusBanner = document.getElementById("statusBanner");
   const nextBtn = document.getElementById("btnNext");
+  const identityPanel = document.getElementById("identityPanel");
+  const identityStatusText = document.getElementById("identityStatusText");
+  const btnIdentityVerify = document.getElementById("btnIdentityVerify");
+  const identityVerificationIdInput = document.getElementById("identityVerificationId");
 
   if (!form) return;
 
   const params = new URLSearchParams(window.location.search);
   let contractId = params.get("contractId") || null;
   const viewMode = Boolean(contractId);
+
+  let identityVerified = false;
 
   const FIELD_IDS = [
     "principalAmount",
@@ -23,6 +29,7 @@
     "creditorAddress",
     "contractAlias",
     "terms",
+    "identityVerificationId",
   ];
 
   function authHeaders(extra) {
@@ -130,7 +137,81 @@
     });
   }
 
+  function setIdentityStatus(message, isError) {
+    if (!identityStatusText) return;
+    identityStatusText.textContent = message;
+    identityStatusText.classList.toggle("is-error", Boolean(isError));
+  }
+
+  function setIdentityVerifying(loading) {
+    if (!btnIdentityVerify) return;
+    btnIdentityVerify.disabled = loading;
+    btnIdentityVerify.textContent = loading ? "본인인증 처리 중..." : "본인인증 시작";
+  }
+
+  async function startIdentityVerification() {
+    if (typeof PortOne === "undefined" || typeof PortOne.requestIdentityVerification !== "function") {
+      setIdentityStatus("포트원 SDK를 불러오지 못했습니다.", true);
+      return;
+    }
+
+    setIdentityVerifying(true);
+    setIdentityStatus("본인인증 요청을 준비하고 있습니다.");
+
+    try {
+      const prepareResponse = await fetch("/api/identity-verifications", {
+        method: "POST",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ purpose: "LOAN_CONTRACT" }),
+      });
+      const prepare = await prepareResponse.json().catch(() => null);
+      if (!prepareResponse.ok || !prepare?.identityVerificationId || !prepare?.storeId || !prepare?.channelKey) {
+        throw new Error(prepare?.message || "본인인증 준비에 실패했습니다.");
+      }
+
+      setIdentityStatus("본인인증 창을 여는 중입니다.");
+      const verifyResult = await PortOne.requestIdentityVerification({
+        storeId: prepare.storeId,
+        channelKey: prepare.channelKey,
+        identityVerificationId: prepare.identityVerificationId,
+      });
+
+      if (verifyResult?.code != null) {
+        throw new Error(verifyResult.message || "본인인증에 실패했습니다.");
+      }
+
+      setIdentityStatus("인증 결과를 확인하고 있습니다.");
+      const completeResponse = await fetch(
+        `/api/identity-verifications/${encodeURIComponent(prepare.identityVerificationId)}/complete`,
+        { method: "POST", headers: authHeaders() }
+      );
+      const completeResult = await completeResponse.json().catch(() => null);
+      if (!completeResponse.ok || completeResult?.status !== "VERIFIED") {
+        throw new Error(completeResult?.message || "본인인증 완료 확인에 실패했습니다.");
+      }
+
+      identityVerified = true;
+      if (identityVerificationIdInput) identityVerificationIdInput.value = prepare.identityVerificationId;
+      identityPanel?.classList.add("is-verified");
+      setIdentityStatus("본인인증이 완료되었습니다.");
+      if (nextBtn) nextBtn.disabled = false;
+
+      await loadCreditorInfo();
+    } catch (err) {
+      identityVerified = false;
+      setIdentityStatus(err.message || "본인인증 처리 중 오류가 발생했습니다.", true);
+    } finally {
+      setIdentityVerifying(false);
+    }
+  }
+
+  btnIdentityVerify?.addEventListener("click", startIdentityVerification);
+
   nextBtn?.addEventListener("click", () => {
+    if (!identityVerified) {
+      showStatus("본인인증을 먼저 진행해 주세요.", true);
+      return;
+    }
     if (!validate()) return;
 
     try {
@@ -213,7 +294,7 @@
 
   if (viewMode) {
     loadExistingContract();
-  } else {
-    loadCreditorInfo();
+  } else if (nextBtn) {
+    nextBtn.disabled = true;
   }
 })();

--- a/src/main/resources/templates/contract/contract-debtor-approve.html
+++ b/src/main/resources/templates/contract/contract-debtor-approve.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-debtor-approve.css}" href="../../static/css/contract/contract-debtor-approve.css" />
+  <script src="https://cdn.portone.io/v2/browser-sdk.js"></script>
 </head>
 <body>
 
@@ -65,6 +66,14 @@
     <h1 class="doc__title">금 전 차 용 계 약 서</h1>
 
     <p class="doc__status-banner" id="statusBanner" hidden></p>
+
+    <section class="identity-panel" id="identityPanel">
+      <div class="identity-panel__info">
+        <strong>본인인증</strong>
+        <span class="identity-panel__status" id="identityStatusText">본인인증 후 계약 내용을 확인할 수 있습니다.</span>
+      </div>
+      <button type="button" class="btn btn--primary" id="btnIdentityVerify">본인인증 시작</button>
+    </section>
 
     <p class="doc__hint">채권자가 작성한 아래 계약 내용을 확인한 뒤, 본인 주소를 입력하고 다음 단계에서 전자서명을 진행해 주세요.</p>
 
@@ -165,7 +174,7 @@
     </table>
 
     <div class="doc__actions">
-      <button type="button" class="btn btn--primary" id="btnNext">다음 (전자서명)</button>
+      <button type="button" class="btn btn--primary" id="btnNext">확인</button>
     </div>
 
     <p class="doc__status" id="formStatus" role="status" aria-live="polite"></p>

--- a/src/main/resources/templates/contract/contract-form.html
+++ b/src/main/resources/templates/contract/contract-form.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="./contract-form.css" />
+  <script src="https://cdn.portone.io/v2/browser-sdk.js"></script>
 </head>
 <body>
 
@@ -65,6 +66,16 @@
     <h1 class="doc__title">금 전 차 용 계 약 서</h1>
 
     <p class="doc__status-banner" id="statusBanner" hidden></p>
+
+    <section class="identity-panel" id="identityPanel">
+      <div class="identity-panel__info">
+        <strong>본인인증</strong>
+        <span class="identity-panel__status" id="identityStatusText">본인인증 후 계약서를 작성할 수 있습니다.</span>
+      </div>
+      <button type="button" class="btn btn--primary" id="btnIdentityVerify">본인인증 시작</button>
+    </section>
+
+    <input type="hidden" id="identityVerificationId" name="identityVerificationId" />
 
     <section class="doc__article">
       <span class="doc__clause">제1조(당사자)</span>

--- a/src/test/java/org/teamsai/saibackend/domain/contract/LoanContractServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contract/LoanContractServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
@@ -16,9 +17,11 @@ import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
 import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractFileService;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
+import org.teamsai.saibackend.domain.identity.service.IdentityService;
+import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
-import org.teamsai.saibackend.domain.user.mapper.UserMapper;
+import org.teamsai.saibackend.domain.user.service.UserService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
@@ -29,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,6 +44,7 @@ class LoanContractServiceTest {
     private static final Long OTHER_USER_ID = 999L;
     private static final String DEBTOR_EMAIL = "debtor@example.com";
     private static final Long CONTRACT_ID = 1L;
+    private static final String IDENTITY_VERIFICATION_ID = "identity-verification-abc123";
 
     @Mock
     private LoanContractMapper contractMapper;
@@ -48,7 +53,10 @@ class LoanContractServiceTest {
     private LoanContractFileService fileService;
 
     @Mock
-    private UserMapper userMapper;
+    private UserService userService;
+
+    @Mock
+    private IdentityService identityService;
 
     @InjectMocks
     private LoanContractService loanContractService;
@@ -58,27 +66,23 @@ class LoanContractServiceTest {
     class CreateContract {
 
         @Test
-        @DisplayName("채권자와 채무자를 각각 조회해 계약서를 생성한다")
+        @DisplayName("채권자 본인 확인 후 계약서를 생성한다")
         void createContractSuccess() {
             LoanContractRequest request = createRequest();
-            UserDTO creditor = createUser(1L);
-            UserDTO debtor = createUser(2L);
-
-            given(userMapper.findById(CREDITOR_ID)).willReturn(Optional.of(creditor));
-            given(userMapper.findByEmail(DEBTOR_EMAIL)).willReturn(Optional.of(debtor));
 
             loanContractService.createContract(request, CREDITOR_ID);
 
-            verify(contractMapper).insertByContract(request, creditor, debtor);
+            verify(identityService).consume(
+                    CREDITOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT
+            );
+            verify(userService).getMyInfo(CREDITOR_ID);
+            verify(contractMapper).insertByContract(request, CREDITOR_ID);
         }
 
         @Test
         @DisplayName("생성된 계약서의 contractId를 그대로 반환한다")
         void createContractReturnsGeneratedId() {
             LoanContractRequest request = createRequest();
-            given(userMapper.findById(CREDITOR_ID)).willReturn(Optional.of(createUser(1L)));
-            given(userMapper.findByEmail(DEBTOR_EMAIL)).willReturn(Optional.of(createUser(2L)));
-
             request.setContractId(100L);
 
             Long contractId = loanContractService.createContract(request, CREDITOR_ID);
@@ -90,7 +94,10 @@ class LoanContractServiceTest {
         @DisplayName("채권자를 찾을 수 없으면 예외가 발생하고 계약서를 생성하지 않는다")
         void createContractFailsWhenCreditorNotFound() {
             LoanContractRequest request = createRequest();
-            given(userMapper.findById(CREDITOR_ID)).willReturn(Optional.empty());
+
+            willThrow(UserErrorCode.USER_NOT_FOUND.toException())
+                    .given(userService)
+                    .getMyInfo(CREDITOR_ID);
 
             assertThatThrownBy(() -> loanContractService.createContract(request, CREDITOR_ID))
                     .isInstanceOfSatisfying(
@@ -99,24 +106,118 @@ class LoanContractServiceTest {
                                     .isEqualTo(UserErrorCode.USER_NOT_FOUND)
                     );
 
-            verify(contractMapper, never()).insertByContract(any(), any(), any());
+            verify(contractMapper, never()).insertByContract(any(), any());
         }
 
         @Test
-        @DisplayName("채무자 이메일로 가입된 회원을 찾을 수 없으면 예외가 발생하고 계약서를 생성하지 않는다")
-        void createContractFailsWhenDebtorNotFound() {
+        @DisplayName("본인인증을 완료하지 않았으면 예외가 발생하고 계약서를 생성하지 않는다")
+        void createContractFailsWhenIdentityNotVerified() {
             LoanContractRequest request = createRequest();
-            given(userMapper.findById(CREDITOR_ID)).willReturn(Optional.of(createUser(1L)));
-            given(userMapper.findByEmail(DEBTOR_EMAIL)).willReturn(Optional.empty());
+
+            willThrow(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED.toException())
+                    .given(identityService)
+                    .consume(CREDITOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT);
 
             assertThatThrownBy(() -> loanContractService.createContract(request, CREDITOR_ID))
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(LoanContractErrorCode.DEBTOR_NOT_FOUND)
+                                    .isEqualTo(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED)
                     );
 
-            verify(contractMapper, never()).insertByContract(any(), any(), any());
+            verify(userService, never()).getMyInfo(any());
+            verify(contractMapper, never()).insertByContract(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("채무자 계약 합류")
+    class LinkDebtor {
+
+        private final LoanContractDebtorLinkRequest linkRequest =
+                new LoanContractDebtorLinkRequest(IDENTITY_VERIFICATION_ID);
+
+        @Test
+        @DisplayName("본인인증을 마친 채무자를 계약에 연결한다")
+        void linkDebtorSuccess() {
+            given(contractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createResponseWithoutDebtor()));
+
+            loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest);
+
+            verify(identityService).consume(
+                    DEBTOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT
+            );
+            verify(contractMapper).updateDebtorId(CONTRACT_ID, DEBTOR_ID);
+        }
+
+        @Test
+        @DisplayName("계약서를 찾을 수 없으면 예외가 발생하고 연결하지 않는다")
+        void linkDebtorFailsWhenContractNotFound() {
+            given(contractMapper.findContractById(CONTRACT_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(LoanContractErrorCode.CONTRACT_NOT_FOUND)
+                    );
+
+            verify(contractMapper, never()).updateDebtorId(any(), any());
+        }
+
+        @Test
+        @DisplayName("이미 채무자가 연결되어 있으면 예외가 발생하고 본인인증을 소비하지 않는다")
+        void linkDebtorFailsWhenAlreadyLinked() {
+            given(contractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createResponse()));
+
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, OTHER_USER_ID, linkRequest))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(LoanContractErrorCode.DEBTOR_ALREADY_LINKED)
+                    );
+
+            verify(identityService, never()).consume(any(), any(), any());
+            verify(contractMapper, never()).updateDebtorId(any(), any());
+        }
+
+        @Test
+        @DisplayName("채권자 본인이 채무자로 합류할 수 없다")
+        void linkDebtorFailsWhenCreditorTriesToJoinAsDebtor() {
+            given(contractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createResponseWithoutDebtor()));
+
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, CREDITOR_ID, linkRequest))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(LoanContractErrorCode.CANNOT_CREATE_CONTRACT_TO_SELF)
+                    );
+
+            verify(identityService, never()).consume(any(), any(), any());
+            verify(contractMapper, never()).updateDebtorId(any(), any());
+        }
+
+        @Test
+        @DisplayName("본인인증을 완료하지 않았으면 예외가 발생하고 연결하지 않는다")
+        void linkDebtorFailsWhenIdentityNotVerified() {
+            given(contractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createResponseWithoutDebtor()));
+
+            willThrow(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED.toException())
+                    .given(identityService)
+                    .consume(DEBTOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT);
+
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED)
+                    );
+
+            verify(contractMapper, never()).updateDebtorId(any(), any());
         }
     }
 
@@ -326,6 +427,7 @@ class LoanContractServiceTest {
 
     private LoanContractRequest createRequest() {
         return LoanContractRequest.builder()
+                .identityVerificationId(IDENTITY_VERIFICATION_ID)
                 .principalAmount(BigDecimal.valueOf(1_000_000))
                 .interestRate(BigDecimal.valueOf(5.0))
                 .repaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
@@ -339,14 +441,22 @@ class LoanContractServiceTest {
                 .build();
     }
 
-    private UserDTO createUser(Long userId) {
-        return UserDTO.builder()
-                .userId(userId)
-                .userToken("token-" + userId)
-                .email("user" + userId + "@example.com")
-                .password("encoded-password")
-                .name("김사이")
-                .birthDate(LocalDate.of(1995, 5, 5))
+    private LoanContractResponse createResponseWithoutDebtor() {
+        return LoanContractResponse.builder()
+                .contractId(CONTRACT_ID)
+                .creditorId(CREDITOR_ID)
+                .debtorId(null)
+                .creditorName("김채권")
+                .creditorBirthDate("1995-05-05")
+                .creditorAddress("서울특별시 강남구 테헤란로 123")
+                .principalAmount(BigDecimal.valueOf(1_000_000))
+                .interestRate(BigDecimal.valueOf(5.0))
+                .repaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
+                .startDate(LocalDate.of(2026, 1, 1))
+                .maturityDate(LocalDate.of(2027, 1, 1))
+                .repaymentDay(15)
+                .contractAlias("생활비 차용")
+                .status(ContractStatus.DRAFT)
                 .build();
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -135,8 +135,22 @@ class ContractChangeServiceTest {
 
             verify(contractChangeMapper).insert(any());
             verify(loanContractMapper).insertChangedContract(
-                    eq(CONTRACT_ID), any(), any(), any(), any(), any(), any(),
-                    any(), any(), any(), any(), any(), any(), any(), any()
+                    eq(CONTRACT_ID),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    eq(ContractStatus.PENDING),
+                    any(),
+                    any()
             );
         }
 

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -13,7 +13,6 @@ import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
-import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
@@ -31,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,9 +43,6 @@ class ContractChangeServiceTest {
 
     @Mock
     private ContractChangeMapper contractChangeMapper;
-
-    @Mock
-    private LoanContractMapper loanContractMapper;
 
     @Mock
     private LoanContractService loanContractService;
@@ -117,8 +114,8 @@ class ContractChangeServiceTest {
                 .changeReason("이자율 조정 요청")
                 .newMaturityDate(LocalDate.of(2027, 1, 1))
                 .newInterestRate(BigDecimal.valueOf(5.0))
-                .newRepaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
-                .newRepaymentDate(LocalDate.of(2027, 1, 15))
+                .newRepaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST.name())
+                .newRepaymentDate(15)
                 .build();
     }
 
@@ -140,7 +137,7 @@ class ContractChangeServiceTest {
 
             ArgumentCaptor<ChangeLoanContractResponse> captor =
                     ArgumentCaptor.forClass(ChangeLoanContractResponse.class);
-            verify(loanContractMapper).insertChangedContract(captor.capture());
+            verify(loanContractService).insertChangedContract(captor.capture());
 
             ChangeLoanContractResponse changedContract = captor.getValue();
             assertThat(changedContract.getPreviousContractId()).isEqualTo(CONTRACT_ID);
@@ -200,6 +197,30 @@ class ContractChangeServiceTest {
                             exception -> assertThat(exception.getErrorCode())
                                     .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
                     );
+        }
+
+        @Test
+        @DisplayName("채무자가 요청하면 예외가 발생하고 저장하지 않는다")
+        void requestChangeFailsWhenRequesterIsDebtor() {
+            LoanContractResponse contract = LoanContractResponse.builder()
+                    .contractId(CONTRACT_ID)
+                    .status(ContractStatus.COMPLETED)
+                    .creditorId(888L)
+                    .debtorId(USER_ID)   // ← 요청자가 채무자인 경우
+                    .build();
+
+            given(loanContractService.findContract(CONTRACT_ID, USER_ID))
+                    .willReturn(contract);
+
+            assertThatThrownBy(() -> contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.NOT_CREDITOR)
+                    );
+
+            verify(contractChangeMapper, never()).insert(any());
+            verify(loanContractService, never()).insertChangedContract(any());
         }
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
+import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
@@ -25,6 +26,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -34,9 +36,13 @@ class ContractChangeServiceTest {
 
     private static final Long CONTRACT_ID = 1L;
     private static final Long USER_ID = 10L;
+    private static final Long DEBTOR_ID = 20L;
 
     @Mock
     private ContractChangeMapper contractChangeMapper;
+
+    @Mock
+    private LoanContractMapper loanContractMapper;
 
     @Mock
     private LoanContractService loanContractService;
@@ -93,6 +99,13 @@ class ContractChangeServiceTest {
                 .contractId(CONTRACT_ID)
                 .status(status)
                 .creditorId(USER_ID)
+                .debtorId(DEBTOR_ID)
+                .principalAmount(BigDecimal.valueOf(1_000_000))
+                .repaymentDay(15)
+                .creditorAddress("서울시 강남구")
+                .debtorAddress("서울시 서초구")
+                .contractAlias("차용증")
+                .terms("계약 조건")
                 .build();
     }
 
@@ -111,7 +124,7 @@ class ContractChangeServiceTest {
     class RequestChange {
 
         @Test
-        @DisplayName("완료된 계약이고 중복 요청이 없으면 저장한다")
+        @DisplayName("완료된 계약이고 중복 요청이 없으면 변경 요청과 계약서 테이블에 함께 저장한다")
         void requestChangeSuccess() {
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
                     .willReturn(createContract(ContractStatus.COMPLETED));
@@ -121,6 +134,10 @@ class ContractChangeServiceTest {
             contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID);
 
             verify(contractChangeMapper).insert(any());
+            verify(loanContractMapper).insertChangedContract(
+                    eq(CONTRACT_ID), any(), any(), any(), any(), any(), any(),
+                    any(), any(), any(), any(), any(), any(), any(), any()
+            );
         }
 
         @Test
@@ -141,7 +158,7 @@ class ContractChangeServiceTest {
         @DisplayName("이미 PENDING 요청이 있으면 예외가 발생한다")
         void requestChangeFailsWhenDuplicatePending() {
             LoanContractChangeDTO pendingRequest = LoanContractChangeDTO.builder()
-                    .status("PENDING")
+                    .status(ContractStatus.PENDING)
                     .build();
 
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
@@ -158,12 +175,13 @@ class ContractChangeServiceTest {
         }
 
         @Test
-        @DisplayName("채권자가 아니면 예외가 발생한다")
-        void requestChangeFailsWhenNotCreditor() {
+        @DisplayName("계약 당사자가 아니면 예외가 발생한다")
+        void requestChangeFailsWhenNotContractParty() {
             LoanContractResponse contract = LoanContractResponse.builder()
                     .contractId(CONTRACT_ID)
                     .status(ContractStatus.COMPLETED)
-                    .creditorId(999L)   // ← userId(10L)와 다른 채권자
+                    .creditorId(888L)   // ← userId(10L)와 다른 채권자
+                    .debtorId(999L)     // ← userId(10L)와 다른 채무자
                     .build();
 
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
@@ -173,7 +191,7 @@ class ContractChangeServiceTest {
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(ContractChangeErrorCode.ONLY_CREDITOR_CAN_REQUEST_CHANGE)
+                                    .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
                     );
         }
     }

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -4,14 +4,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
+import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
 import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
+import org.teamsai.saibackend.domain.contractchange.dto.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
 import org.teamsai.saibackend.domain.contractchange.exception.ContractChangeErrorCode;
@@ -26,7 +30,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -114,7 +117,7 @@ class ContractChangeServiceTest {
                 .changeReason("이자율 조정 요청")
                 .newMaturityDate(LocalDate.of(2027, 1, 1))
                 .newInterestRate(BigDecimal.valueOf(5.0))
-                .newRepaymentType("원리금균등상환")
+                .newRepaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
                 .newRepaymentDate(LocalDate.of(2027, 1, 15))
                 .build();
     }
@@ -134,24 +137,14 @@ class ContractChangeServiceTest {
             contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID);
 
             verify(contractChangeMapper).insert(any());
-            verify(loanContractMapper).insertChangedContract(
-                    eq(CONTRACT_ID),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    eq(ContractStatus.PENDING),
-                    any(),
-                    any()
-            );
+
+            ArgumentCaptor<ChangeLoanContractResponse> captor =
+                    ArgumentCaptor.forClass(ChangeLoanContractResponse.class);
+            verify(loanContractMapper).insertChangedContract(captor.capture());
+
+            ChangeLoanContractResponse changedContract = captor.getValue();
+            assertThat(changedContract.getPreviousContractId()).isEqualTo(CONTRACT_ID);
+            assertThat(changedContract.getStatus()).isEqualTo(ContractStatus.PENDING);
         }
 
         @Test
@@ -172,7 +165,7 @@ class ContractChangeServiceTest {
         @DisplayName("이미 PENDING 요청이 있으면 예외가 발생한다")
         void requestChangeFailsWhenDuplicatePending() {
             LoanContractChangeDTO pendingRequest = LoanContractChangeDTO.builder()
-                    .status(ContractStatus.PENDING)
+                    .status(ChangeRequestStatus.PENDING)
                     .build();
 
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))


### PR DESCRIPTION
## 🔗 연관 이슈

- 계약서 변경시 LoanContract 테이블에 반영이 되지 않는 문제점이 있었습니다.

## 🛠 작업 사항

-계약서 변경 요청시 변경사항을 반영한 새로운 계약서가 작성되어 LoanContract 테이블에 저장됩니다.
-새로운 계약서 작성 시 이전 계약서가 연동되도록 previouscontractId 속성을 만들어 조인 시켰습니다.
-계약서 변경시 누가 채무자이고 채권자인지를 구분이 된 상태에서 계약서 변경이 가능하도록 기능을 추가하였습니다.

## ✅ 테스트

- [O] 로컬 서버 테스트 완료
- [O] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
-