### PR TITLE
feat(#28): 공통 은행 거래 및 상태 기반 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/transaction/dto/BankTransactionDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/dto/BankTransactionDTO.java
@@ -1,0 +1,38 @@
+package org.teamsai.saibackend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BankTransactionDTO {
+
+    private Long bankTransactionId;
+
+    private Long linkedAccountId;
+
+    private String externalTransactionId;
+
+    private BigDecimal amount;
+
+    private BankTransactionType transactionType;
+
+    private BankTransactionProcessingStatus processingStatus;
+
+    private LocalDateTime transactionAt;
+
+    private String counterpartyName;
+
+    private String memo;
+
+    private LocalDateTime syncedAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/exception/BankTransactionErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/exception/BankTransactionErrorCode.java
@@ -10,13 +10,23 @@ import org.teamsai.saibackend.global.exception.DomainException;
 @RequiredArgsConstructor
 public enum BankTransactionErrorCode implements BaseErrorCode<DomainException> {
 
+    INVALID_BANK_TRANSACTION(
+            HttpStatus.BAD_REQUEST,
+            "은행 거래 정보가 올바르지 않습니다."
+    ),
+
+    INVALID_BANK_TRANSACTION_STATUS_TRANSITION(
+            HttpStatus.BAD_REQUEST,
+            "은행 거래 처리 상태 전이가 올바르지 않습니다."
+    ),
+
     BANK_TRANSACTION_CREATE_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "은행 거래 생성에 실패했습니다."
     ),
 
     BANK_TRANSACTION_STATUS_UPDATE_FAILED(
-            HttpStatus.INTERNAL_SERVER_ERROR,
+            HttpStatus.CONFLICT,
             "은행 거래 처리 상태 변경에 실패했습니다."
     ),
 

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/exception/BankTransactionErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/exception/BankTransactionErrorCode.java
@@ -1,0 +1,35 @@
+package org.teamsai.saibackend.domain.transaction.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.teamsai.saibackend.global.exception.BaseErrorCode;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+@Getter
+@RequiredArgsConstructor
+public enum BankTransactionErrorCode implements BaseErrorCode<DomainException> {
+
+    BANK_TRANSACTION_CREATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "은행 거래 생성에 실패했습니다."
+    ),
+
+    BANK_TRANSACTION_STATUS_UPDATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "은행 거래 처리 상태 변경에 실패했습니다."
+    ),
+
+    BANK_TRANSACTION_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "은행 거래를 찾을 수 없습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Mapper
 public interface BankTransactionMapper {
 
-    int insert(BankTransactionDTO bankTransaction);
+    int insertOrGetId(BankTransactionDTO bankTransaction);
 
     Optional<BankTransactionDTO> findById(
             @Param("bankTransactionId") Long bankTransactionId

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
@@ -26,7 +26,9 @@ public interface BankTransactionMapper {
 
     int updateStatus(
             @Param("bankTransactionId") Long bankTransactionId,
-            @Param("processingStatus") BankTransactionProcessingStatus
-                    processingStatus
+            @Param("currentStatus")
+            BankTransactionProcessingStatus currentStatus,
+            @Param("nextStatus")
+            BankTransactionProcessingStatus nextStatus
     );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
@@ -1,0 +1,32 @@
+package org.teamsai.saibackend.domain.transaction.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface BankTransactionMapper {
+
+    int insert(BankTransactionDTO bankTransaction);
+
+    Optional<BankTransactionDTO> findById(
+            @Param("bankTransactionId") Long bankTransactionId
+    );
+
+    Optional<BankTransactionDTO> findByExternalKey(
+            @Param("linkedAccountId") Long linkedAccountId,
+            @Param("externalTransactionId") String externalTransactionId
+    );
+
+    List<BankTransactionDTO> findPendingDeposits();
+
+    int updateStatus(
+            @Param("bankTransactionId") Long bankTransactionId,
+            @Param("processingStatus") BankTransactionProcessingStatus
+                    processingStatus
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -1,7 +1,6 @@
 package org.teamsai.saibackend.domain.transaction.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
@@ -20,12 +19,17 @@ public class BankTransactionService {
 
     @Transactional
     public Long saveIfNotExists(BankTransactionDTO bankTransaction) {
-        return bankTransactionMapper.findByExternalKey(
-                        bankTransaction.getLinkedAccountId(),
-                        bankTransaction.getExternalTransactionId()
-                )
-                .map(BankTransactionDTO::getBankTransactionId)
-                .orElseGet(() -> insertOrFindExisting(bankTransaction));
+        bankTransactionMapper.insertOrGetId(bankTransaction);
+
+        Long bankTransactionId = bankTransaction.getBankTransactionId();
+
+        if (bankTransactionId == null) {
+            throw BankTransactionErrorCode
+                    .BANK_TRANSACTION_CREATE_FAILED
+                    .toException();
+        }
+
+        return bankTransactionId;
     }
 
     public List<BankTransactionDTO> findPendingDeposits() {
@@ -46,31 +50,6 @@ public class BankTransactionService {
             throw BankTransactionErrorCode
                     .BANK_TRANSACTION_STATUS_UPDATE_FAILED
                     .toException();
-        }
-    }
-
-    private Long insertOrFindExisting(BankTransactionDTO bankTransaction) {
-        try {
-            int insertedCount = bankTransactionMapper.insert(bankTransaction);
-
-            if (insertedCount != 1
-                    || bankTransaction.getBankTransactionId() == null) {
-                throw BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
-                        .toException();
-            }
-
-            return bankTransaction.getBankTransactionId();
-
-        } catch (DuplicateKeyException exception) {
-            return bankTransactionMapper.findByExternalKey(
-                            bankTransaction.getLinkedAccountId(),
-                            bankTransaction.getExternalTransactionId()
-                    )
-                    .map(BankTransactionDTO::getBankTransactionId)
-                    .orElseThrow(
-                            BankTransactionErrorCode
-                                    .BANK_TRANSACTION_CREATE_FAILED::toException
-                    );
         }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -19,10 +19,11 @@ public class BankTransactionService {
 
     @Transactional
     public Long saveIfNotExists(BankTransactionDTO bankTransaction) {
+        validateNewBankTransaction(bankTransaction);
+
         bankTransactionMapper.insertOrGetId(bankTransaction);
 
         Long bankTransactionId = bankTransaction.getBankTransactionId();
-
         if (bankTransactionId == null) {
             throw BankTransactionErrorCode
                     .BANK_TRANSACTION_CREATE_FAILED
@@ -39,11 +40,15 @@ public class BankTransactionService {
     @Transactional
     public void updateStatus(
             Long bankTransactionId,
-            BankTransactionProcessingStatus processingStatus
+            BankTransactionProcessingStatus currentStatus,
+            BankTransactionProcessingStatus nextStatus
     ) {
+        validateStatusTransition(currentStatus, nextStatus);
+
         int updatedCount = bankTransactionMapper.updateStatus(
                 bankTransactionId,
-                processingStatus
+                currentStatus,
+                nextStatus
         );
 
         if (updatedCount != 1) {
@@ -51,5 +56,68 @@ public class BankTransactionService {
                     .BANK_TRANSACTION_STATUS_UPDATE_FAILED
                     .toException();
         }
+    }
+
+    private void validateNewBankTransaction(
+            BankTransactionDTO bankTransaction
+    ) {
+        if (bankTransaction == null
+                || hasInvalidRequiredField(bankTransaction)
+                || hasInvalidAmount(bankTransaction)
+                || hasInvalidInitialStatus(bankTransaction)) {
+            throw BankTransactionErrorCode.INVALID_BANK_TRANSACTION
+                    .toException();
+        }
+    }
+
+    private boolean hasInvalidRequiredField(
+            BankTransactionDTO bankTransaction
+    ) {
+        return bankTransaction.getLinkedAccountId() == null
+                || isBlank(bankTransaction.getExternalTransactionId())
+                || bankTransaction.getTransactionType() == null
+                || bankTransaction.getTransactionAt() == null
+                || bankTransaction.getSyncedAt() == null;
+    }
+
+    private boolean hasInvalidAmount(BankTransactionDTO bankTransaction) {
+        return bankTransaction.getAmount() == null
+                || bankTransaction.getAmount().signum() <= 0;
+    }
+
+    private boolean hasInvalidInitialStatus(
+            BankTransactionDTO bankTransaction
+    ) {
+        return bankTransaction.getProcessingStatus() != null
+                && bankTransaction.getProcessingStatus()
+                != BankTransactionProcessingStatus.PENDING;
+    }
+
+    private void validateStatusTransition(
+            BankTransactionProcessingStatus currentStatus,
+            BankTransactionProcessingStatus nextStatus
+    ) {
+        if (currentStatus != BankTransactionProcessingStatus.PENDING
+                || !isTerminalStatus(nextStatus)) {
+            throw BankTransactionErrorCode
+                    .INVALID_BANK_TRANSACTION_STATUS_TRANSITION
+                    .toException();
+        }
+    }
+
+    private boolean isTerminalStatus(
+            BankTransactionProcessingStatus processingStatus
+    ) {
+        return processingStatus == BankTransactionProcessingStatus.APPLIED
+                || processingStatus
+                == BankTransactionProcessingStatus.UNMATCHED
+                || processingStatus
+                == BankTransactionProcessingStatus.NEEDS_CHECK
+                || processingStatus
+                == BankTransactionProcessingStatus.FAILED;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -1,0 +1,76 @@
+package org.teamsai.saibackend.domain.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
+import org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BankTransactionService {
+
+    private final BankTransactionMapper bankTransactionMapper;
+
+    @Transactional
+    public Long saveIfNotExists(BankTransactionDTO bankTransaction) {
+        return bankTransactionMapper.findByExternalKey(
+                        bankTransaction.getLinkedAccountId(),
+                        bankTransaction.getExternalTransactionId()
+                )
+                .map(BankTransactionDTO::getBankTransactionId)
+                .orElseGet(() -> insertOrFindExisting(bankTransaction));
+    }
+
+    public List<BankTransactionDTO> findPendingDeposits() {
+        return bankTransactionMapper.findPendingDeposits();
+    }
+
+    @Transactional
+    public void updateStatus(
+            Long bankTransactionId,
+            BankTransactionProcessingStatus processingStatus
+    ) {
+        int updatedCount = bankTransactionMapper.updateStatus(
+                bankTransactionId,
+                processingStatus
+        );
+
+        if (updatedCount != 1) {
+            throw BankTransactionErrorCode
+                    .BANK_TRANSACTION_STATUS_UPDATE_FAILED
+                    .toException();
+        }
+    }
+
+    private Long insertOrFindExisting(BankTransactionDTO bankTransaction) {
+        try {
+            int insertedCount = bankTransactionMapper.insert(bankTransaction);
+
+            if (insertedCount != 1
+                    || bankTransaction.getBankTransactionId() == null) {
+                throw BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
+                        .toException();
+            }
+
+            return bankTransaction.getBankTransactionId();
+
+        } catch (DuplicateKeyException exception) {
+            return bankTransactionMapper.findByExternalKey(
+                            bankTransaction.getLinkedAccountId(),
+                            bankTransaction.getExternalTransactionId()
+                    )
+                    .map(BankTransactionDTO::getBankTransactionId)
+                    .orElseThrow(
+                            BankTransactionErrorCode
+                                    .BANK_TRANSACTION_CREATE_FAILED::toException
+                    );
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/type/BankTransactionProcessingStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/type/BankTransactionProcessingStatus.java
@@ -1,0 +1,9 @@
+package org.teamsai.saibackend.domain.transaction.type;
+
+public enum BankTransactionProcessingStatus {
+    PENDING,
+    APPLIED,
+    UNMATCHED,
+    NEEDS_CHECK,
+    FAILED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/type/BankTransactionType.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/type/BankTransactionType.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.transaction.type;
+
+public enum BankTransactionType {
+    DEPOSIT,
+    WITHDRAWAL
+}

--- a/src/main/resources/db/transaction.sql
+++ b/src/main/resources/db/transaction.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS bank_transaction (
+    bank_transaction_id BIGINT NOT NULL AUTO_INCREMENT,
+
+    linked_account_id BIGINT NOT NULL,
+    external_transaction_id VARCHAR(100) NOT NULL,
+
+    amount DECIMAL(19, 2) NOT NULL CHECK (amount > 0),
+
+    transaction_type VARCHAR(20) NOT NULL CHECK (
+        transaction_type IN ('DEPOSIT', 'WITHDRAWAL')
+    ),
+
+    processing_status VARCHAR(30) NOT NULL DEFAULT 'PENDING' CHECK (
+        processing_status IN (
+            'PENDING',
+            'APPLIED',
+            'UNMATCHED',
+            'NEEDS_CHECK',
+            'FAILED'
+        )
+    ),
+
+    transaction_at DATETIME NOT NULL,
+    counterparty_name VARCHAR(50) NULL,
+    memo VARCHAR(50) NULL,
+    synced_at DATETIME NOT NULL,
+
+    PRIMARY KEY (bank_transaction_id),
+
+    CONSTRAINT uk_bank_transaction_linked_external
+        UNIQUE (linked_account_id, external_transaction_id),
+
+    INDEX idx_bank_transaction_matching_target (
+        processing_status,
+        transaction_type,
+        transaction_at
+    ),
+
+    INDEX idx_bank_transaction_linked_account (
+       linked_account_id
+    )
+    ) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4
+    COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/transaction/BankTransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/BankTransactionMapper.xml
@@ -32,10 +32,11 @@
         synced_at
     </sql>
 
-    <insert id="insert"
+    <insert id="insertOrGetId"
             parameterType="org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO"
             useGeneratedKeys="true"
-            keyProperty="bankTransactionId">
+            keyProperty="bankTransactionId"
+            keyColumn="bank_transaction_id">
         INSERT INTO bank_transaction (
         linked_account_id,
         external_transaction_id,
@@ -56,6 +57,8 @@
         #{memo},
         #{syncedAt}
         )
+        ON DUPLICATE KEY UPDATE
+        bank_transaction_id = LAST_INSERT_ID(bank_transaction_id)
     </insert>
 
     <select id="findById" resultMap="BankTransactionResultMap">

--- a/src/main/resources/mapper/transaction/BankTransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/BankTransactionMapper.xml
@@ -42,6 +42,7 @@
         external_transaction_id,
         amount,
         transaction_type,
+        processing_status,
         transaction_at,
         counterparty_name,
         memo,
@@ -52,6 +53,7 @@
         #{externalTransactionId},
         #{amount},
         #{transactionType},
+        'PENDING',
         #{transactionAt},
         #{counterpartyName},
         #{memo},
@@ -89,8 +91,9 @@
 
     <update id="updateStatus">
         UPDATE bank_transaction
-        SET processing_status = #{processingStatus}
+        SET processing_status = #{nextStatus}
         WHERE bank_transaction_id = #{bankTransactionId}
+        AND processing_status = #{currentStatus}
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/transaction/BankTransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/BankTransactionMapper.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper">
+
+    <resultMap id="BankTransactionResultMap"
+               type="org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO">
+        <id property="bankTransactionId" column="bank_transaction_id"/>
+        <result property="linkedAccountId" column="linked_account_id"/>
+        <result property="externalTransactionId" column="external_transaction_id"/>
+        <result property="amount" column="amount"/>
+        <result property="transactionType" column="transaction_type"/>
+        <result property="processingStatus" column="processing_status"/>
+        <result property="transactionAt" column="transaction_at"/>
+        <result property="counterpartyName" column="counterparty_name"/>
+        <result property="memo" column="memo"/>
+        <result property="syncedAt" column="synced_at"/>
+    </resultMap>
+
+    <sql id="BankTransactionColumns">
+        bank_transaction_id,
+        linked_account_id,
+        external_transaction_id,
+        amount,
+        transaction_type,
+        processing_status,
+        transaction_at,
+        counterparty_name,
+        memo,
+        synced_at
+    </sql>
+
+    <insert id="insert"
+            parameterType="org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO"
+            useGeneratedKeys="true"
+            keyProperty="bankTransactionId">
+        INSERT INTO bank_transaction (
+        linked_account_id,
+        external_transaction_id,
+        amount,
+        transaction_type,
+        transaction_at,
+        counterparty_name,
+        memo,
+        synced_at
+        )
+        VALUES (
+        #{linkedAccountId},
+        #{externalTransactionId},
+        #{amount},
+        #{transactionType},
+        #{transactionAt},
+        #{counterpartyName},
+        #{memo},
+        #{syncedAt}
+        )
+    </insert>
+
+    <select id="findById" resultMap="BankTransactionResultMap">
+        SELECT
+        <include refid="BankTransactionColumns"/>
+        FROM bank_transaction
+        WHERE bank_transaction_id = #{bankTransactionId}
+    </select>
+
+    <select id="findByExternalKey"
+            resultMap="BankTransactionResultMap">
+        SELECT
+        <include refid="BankTransactionColumns"/>
+        FROM bank_transaction
+        WHERE linked_account_id = #{linkedAccountId}
+        AND external_transaction_id = #{externalTransactionId}
+    </select>
+
+    <select id="findPendingDeposits"
+            resultMap="BankTransactionResultMap">
+        SELECT
+        <include refid="BankTransactionColumns"/>
+        FROM bank_transaction
+        WHERE processing_status = 'PENDING'
+        AND transaction_type = 'DEPOSIT'
+        ORDER BY transaction_at ASC, bank_transaction_id ASC
+    </select>
+
+    <update id="updateStatus">
+        UPDATE bank_transaction
+        SET processing_status = #{processingStatus}
+        WHERE bank_transaction_id = #{bankTransactionId}
+    </update>
+
+</mapper>

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
@@ -1,0 +1,165 @@
+package org.teamsai.saibackend.domain.transaction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("dev")
+@Sql(scripts = "/db/transaction.sql")
+@DisplayName("BankTransactionMapper 통합 테스트")
+class BankTransactionMapperTest {
+
+    private static final Long LINKED_ACCOUNT_ID = 1L;
+
+    @Autowired
+    private BankTransactionMapper bankTransactionMapper;
+
+    @Test
+    @Transactional
+    @DisplayName("신규 은행 거래를 저장하면 DTO에 생성된 ID가 채워진다")
+    void insertOrGetIdAssignsGeneratedKeyToNewTransaction() {
+        BankTransactionDTO bankTransaction = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+
+        bankTransactionMapper.insertOrGetId(bankTransaction);
+
+        assertThat(bankTransaction.getBankTransactionId()).isNotNull();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("같은 외부 거래 키를 다시 저장하면 기존 은행 거래 ID가 채워진다")
+    void insertOrGetIdAssignsExistingIdToDuplicatedTransaction() {
+        String externalTransactionId = uniqueExternalTransactionId();
+        BankTransactionDTO firstTransaction = transaction(
+                externalTransactionId,
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+        BankTransactionDTO duplicatedTransaction = transaction(
+                externalTransactionId,
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 1)
+        );
+
+        bankTransactionMapper.insertOrGetId(firstTransaction);
+        bankTransactionMapper.insertOrGetId(duplicatedTransaction);
+
+        assertThat(duplicatedTransaction.getBankTransactionId())
+                .isEqualTo(firstTransaction.getBankTransactionId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("신규 은행 거래는 DB 기본값으로 PENDING 상태가 된다")
+    void insertOrGetIdAppliesPendingStatusByDefault() {
+        BankTransactionDTO bankTransaction = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+
+        bankTransactionMapper.insertOrGetId(bankTransaction);
+
+        BankTransactionDTO savedTransaction =
+                bankTransactionMapper.findById(
+                        bankTransaction.getBankTransactionId()
+                ).orElseThrow();
+
+        assertThat(savedTransaction.getProcessingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.PENDING);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("처리 대기 중인 입금 거래만 거래 시각과 ID 순서로 조회한다")
+    void findPendingDepositsReturnsOnlyPendingDepositsInOrder() {
+        BankTransactionDTO laterDeposit = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 11, 0)
+        );
+        BankTransactionDTO earlierDeposit = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+        BankTransactionDTO withdrawal = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.WITHDRAWAL,
+                LocalDateTime.of(2026, 8, 4, 9, 0)
+        );
+        BankTransactionDTO appliedDeposit = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 8, 0)
+        );
+
+        bankTransactionMapper.insertOrGetId(laterDeposit);
+        bankTransactionMapper.insertOrGetId(earlierDeposit);
+        bankTransactionMapper.insertOrGetId(withdrawal);
+        bankTransactionMapper.insertOrGetId(appliedDeposit);
+        bankTransactionMapper.updateStatus(
+                appliedDeposit.getBankTransactionId(),
+                BankTransactionProcessingStatus.APPLIED
+        );
+
+        List<BankTransactionDTO> result =
+                bankTransactionMapper.findPendingDeposits();
+
+        assertThat(result)
+                .extracting(BankTransactionDTO::getBankTransactionId)
+                .containsSubsequence(
+                        earlierDeposit.getBankTransactionId(),
+                        laterDeposit.getBankTransactionId()
+                );
+        assertThat(result)
+                .extracting(BankTransactionDTO::getBankTransactionId)
+                .doesNotContain(
+                        withdrawal.getBankTransactionId(),
+                        appliedDeposit.getBankTransactionId()
+                );
+    }
+
+    private BankTransactionDTO transaction(
+            String externalTransactionId,
+            BankTransactionType transactionType,
+            LocalDateTime transactionAt
+    ) {
+        return BankTransactionDTO.builder()
+                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .externalTransactionId(externalTransactionId)
+                .amount(new BigDecimal("10000.00"))
+                .transactionType(transactionType)
+                .transactionAt(transactionAt)
+                .counterpartyName("Hong Gil Dong")
+                .memo("deposit")
+                .syncedAt(LocalDateTime.of(2026, 8, 4, 12, 0))
+                .build();
+    }
+
+    private String uniqueExternalTransactionId() {
+        return "test-tx-" + UUID.randomUUID();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
@@ -72,8 +72,8 @@ class BankTransactionMapperTest {
 
     @Test
     @Transactional
-    @DisplayName("신규 은행 거래는 DB 기본값으로 PENDING 상태가 된다")
-    void insertOrGetIdAppliesPendingStatusByDefault() {
+    @DisplayName("신규 은행 거래는 PENDING 상태로 저장된다")
+    void insertOrGetIdSavesNewTransactionAsPending() {
         BankTransactionDTO bankTransaction = transaction(
                 uniqueExternalTransactionId(),
                 BankTransactionType.DEPOSIT,
@@ -89,6 +89,33 @@ class BankTransactionMapperTest {
 
         assertThat(savedTransaction.getProcessingStatus())
                 .isEqualTo(BankTransactionProcessingStatus.PENDING);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("현재 상태가 일치할 때만 은행 거래 처리 상태를 변경한다")
+    void updateStatusUpdatesOnlyWhenCurrentStatusMatches() {
+        BankTransactionDTO bankTransaction = transaction(
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+
+        bankTransactionMapper.insertOrGetId(bankTransaction);
+
+        int updatedCount = bankTransactionMapper.updateStatus(
+                bankTransaction.getBankTransactionId(),
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.APPLIED
+        );
+        int staleUpdatedCount = bankTransactionMapper.updateStatus(
+                bankTransaction.getBankTransactionId(),
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.FAILED
+        );
+
+        assertThat(updatedCount).isEqualTo(1);
+        assertThat(staleUpdatedCount).isZero();
     }
 
     @Test
@@ -122,6 +149,7 @@ class BankTransactionMapperTest {
         bankTransactionMapper.insertOrGetId(appliedDeposit);
         bankTransactionMapper.updateStatus(
                 appliedDeposit.getBankTransactionId(),
+                BankTransactionProcessingStatus.PENDING,
                 BankTransactionProcessingStatus.APPLIED
         );
 

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,6 +80,54 @@ class BankTransactionServiceTest {
 
             verify(bankTransactionMapper).insertOrGetId(bankTransaction);
         }
+
+        @Test
+        @DisplayName("필수 값이 없으면 은행 거래 정보 오류 예외가 발생한다")
+        void throwsInvalidBankTransactionWhenRequiredFieldIsMissing() {
+            BankTransactionDTO bankTransaction = BankTransactionDTO.builder()
+                    .linkedAccountId(LINKED_ACCOUNT_ID)
+                    .externalTransactionId(EXTERNAL_TRANSACTION_ID)
+                    .amount(new BigDecimal("10000.00"))
+                    .transactionType(BankTransactionType.DEPOSIT)
+                    .transactionAt(LocalDateTime.of(2026, 8, 4, 10, 0))
+                    .build();
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.saveIfNotExists(
+                            bankTransaction
+                    ),
+                    BankTransactionErrorCode.INVALID_BANK_TRANSACTION
+            );
+
+            verify(bankTransactionMapper, never()).insertOrGetId(
+                    bankTransaction
+            );
+        }
+
+        @Test
+        @DisplayName("신규 거래 상태가 PENDING이 아니면 은행 거래 정보 오류 예외가 발생한다")
+        void throwsInvalidBankTransactionWhenInitialStatusIsNotPending() {
+            BankTransactionDTO bankTransaction = BankTransactionDTO.builder()
+                    .linkedAccountId(LINKED_ACCOUNT_ID)
+                    .externalTransactionId(EXTERNAL_TRANSACTION_ID)
+                    .amount(new BigDecimal("10000.00"))
+                    .transactionType(BankTransactionType.DEPOSIT)
+                    .processingStatus(BankTransactionProcessingStatus.APPLIED)
+                    .transactionAt(LocalDateTime.of(2026, 8, 4, 10, 0))
+                    .syncedAt(LocalDateTime.of(2026, 8, 4, 10, 5))
+                    .build();
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.saveIfNotExists(
+                            bankTransaction
+                    ),
+                    BankTransactionErrorCode.INVALID_BANK_TRANSACTION
+            );
+
+            verify(bankTransactionMapper, never()).insertOrGetId(
+                    bankTransaction
+            );
+        }
     }
 
     @Nested
@@ -106,21 +155,44 @@ class BankTransactionServiceTest {
     class UpdateStatus {
 
         @Test
-        @DisplayName("은행 거래 처리 상태를 변경한다")
-        void updatesTransactionProcessingStatus() {
+        @DisplayName("PENDING 상태의 은행 거래를 최종 상태로 변경한다")
+        void updatesPendingTransactionToTerminalStatus() {
             given(bankTransactionMapper.updateStatus(
                     BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.PENDING,
                     BankTransactionProcessingStatus.APPLIED
             )).willReturn(1);
 
             bankTransactionService.updateStatus(
                     BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.PENDING,
                     BankTransactionProcessingStatus.APPLIED
             );
 
             verify(bankTransactionMapper).updateStatus(
                     BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.PENDING,
                     BankTransactionProcessingStatus.APPLIED
+            );
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 상태 전이면 상태 전이 오류 예외가 발생한다")
+        void throwsInvalidStatusTransitionWhenTransitionIsNotAllowed() {
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.updateStatus(
+                            BANK_TRANSACTION_ID,
+                            BankTransactionProcessingStatus.APPLIED,
+                            BankTransactionProcessingStatus.FAILED
+                    ),
+                    BankTransactionErrorCode
+                            .INVALID_BANK_TRANSACTION_STATUS_TRANSITION
+            );
+
+            verify(bankTransactionMapper, never()).updateStatus(
+                    BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.APPLIED,
+                    BankTransactionProcessingStatus.FAILED
             );
         }
 
@@ -129,12 +201,14 @@ class BankTransactionServiceTest {
         void throwsStatusUpdateFailedWhenUpdateCountIsNotOne() {
             given(bankTransactionMapper.updateStatus(
                     BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.PENDING,
                     BankTransactionProcessingStatus.APPLIED
             )).willReturn(0);
 
             assertTransactionExceptionThrownBy(
                     () -> bankTransactionService.updateStatus(
                             BANK_TRANSACTION_ID,
+                            BankTransactionProcessingStatus.PENDING,
                             BankTransactionProcessingStatus.APPLIED
                     ),
                     BankTransactionErrorCode

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -1,0 +1,259 @@
+package org.teamsai.saibackend.domain.transaction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
+import org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankTransactionService 단위 테스트")
+class BankTransactionServiceTest {
+
+    private static final Long BANK_TRANSACTION_ID = 101L;
+    private static final Long LINKED_ACCOUNT_ID = 1L;
+    private static final String EXTERNAL_TRANSACTION_ID = "external-tx-001";
+
+    @Mock
+    private BankTransactionMapper bankTransactionMapper;
+
+    @InjectMocks
+    private BankTransactionService bankTransactionService;
+
+    @Nested
+    @DisplayName("은행 거래 저장")
+    class SaveIfNotExists {
+
+        @Test
+        @DisplayName("이미 저장된 외부 거래 키이면 기존 은행 거래 ID를 반환한다")
+        void returnsExistingTransactionIdWhenExternalKeyAlreadyExists() {
+            BankTransactionDTO existingTransaction =
+                    transaction(BANK_TRANSACTION_ID);
+            BankTransactionDTO newTransaction = transaction(null);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.of(existingTransaction));
+
+            Long result =
+                    bankTransactionService.saveIfNotExists(newTransaction);
+
+            assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
+            verify(bankTransactionMapper, never()).insert(newTransaction);
+        }
+
+        @Test
+        @DisplayName("저장된 외부 거래 키가 없으면 새 거래를 저장하고 생성된 ID를 반환한다")
+        void insertsAndReturnsNewTransactionIdWhenExternalKeyDoesNotExist() {
+            BankTransactionDTO newTransaction = transaction(null);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.empty());
+            given(bankTransactionMapper.insert(newTransaction))
+                    .willAnswer(invocation -> {
+                        ReflectionTestUtils.setField(
+                                newTransaction,
+                                "bankTransactionId",
+                                BANK_TRANSACTION_ID
+                        );
+                        return 1;
+                    });
+
+            Long result =
+                    bankTransactionService.saveIfNotExists(newTransaction);
+
+            assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
+            verify(bankTransactionMapper).insert(newTransaction);
+        }
+
+        @Test
+        @DisplayName("거래 저장 후 생성된 ID가 없으면 생성 실패 예외가 발생한다")
+        void throwsCreateFailedWhenGeneratedIdIsNullAfterInsert() {
+            BankTransactionDTO newTransaction = transaction(null);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.empty());
+            given(bankTransactionMapper.insert(newTransaction)).willReturn(1);
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.saveIfNotExists(
+                            newTransaction
+                    ),
+                    BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("거래 저장 결과가 1건이 아니면 생성 실패 예외가 발생한다")
+        void throwsCreateFailedWhenInsertCountIsNotOne() {
+            BankTransactionDTO newTransaction = transaction(null);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.empty());
+            given(bankTransactionMapper.insert(newTransaction)).willReturn(0);
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.saveIfNotExists(
+                            newTransaction
+                    ),
+                    BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("저장 중 중복 키가 발생하면 기존 거래를 다시 조회해 ID를 반환한다")
+        void returnsExistingIdWhenDuplicateKeyOccursDuringInsert() {
+            BankTransactionDTO newTransaction = transaction(null);
+            BankTransactionDTO existingTransaction =
+                    transaction(BANK_TRANSACTION_ID);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.empty(), Optional.of(existingTransaction));
+            given(bankTransactionMapper.insert(newTransaction))
+                    .willThrow(new DuplicateKeyException("duplicate"));
+
+            Long result =
+                    bankTransactionService.saveIfNotExists(newTransaction);
+
+            assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
+        }
+
+        @Test
+        @DisplayName("중복 키 발생 후 기존 거래를 찾지 못하면 생성 실패 예외가 발생한다")
+        void throwsCreateFailedWhenDuplicateKeyCannotBeResolved() {
+            BankTransactionDTO newTransaction = transaction(null);
+
+            given(bankTransactionMapper.findByExternalKey(
+                    LINKED_ACCOUNT_ID,
+                    EXTERNAL_TRANSACTION_ID
+            )).willReturn(Optional.empty(), Optional.empty());
+            given(bankTransactionMapper.insert(newTransaction))
+                    .willThrow(new DuplicateKeyException("duplicate"));
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.saveIfNotExists(
+                            newTransaction
+                    ),
+                    BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("자동매칭 대상 거래 조회")
+    class FindPendingDeposits {
+
+        @Test
+        @DisplayName("처리 대기 중인 입금 거래 목록을 반환한다")
+        void returnsPendingDepositTransactions() {
+            BankTransactionDTO transaction = transaction(BANK_TRANSACTION_ID);
+
+            given(bankTransactionMapper.findPendingDeposits())
+                    .willReturn(List.of(transaction));
+
+            List<BankTransactionDTO> result =
+                    bankTransactionService.findPendingDeposits();
+
+            assertThat(result).containsExactly(transaction);
+        }
+    }
+
+    @Nested
+    @DisplayName("은행 거래 처리 상태 변경")
+    class UpdateStatus {
+
+        @Test
+        @DisplayName("은행 거래 처리 상태를 변경한다")
+        void updatesTransactionProcessingStatus() {
+            given(bankTransactionMapper.updateStatus(
+                    BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.APPLIED
+            )).willReturn(1);
+
+            bankTransactionService.updateStatus(
+                    BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+
+            verify(bankTransactionMapper).updateStatus(
+                    BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+        }
+
+        @Test
+        @DisplayName("상태 변경 결과가 1건이 아니면 상태 변경 실패 예외가 발생한다")
+        void throwsStatusUpdateFailedWhenUpdateCountIsNotOne() {
+            given(bankTransactionMapper.updateStatus(
+                    BANK_TRANSACTION_ID,
+                    BankTransactionProcessingStatus.APPLIED
+            )).willReturn(0);
+
+            assertTransactionExceptionThrownBy(
+                    () -> bankTransactionService.updateStatus(
+                            BANK_TRANSACTION_ID,
+                            BankTransactionProcessingStatus.APPLIED
+                    ),
+                    BankTransactionErrorCode
+                            .BANK_TRANSACTION_STATUS_UPDATE_FAILED
+            );
+        }
+    }
+
+    private BankTransactionDTO transaction(Long bankTransactionId) {
+        return BankTransactionDTO.builder()
+                .bankTransactionId(bankTransactionId)
+                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .externalTransactionId(EXTERNAL_TRANSACTION_ID)
+                .amount(new BigDecimal("10000.00"))
+                .transactionType(BankTransactionType.DEPOSIT)
+                .transactionAt(LocalDateTime.of(2026, 8, 4, 10, 0))
+                .counterpartyName("Hong Gil Dong")
+                .memo("deposit")
+                .syncedAt(LocalDateTime.of(2026, 8, 4, 10, 5))
+                .build();
+    }
+
+    private void assertTransactionExceptionThrownBy(
+            Runnable operation,
+            BankTransactionErrorCode errorCode
+    ) {
+        assertThatThrownBy(operation::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(errorCode)
+                );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
 import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
@@ -20,12 +19,11 @@ import org.teamsai.saibackend.global.exception.DomainException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,126 +45,39 @@ class BankTransactionServiceTest {
     class SaveIfNotExists {
 
         @Test
-        @DisplayName("이미 저장된 외부 거래 키이면 기존 은행 거래 ID를 반환한다")
-        void returnsExistingTransactionIdWhenExternalKeyAlreadyExists() {
-            BankTransactionDTO existingTransaction =
-                    transaction(BANK_TRANSACTION_ID);
-            BankTransactionDTO newTransaction = transaction(null);
+        @DisplayName("은행 거래를 저장하거나 기존 거래 ID를 반환한다")
+        void savesOrGetsBankTransactionId() {
+            BankTransactionDTO bankTransaction = transaction(null);
 
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.of(existingTransaction));
+            willAnswer(invocation -> {
+                ReflectionTestUtils.setField(
+                        bankTransaction,
+                        "bankTransactionId",
+                        BANK_TRANSACTION_ID
+                );
+                return 1;
+            }).given(bankTransactionMapper).insertOrGetId(bankTransaction);
 
             Long result =
-                    bankTransactionService.saveIfNotExists(newTransaction);
+                    bankTransactionService.saveIfNotExists(bankTransaction);
 
             assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
-            verify(bankTransactionMapper, never()).insert(newTransaction);
+            verify(bankTransactionMapper).insertOrGetId(bankTransaction);
         }
 
         @Test
-        @DisplayName("저장된 외부 거래 키가 없으면 새 거래를 저장하고 생성된 ID를 반환한다")
-        void insertsAndReturnsNewTransactionIdWhenExternalKeyDoesNotExist() {
-            BankTransactionDTO newTransaction = transaction(null);
-
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.empty());
-            given(bankTransactionMapper.insert(newTransaction))
-                    .willAnswer(invocation -> {
-                        ReflectionTestUtils.setField(
-                                newTransaction,
-                                "bankTransactionId",
-                                BANK_TRANSACTION_ID
-                        );
-                        return 1;
-                    });
-
-            Long result =
-                    bankTransactionService.saveIfNotExists(newTransaction);
-
-            assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
-            verify(bankTransactionMapper).insert(newTransaction);
-        }
-
-        @Test
-        @DisplayName("거래 저장 후 생성된 ID가 없으면 생성 실패 예외가 발생한다")
-        void throwsCreateFailedWhenGeneratedIdIsNullAfterInsert() {
-            BankTransactionDTO newTransaction = transaction(null);
-
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.empty());
-            given(bankTransactionMapper.insert(newTransaction)).willReturn(1);
+        @DisplayName("저장 후 은행 거래 ID가 없으면 생성 실패 예외가 발생한다")
+        void throwsCreateFailedWhenBankTransactionIdIsNull() {
+            BankTransactionDTO bankTransaction = transaction(null);
 
             assertTransactionExceptionThrownBy(
                     () -> bankTransactionService.saveIfNotExists(
-                            newTransaction
+                            bankTransaction
                     ),
                     BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
             );
-        }
 
-        @Test
-        @DisplayName("거래 저장 결과가 1건이 아니면 생성 실패 예외가 발생한다")
-        void throwsCreateFailedWhenInsertCountIsNotOne() {
-            BankTransactionDTO newTransaction = transaction(null);
-
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.empty());
-            given(bankTransactionMapper.insert(newTransaction)).willReturn(0);
-
-            assertTransactionExceptionThrownBy(
-                    () -> bankTransactionService.saveIfNotExists(
-                            newTransaction
-                    ),
-                    BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
-            );
-        }
-
-        @Test
-        @DisplayName("저장 중 중복 키가 발생하면 기존 거래를 다시 조회해 ID를 반환한다")
-        void returnsExistingIdWhenDuplicateKeyOccursDuringInsert() {
-            BankTransactionDTO newTransaction = transaction(null);
-            BankTransactionDTO existingTransaction =
-                    transaction(BANK_TRANSACTION_ID);
-
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.empty(), Optional.of(existingTransaction));
-            given(bankTransactionMapper.insert(newTransaction))
-                    .willThrow(new DuplicateKeyException("duplicate"));
-
-            Long result =
-                    bankTransactionService.saveIfNotExists(newTransaction);
-
-            assertThat(result).isEqualTo(BANK_TRANSACTION_ID);
-        }
-
-        @Test
-        @DisplayName("중복 키 발생 후 기존 거래를 찾지 못하면 생성 실패 예외가 발생한다")
-        void throwsCreateFailedWhenDuplicateKeyCannotBeResolved() {
-            BankTransactionDTO newTransaction = transaction(null);
-
-            given(bankTransactionMapper.findByExternalKey(
-                    LINKED_ACCOUNT_ID,
-                    EXTERNAL_TRANSACTION_ID
-            )).willReturn(Optional.empty(), Optional.empty());
-            given(bankTransactionMapper.insert(newTransaction))
-                    .willThrow(new DuplicateKeyException("duplicate"));
-
-            assertTransactionExceptionThrownBy(
-                    () -> bankTransactionService.saveIfNotExists(
-                            newTransaction
-                    ),
-                    BankTransactionErrorCode.BANK_TRANSACTION_CREATE_FAILED
-            );
+            verify(bankTransactionMapper).insertOrGetId(bankTransaction);
         }
     }
 
@@ -177,15 +88,16 @@ class BankTransactionServiceTest {
         @Test
         @DisplayName("처리 대기 중인 입금 거래 목록을 반환한다")
         void returnsPendingDepositTransactions() {
-            BankTransactionDTO transaction = transaction(BANK_TRANSACTION_ID);
+            BankTransactionDTO bankTransaction =
+                    transaction(BANK_TRANSACTION_ID);
 
             given(bankTransactionMapper.findPendingDeposits())
-                    .willReturn(List.of(transaction));
+                    .willReturn(List.of(bankTransaction));
 
             List<BankTransactionDTO> result =
                     bankTransactionService.findPendingDeposits();
 
-            assertThat(result).containsExactly(transaction);
+            assertThat(result).containsExactly(bankTransaction);
         }
     }
 


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #28 

## 🛠 작업 사항
  - bank_transaction 테이블 추가
  - BankTransaction DTO/type/Mapper/XML/Service 추가
  - linked_account_id + external_transaction_id 기준 중복 방지
  - 신규 거래 processing_status 기본값 PENDING 적용
  - 중복 저장 동시성 방어 추가
  - BankTransactionService 단위 테스트 추가

## ✅ 테스트

- [ ] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
- `bank_transaction.linked_account_id`는 현재 FK를 걸지 않았습니다. `linked_bank_account` 스키마와 초기화 순서가 안정화되면 
별도 이슈에서 FK 추가를 검토합니다.
- 신규 거래의 `processing_status`는 DB 기본값 `PENDING`에 의존합니다. Mapper insert에서는
  `processing_status` 컬럼을 의도적으로 제외했습니다.
- 실제 mock-bank 거래내역 동기화, 자동매칭 실행 API, 정산/차용증 후보 조회, PaymentRecord FK 연결은 이
  번 PR 범위에서 제외했습니다.
