### PR TITLE
feat(#45): 정산 참여자 초대 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
@@ -1,0 +1,47 @@
+package org.teamsai.saibackend.domain.settlement.controller;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
+
+@Tag(
+        name = "정산 초대 API",
+        description = "정산 참여자 초대 전송 및 관리 API"
+)
+@Controller
+@RequiredArgsConstructor
+public class SettlementInvitationController {
+    private final SettlementInvitationService service;
+
+
+    @ResponseBody
+    @PostMapping("/api/settlements/{settlementId}/invitations")
+    public ResponseEntity<CreateSettlementInvitationResponse>invite(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")Long userId,
+            @Parameter(description = "초대를 보낼 정산 ID", example = "1")
+            @PathVariable Long settlementId,
+            @Valid
+            @RequestBody CreateSettlementInvitationRequest request
+            ){
+        CreateSettlementInvitationResponse response =
+                service.invite(
+                        userId, settlementId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
@@ -1,6 +1,11 @@
 package org.teamsai.saibackend.domain.settlement.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +30,45 @@ import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationServ
 public class SettlementInvitationController {
     private final SettlementInvitationService service;
 
-
+    @Operation(
+            summary = "공동정산 참여자 초대",
+            description = "정산 소유자가 회원토큰을 이용하여 다른 회원에게 공동정산 참여 초대를 전송합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "정산 초대 생성 성공",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = CreateSettlementInvitationResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 또는 종료된 정산"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요하거나 토큰이 유효하지 않음"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 정산에 대한 초대 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "정산 또는 초대 대상 회원을 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 참여 중이거나 대기 중인 초대가 존재함"
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "정산 초대 생성 실패"
+            )
+    })
     @ResponseBody
     @PostMapping("/api/settlements/{settlementId}/invitations")
     public ResponseEntity<CreateSettlementInvitationResponse>invite(

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementInvitationDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementInvitationDTO.java
@@ -1,0 +1,21 @@
+package org.teamsai.saibackend.domain.settlement.dto;
+
+import lombok.*;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementInvitationDTO {
+    private Long invitationId;
+    private Long settlementId;
+    private Long invitedUserId;
+    private SettlementInvitationStatus invitationStatus;
+    private LocalDateTime invitedAt;
+    private LocalDateTime acceptedAt;
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementParticipantDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementParticipantDTO.java
@@ -1,0 +1,27 @@
+package org.teamsai.saibackend.domain.settlement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantRole;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementParticipantDTO {
+
+    private Long participantId;
+    private Long invitationId;
+
+    private SettlementParticipantRole participantRole;
+    private SettlementParticipantStatus participantStatus;
+
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateSettlementInvitationRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateSettlementInvitationRequest.java
@@ -1,0 +1,16 @@
+package org.teamsai.saibackend.domain.settlement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSettlementInvitationRequest {
+    @NotBlank(message = "초대할 회원토큰을 입력해 주세요.")
+    private String userToken;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/CreateSettlementInvitationResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/CreateSettlementInvitationResponse.java
@@ -1,0 +1,23 @@
+package org.teamsai.saibackend.domain.settlement.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSettlementInvitationResponse {
+    private Long invitationId;
+    private Long settlementId;
+    private String invitedUserToken;
+    private String invitedUserName;
+    private SettlementInvitationStatus invitationStatus;
+    private LocalDateTime invitedAt;
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/ReceivedSettlementInvitationResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/ReceivedSettlementInvitationResponse.java
@@ -1,0 +1,29 @@
+package org.teamsai.saibackend.domain.settlement.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReceivedSettlementInvitationResponse {
+
+    private Long invitationId;
+    private Long settlementId;
+
+    private String settlementTitle;
+    private String ownerName;
+
+    private SettlementInvitationStatus invitationStatus;
+    private LocalDateTime invitedAt;
+    private LocalDateTime acceptedAt;
+
+
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
@@ -12,6 +12,50 @@ public enum SettlementErrorCode implements BaseErrorCode<DomainException> {
     SETTLEMENT_CREATE_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "정산 생성에 실패했습니다."
+    ),
+    SETTLEMENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "존재하지 않는 정산입니다."
+    ),
+
+    SETTLEMENT_ACCESS_DENIED(
+            HttpStatus.FORBIDDEN,
+            "해당 정산에 대한 접근 권한이 없습니다."
+    ),
+
+    ALREADY_CLOSED_SETTLEMENT(
+            HttpStatus.BAD_REQUEST,
+            "이미 종료된 정산입니다."
+    ),
+
+    ALREADY_SETTLEMENT_PARTICIPANT(
+            HttpStatus.CONFLICT,
+            "이미 참여 중인 회원입니다."
+    ),
+
+    DUPLICATE_SETTLEMENT_INVITATION(
+            HttpStatus.CONFLICT,
+            "이미 대기 중인 초대가 존재합니다."
+    ),
+
+    SETTLEMENT_INVITATION_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "존재하지 않는 정산 초대입니다."
+    ),
+
+    INVITATION_ACCESS_DENIED(
+            HttpStatus.FORBIDDEN,
+            "해당 초대를 처리할 권한이 없습니다."
+    ),
+
+    INVITATION_ALREADY_PROCESSED(
+            HttpStatus.CONFLICT,
+            "이미 처리된 초대입니다."
+    ),
+
+    SETTLEMENT_INVITATION_CREATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "정산 초대 생성에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementInvitationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementInvitationMapper.java
@@ -1,0 +1,38 @@
+package org.teamsai.saibackend.domain.settlement.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
+import org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface SettlementInvitationMapper {
+
+    int insert(SettlementInvitationDTO invitation);
+
+    boolean existsInvitedInvitation(
+            @Param("settlementId") Long settlementId,
+            @Param("userId") Long userId
+    );
+
+    Optional<SettlementInvitationDTO> findById(
+            @Param("invitationId") Long invitationId
+    );
+
+    List<ReceivedSettlementInvitationResponse> findReceivedInvitations(
+            @Param("userId") Long userId
+    );
+
+    int accept(
+            @Param("invitationId") Long invitationId,
+            @Param("acceptedAt")LocalDateTime acceptedAt
+    );
+
+    int reject(
+            @Param("invitationId") Long invitationId
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -1,9 +1,16 @@
 package org.teamsai.saibackend.domain.settlement.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+
+import java.util.Optional;
 
 @Mapper
 public interface SettlementMapper {
     int insertSettlement(SettlementDTO settlement);
+
+    Optional<SettlementDTO> findById(
+            @Param("settlementId") Long settlementId
+    );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
@@ -1,0 +1,17 @@
+package org.teamsai.saibackend.domain.settlement.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+
+@Mapper
+public interface  SettlementParticipantMapper {
+    int insert(SettlementParticipantDTO participant);
+
+    boolean existsByInvitationId(@Param("invitationId") Long invitationId);
+
+    boolean existsActiveParticipant(
+            @Param("settlementId") Long settlementId,
+            @Param("userId") Long userId
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
@@ -1,0 +1,88 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.service.UserService;
+
+import java.time.LocalDateTime;
+
+
+@Service
+@RequiredArgsConstructor
+public class SettlementInvitationService {
+
+    private final SettlementMapper settlementMapper;
+    private final SettlementInvitationMapper invitationMapper;
+    private final SettlementParticipantMapper participantMapper;
+    private final UserService userService;
+    private final SettlementInvitationValidator invitationValidator;
+
+    @Transactional
+    public CreateSettlementInvitationResponse invite(Long ownerId, Long settlementId, CreateSettlementInvitationRequest request){
+        SettlementDTO settlement = settlementMapper.findById(settlementId)
+                .orElseThrow(
+                        SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException
+                );
+        invitationValidator.validateInvitableSettlement(settlement,ownerId);
+        UserDTO invitedUser = userService.findRequestTarget(ownerId,request.getUserToken());
+        invitationValidator.validateInviteTarget(settlementId,invitedUser.getUserId());
+
+        boolean alreadyParticipant = participantMapper.existsActiveParticipant(settlementId,invitedUser.getUserId());
+
+        if(alreadyParticipant){
+            throw SettlementErrorCode.ALREADY_CLOSED_SETTLEMENT.toException();
+        }
+
+        boolean duplicateInvitation = invitationMapper.existsInvitedInvitation(settlementId,invitedUser.getUserId());
+
+        if(duplicateInvitation){
+            throw SettlementErrorCode.DUPLICATE_SETTLEMENT_INVITATION.toException();
+        }
+
+        LocalDateTime invitedAt = LocalDateTime.now();
+
+
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .settlementId(settlementId)
+                        .invitedUserId(invitedUser.getUserId())
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .invitedAt(invitedAt)
+                        .acceptedAt(null)
+                        .build();
+        int insertCount = invitationMapper.insert(invitation);
+
+        if(insertCount != 1){
+            throw SettlementErrorCode.SETTLEMENT_INVITATION_CREATE_FAILED.toException();
+        }
+
+        return CreateSettlementInvitationResponse.builder()
+                .invitationId(invitation.getInvitationId())
+                .settlementId(settlementId)
+                .invitedUserToken(invitedUser.getUserToken())
+                .invitedUserName(invitedUser.getName())
+                .invitationStatus(invitation.getInvitationStatus())
+                .invitedAt(invitation.getInvitedAt())
+                .build();
+
+
+    }
+
+    private SettlementDTO findSettlement(Long settlementId){
+        return settlementMapper.findById(settlementId)
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+    }
+
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
@@ -10,13 +10,11 @@ import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInv
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
-import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
 import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.service.UserService;
 
 import java.time.LocalDateTime;
-
 
 @Service
 @RequiredArgsConstructor
@@ -24,34 +22,33 @@ public class SettlementInvitationService {
 
     private final SettlementMapper settlementMapper;
     private final SettlementInvitationMapper invitationMapper;
-    private final SettlementParticipantMapper participantMapper;
     private final UserService userService;
     private final SettlementInvitationValidator invitationValidator;
 
     @Transactional
-    public CreateSettlementInvitationResponse invite(Long ownerId, Long settlementId, CreateSettlementInvitationRequest request){
-        SettlementDTO settlement = settlementMapper.findById(settlementId)
-                .orElseThrow(
-                        SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException
-                );
-        invitationValidator.validateInvitableSettlement(settlement,ownerId);
-        UserDTO invitedUser = userService.findRequestTarget(ownerId,request.getUserToken());
-        invitationValidator.validateInviteTarget(settlementId,invitedUser.getUserId());
+    public CreateSettlementInvitationResponse invite(
+            Long ownerId,
+            Long settlementId,
+            CreateSettlementInvitationRequest request
+    ) {
+        SettlementDTO settlement = findSettlement(settlementId);
 
-        boolean alreadyParticipant = participantMapper.existsActiveParticipant(settlementId,invitedUser.getUserId());
+        invitationValidator.validateInvitableSettlement(
+                settlement,
+                ownerId
+        );
 
-        if(alreadyParticipant){
-            throw SettlementErrorCode.ALREADY_CLOSED_SETTLEMENT.toException();
-        }
+        UserDTO invitedUser = userService.findRequestTarget(
+                ownerId,
+                request.getUserToken()
+        );
 
-        boolean duplicateInvitation = invitationMapper.existsInvitedInvitation(settlementId,invitedUser.getUserId());
-
-        if(duplicateInvitation){
-            throw SettlementErrorCode.DUPLICATE_SETTLEMENT_INVITATION.toException();
-        }
+        invitationValidator.validateInviteTarget(
+                settlementId,
+                invitedUser.getUserId()
+        );
 
         LocalDateTime invitedAt = LocalDateTime.now();
-
 
         SettlementInvitationDTO invitation =
                 SettlementInvitationDTO.builder()
@@ -61,10 +58,13 @@ public class SettlementInvitationService {
                         .invitedAt(invitedAt)
                         .acceptedAt(null)
                         .build();
+
         int insertCount = invitationMapper.insert(invitation);
 
-        if(insertCount != 1){
-            throw SettlementErrorCode.SETTLEMENT_INVITATION_CREATE_FAILED.toException();
+        if (insertCount != 1) {
+            throw SettlementErrorCode
+                    .SETTLEMENT_INVITATION_CREATE_FAILED
+                    .toException();
         }
 
         return CreateSettlementInvitationResponse.builder()
@@ -75,14 +75,14 @@ public class SettlementInvitationService {
                 .invitationStatus(invitation.getInvitationStatus())
                 .invitedAt(invitation.getInvitedAt())
                 .build();
-
-
     }
 
-    private SettlementDTO findSettlement(Long settlementId){
+    private SettlementDTO findSettlement(Long settlementId) {
         return settlementMapper.findById(settlementId)
-                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+                .orElseThrow(
+                        SettlementErrorCode
+                                .SETTLEMENT_NOT_FOUND
+                                ::toException
+                );
     }
-
-
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationValidator.java
@@ -1,0 +1,102 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementInvitationValidator {
+
+    private final SettlementParticipantMapper participantMapper;
+    private final SettlementInvitationMapper invitationMapper;
+
+    public void validateInvitableSettlement(
+            SettlementDTO settlement,
+            Long ownerId
+    ) {
+        validateOwner(settlement, ownerId);
+        validateInProgress(settlement);
+    }
+
+    public void validateInviteTarget(
+            Long settlementId,
+            Long invitedUserId
+    ) {
+        validateNotParticipant(
+                settlementId,
+                invitedUserId
+        );
+
+        validateNoPendingInvitation(
+                settlementId,
+                invitedUserId
+        );
+    }
+
+    private void validateOwner(
+            SettlementDTO settlement,
+            Long ownerId
+    ) {
+        if (!Objects.equals(
+                settlement.getOwnerId(),
+                ownerId
+        )) {
+            throw SettlementErrorCode
+                    .SETTLEMENT_ACCESS_DENIED
+                    .toException();
+        }
+    }
+
+    private void validateInProgress(
+            SettlementDTO settlement
+    ) {
+        if (settlement.getSettlementStatus()
+                == SettlementStatus.CLOSED) {
+
+            throw SettlementErrorCode
+                    .ALREADY_CLOSED_SETTLEMENT
+                    .toException();
+        }
+    }
+
+    private void validateNotParticipant(
+            Long settlementId,
+            Long invitedUserId
+    ) {
+        boolean alreadyParticipant =
+                participantMapper.existsActiveParticipant(
+                        settlementId,
+                        invitedUserId
+                );
+
+        if (alreadyParticipant) {
+            throw SettlementErrorCode
+                    .ALREADY_SETTLEMENT_PARTICIPANT
+                    .toException();
+        }
+    }
+
+    private void validateNoPendingInvitation(
+            Long settlementId,
+            Long invitedUserId
+    ) {
+        boolean duplicateInvitation =
+                invitationMapper.existsInvitedInvitation(
+                        settlementId,
+                        invitedUserId
+                );
+
+        if (duplicateInvitation) {
+            throw SettlementErrorCode
+                    .DUPLICATE_SETTLEMENT_INVITATION
+                    .toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementInvitationStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementInvitationStatus.java
@@ -1,0 +1,8 @@
+package org.teamsai.saibackend.domain.settlement.type;
+
+public enum SettlementInvitationStatus {
+    INVITED,
+    ACCEPTED,
+    REJECTED,
+    EXPIRED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementParticipantRole.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementParticipantRole.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.settlement.type;
+
+public enum SettlementParticipantRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementParticipantStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementParticipantStatus.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.settlement.type;
+
+public enum SettlementParticipantStatus {
+    ACTIVE,
+    LEFT,
+    REMOVED
+}

--- a/src/main/resources/db/settlement_invitation.sql
+++ b/src/main/resources/db/settlement_invitation.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS settlement_invitation (
+    invitation_id BIGINT NOT NULL AUTO_INCREMENT,
+    settlement_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+
+    invitation_status ENUM(
+        'INVITED',
+        'ACCEPTED',
+        'REJECTED',
+        'EXPIRED'
+    ) NOT NULL DEFAULT 'INVITED',
+
+    invited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    accepted_at DATETIME NULL,
+
+    PRIMARY KEY (invitation_id),
+
+    INDEX idx_settlement_invitation_settlement (
+        settlement_id
+    ),
+
+    INDEX idx_settlement_invitation_user (
+        user_id
+    ),
+
+    INDEX idx_settlement_invitation_user_status (
+        user_id,
+        invitation_status
+    ),
+
+    CONSTRAINT fk_settlement_invitation_settlement
+        FOREIGN KEY (settlement_id)
+        REFERENCES settlement (settlement_id),
+
+    CONSTRAINT fk_settlement_invitation_user
+        FOREIGN KEY (user_id)
+        REFERENCES users (user_id)
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/settlement_invitation.sql
+++ b/src/main/resources/db/settlement_invitation.sql
@@ -1,41 +1,47 @@
 CREATE TABLE IF NOT EXISTS settlement_invitation (
-    invitation_id BIGINT NOT NULL AUTO_INCREMENT,
-    settlement_id BIGINT NOT NULL,
-    user_id BIGINT NOT NULL,
+                                                     invitation_id BIGINT NOT NULL AUTO_INCREMENT,
+                                                     settlement_id BIGINT NOT NULL,
+                                                     user_id BIGINT NOT NULL,
 
-    invitation_status ENUM(
-        'INVITED',
-        'ACCEPTED',
-        'REJECTED',
-        'EXPIRED'
-    ) NOT NULL DEFAULT 'INVITED',
+                                                     invitation_status ENUM(
+                                                     'INVITED',
+                                                     'ACCEPTED',
+                                                     'REJECTED',
+                                                     'EXPIRED'
+) NOT NULL DEFAULT 'INVITED',
 
     invited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     accepted_at DATETIME NULL,
 
     PRIMARY KEY (invitation_id),
 
+    CONSTRAINT uk_settlement_invitation_settlement_user
+    UNIQUE (
+               settlement_id,
+               user_id
+           ),
+
     INDEX idx_settlement_invitation_settlement (
-        settlement_id
-    ),
+                                                   settlement_id
+                                               ),
 
     INDEX idx_settlement_invitation_user (
-        user_id
-    ),
+                                             user_id
+                                         ),
 
     INDEX idx_settlement_invitation_user_status (
-        user_id,
-        invitation_status
-    ),
+                                                    user_id,
+                                                    invitation_status
+                                                ),
 
     CONSTRAINT fk_settlement_invitation_settlement
-        FOREIGN KEY (settlement_id)
-        REFERENCES settlement (settlement_id),
+    FOREIGN KEY (settlement_id)
+    REFERENCES settlement (settlement_id),
 
     CONSTRAINT fk_settlement_invitation_user
-        FOREIGN KEY (user_id)
-        REFERENCES users (user_id)
-)
-ENGINE = InnoDB
-DEFAULT CHARSET = utf8mb4
-COLLATE = utf8mb4_unicode_ci;
+    FOREIGN KEY (user_id)
+    REFERENCES users (user_id)
+    )
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/settlement_participant.sql
+++ b/src/main/resources/db/settlement_participant.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS settlement_participant (
+                                                      participant_id BIGINT NOT NULL AUTO_INCREMENT,
+                                                      invitation_id BIGINT NOT NULL,
+
+                                                      participant_role ENUM(
+                                                      'OWNER',
+                                                      'MEMBER'
+) NOT NULL,
+
+    participant_status ENUM(
+                               'ACTIVE',
+                               'LEFT',
+                               'REMOVED'
+                           ) NOT NULL DEFAULT 'ACTIVE',
+
+    joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (participant_id),
+
+    UNIQUE KEY uk_settlement_participant_invitation (
+                                                        invitation_id
+                                                    ),
+
+    CONSTRAINT fk_settlement_participant_invitation
+    FOREIGN KEY (invitation_id)
+    REFERENCES settlement_invitation (invitation_id)
+    )
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/settlement/SettlementInvitationMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementInvitationMapper.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper">
+
+    <resultMap
+            id="settlementInvitationResultMap"
+            type="org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO">
+
+        <id
+                property="invitationId"
+                column="invitation_id"
+        />
+
+        <result
+                property="settlementId"
+                column="settlement_id"
+        />
+
+        <result
+                property="invitedUserId"
+                column="user_id"
+        />
+
+        <result
+                property="invitationStatus"
+                column="invitation_status"
+        />
+
+        <result
+                property="invitedAt"
+                column="invited_at"
+        />
+
+        <result
+                property="acceptedAt"
+                column="accepted_at"
+        />
+
+    </resultMap>
+
+    <insert
+            id="insert"
+            parameterType="org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO"
+            useGeneratedKeys="true"
+            keyProperty="invitationId"
+            keyColumn="invitation_id">
+
+        INSERT INTO settlement_invitation (
+        settlement_id,
+        user_id,
+        invitation_status,
+        invited_at,
+        accepted_at
+        )
+        VALUES (
+        #{settlementId},
+        #{invitedUserId},
+        #{invitationStatus},
+        #{invitedAt},
+        #{acceptedAt}
+        )
+
+    </insert>
+
+    <select
+            id="existsInvitedInvitation"
+            resultType="boolean">
+
+        SELECT EXISTS (
+        SELECT 1
+        FROM settlement_invitation
+        WHERE settlement_id = #{settlementId}
+        AND user_id = #{userId}
+        AND invitation_status = 'INVITED'
+        )
+
+    </select>
+
+    <select
+            id="findById"
+            resultMap="settlementInvitationResultMap">
+
+        SELECT
+        invitation_id,
+        settlement_id,
+        user_id,
+        invitation_status,
+        invited_at,
+        accepted_at
+        FROM settlement_invitation
+        WHERE invitation_id = #{invitationId}
+
+    </select>
+
+    <select
+            id="findReceivedInvitations"
+            resultType="org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse">
+
+        SELECT
+        si.invitation_id AS invitationId,
+        si.settlement_id AS settlementId,
+        s.title AS settlementTitle,
+        owner.name AS ownerName,
+        si.invitation_status AS invitationStatus,
+        si.invited_at AS invitedAt,
+        si.accepted_at AS acceptedAt
+        FROM settlement_invitation si
+        JOIN settlement s
+        ON s.settlement_id = si.settlement_id
+        JOIN users owner
+        ON owner.user_id = s.owner_id
+        WHERE si.user_id = #{userId}
+        ORDER BY
+        CASE
+        WHEN si.invitation_status = 'INVITED' THEN 0
+        ELSE 1
+        END,
+        si.invited_at DESC
+
+    </select>
+
+    <update id="accept">
+
+        UPDATE settlement_invitation
+        SET invitation_status = 'ACCEPTED',
+        accepted_at = #{acceptedAt}
+        WHERE invitation_id = #{invitationId}
+        AND invitation_status = 'INVITED'
+
+    </update>
+
+    <update id="reject">
+
+        UPDATE settlement_invitation
+        SET invitation_status = 'REJECTED'
+        WHERE invitation_id = #{invitationId}
+        AND invitation_status = 'INVITED'
+
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -5,6 +5,25 @@
 
 <mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper">
 
+    <resultMap id="settlementResultMap" type="org.teamsai.saibackend.domain.settlement.dto.SettlementDTO">
+        <id property="settlementId" column="settlement_id"/>
+        <result property="ownerId" column="owner_id"/>
+        <result property="settlementType" column="settlement_type"/>
+        <result property="settlementStatus" column="settlement_status"/>
+        <result property="settlementCategory" column="settlement_category"/>
+        <result property="title" column="title"/>
+        <result property="splitType" column="split_type"/>
+        <result property="dueDate" column="due_date"/>
+        <result property="cycleRule" column="cycle_rule"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="closedAt" column="closed_at"/>
+        <result property="status" column="status"/>
+        <result property="cycleDate" column="cycle_date"/>
+        <result property="invitationToken" column="invitation_token"/>
+    </resultMap>
+
     <insert id="insertSettlement"
             parameterType="org.teamsai.saibackend.domain.settlement.dto.SettlementDTO"
             useGeneratedKeys="true"
@@ -31,7 +50,28 @@
         #{dueDate},
         #{createdAt}
         )
-
     </insert>
+
+    <select id="findById" resultMap="settlementResultMap">
+        SELECT
+        settlement_id,
+        owner_id,
+        settlement_type,
+        settlement_status,
+        settlement_category,
+        title,
+        split_type,
+        due_date,
+        cycle_rule,
+        start_date,
+        end_date,
+        created_at,
+        closed_at,
+        status,
+        cycle_date,
+        invitation_token
+        FROM settlement
+        WHERE settlement_id = #{settlementId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper">
+
+    <insert
+            id="insert"
+            parameterType="org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO"
+            useGeneratedKeys="true"
+            keyProperty="participantId"
+            keyColumn="participant_id">
+
+        INSERT INTO settlement_participant (
+        invitation_id,
+        participant_role,
+        participant_status,
+        joined_at
+        )
+        VALUES (
+        #{invitationId},
+        #{participantRole},
+        #{participantStatus},
+        #{joinedAt}
+        )
+
+    </insert>
+
+    <select
+            id="existsByInvitationId"
+            resultType="boolean">
+
+        SELECT EXISTS (
+        SELECT 1
+        FROM settlement_participant
+        WHERE invitation_id = #{invitationId}
+        )
+
+    </select>
+
+    <select
+            id="existsActiveParticipant"
+            resultType="boolean">
+
+        SELECT EXISTS (
+        SELECT 1
+        FROM settlement_participant sp
+        JOIN settlement_invitation si
+        ON si.invitation_id = sp.invitation_id
+        WHERE si.settlement_id = #{settlementId}
+        AND si.user_id = #{userId}
+        AND sp.participant_status = 'ACTIVE'
+        )
+
+    </select>
+
+</mapper>

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationServiceTest.java
@@ -1,0 +1,212 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationValidator;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.service.UserService;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementInvitationServiceTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long SETTLEMENT_ID = 10L;
+    private static final Long INVITED_USER_ID = 2L;
+    private static final Long INVITATION_ID = 100L;
+    private static final String USER_TOKEN = "target-user-token";
+
+    @Mock
+    private SettlementMapper settlementMapper;
+
+    @Mock
+    private SettlementInvitationMapper invitationMapper;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private SettlementInvitationValidator invitationValidator;
+
+    @InjectMocks
+    private SettlementInvitationService settlementInvitationService;
+
+    @Test
+    @DisplayName("정산 소유자는 회원토큰을 이용해 참여자를 초대할 수 있다")
+    void inviteSuccess() {
+        SettlementDTO settlement = mock(SettlementDTO.class);
+        UserDTO invitedUser = mock(UserDTO.class);
+        CreateSettlementInvitationRequest request =
+                mock(CreateSettlementInvitationRequest.class);
+
+        when(request.getUserToken()).thenReturn(USER_TOKEN);
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(userService.findRequestTarget(OWNER_ID, USER_TOKEN))
+                .thenReturn(invitedUser);
+
+        when(invitedUser.getUserId()).thenReturn(INVITED_USER_ID);
+        when(invitedUser.getUserToken()).thenReturn(USER_TOKEN);
+        when(invitedUser.getName()).thenReturn("초대회원");
+
+        doAnswer(invocation -> {
+            SettlementInvitationDTO invitation =
+                    invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(
+                    invitation,
+                    "invitationId",
+                    INVITATION_ID
+            );
+
+            return 1;
+        }).when(invitationMapper)
+                .insert(any(SettlementInvitationDTO.class));
+
+        CreateSettlementInvitationResponse response =
+                settlementInvitationService.invite(
+                        OWNER_ID,
+                        SETTLEMENT_ID,
+                        request
+                );
+
+        assertThat(response.getInvitationId())
+                .isEqualTo(INVITATION_ID);
+
+        assertThat(response.getSettlementId())
+                .isEqualTo(SETTLEMENT_ID);
+
+        assertThat(response.getInvitedUserToken())
+                .isEqualTo(USER_TOKEN);
+
+        assertThat(response.getInvitedUserName())
+                .isEqualTo("초대회원");
+
+        assertThat(response.getInvitationStatus())
+                .isEqualTo(SettlementInvitationStatus.INVITED);
+
+        assertThat(response.getInvitedAt())
+                .isNotNull();
+
+        verify(invitationValidator)
+                .validateInvitableSettlement(
+                        settlement,
+                        OWNER_ID
+                );
+
+        verify(invitationValidator)
+                .validateInviteTarget(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                );
+
+        ArgumentCaptor<SettlementInvitationDTO> captor =
+                ArgumentCaptor.forClass(
+                        SettlementInvitationDTO.class
+                );
+
+        verify(invitationMapper).insert(captor.capture());
+
+        SettlementInvitationDTO savedInvitation =
+                captor.getValue();
+
+        assertThat(savedInvitation.getSettlementId())
+                .isEqualTo(SETTLEMENT_ID);
+
+        assertThat(savedInvitation.getInvitedUserId())
+                .isEqualTo(INVITED_USER_ID);
+
+        assertThat(savedInvitation.getInvitationStatus())
+                .isEqualTo(SettlementInvitationStatus.INVITED);
+
+        assertThat(savedInvitation.getInvitedAt())
+                .isNotNull();
+
+        assertThat(savedInvitation.getAcceptedAt())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정산에는 초대를 생성할 수 없다")
+    void inviteFailWhenSettlementNotFound() {
+        CreateSettlementInvitationRequest request =
+                mock(CreateSettlementInvitationRequest.class);
+
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> settlementInvitationService.invite(
+                        OWNER_ID,
+                        SETTLEMENT_ID,
+                        request
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verifyNoInteractions(
+                invitationValidator,
+                userService
+        );
+
+        verify(
+                invitationMapper,
+                never()
+        ).insert(any());
+    }
+
+    @Test
+    @DisplayName("초대 저장 결과가 1건이 아니면 예외가 발생한다")
+    void inviteFailWhenInsertFailed() {
+        SettlementDTO settlement = mock(SettlementDTO.class);
+        UserDTO invitedUser = mock(UserDTO.class);
+        CreateSettlementInvitationRequest request =
+                mock(CreateSettlementInvitationRequest.class);
+
+        when(request.getUserToken()).thenReturn(USER_TOKEN);
+
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(userService.findRequestTarget(OWNER_ID, USER_TOKEN))
+                .thenReturn(invitedUser);
+
+        when(invitedUser.getUserId())
+                .thenReturn(INVITED_USER_ID);
+
+        when(invitationMapper.insert(any()))
+                .thenReturn(0);
+
+        assertThatThrownBy(
+                () -> settlementInvitationService.invite(
+                        OWNER_ID,
+                        SETTLEMENT_ID,
+                        request
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(invitationMapper)
+                .insert(any(SettlementInvitationDTO.class));
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationValidatorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationValidatorTest.java
@@ -1,0 +1,189 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationValidator;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementInvitationValidatorTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long OTHER_USER_ID = 2L;
+    private static final Long SETTLEMENT_ID = 10L;
+    private static final Long INVITED_USER_ID = 3L;
+
+    @Mock
+    private SettlementParticipantMapper participantMapper;
+
+    @Mock
+    private SettlementInvitationMapper invitationMapper;
+
+    private SettlementInvitationValidator invitationValidator;
+
+    @BeforeEach
+    void setUp() {
+        invitationValidator =
+                new SettlementInvitationValidator(
+                        participantMapper,
+                        invitationMapper
+                );
+    }
+
+    @Test
+    @DisplayName("정산 소유자이며 진행 중인 정산이면 초대할 수 있다")
+    void validateInvitableSettlementSuccess() {
+        SettlementDTO settlement = mock(SettlementDTO.class);
+
+        when(settlement.getOwnerId())
+                .thenReturn(OWNER_ID);
+
+        when(settlement.getSettlementStatus())
+                .thenReturn(SettlementStatus.IN_PROGRESS);
+
+        assertThatCode(
+                () -> invitationValidator
+                        .validateInvitableSettlement(
+                                settlement,
+                                OWNER_ID
+                        )
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("정산 소유자가 아니면 초대할 수 없다")
+    void validateInvitableSettlementFailWhenNotOwner() {
+        SettlementDTO settlement = mock(SettlementDTO.class);
+
+        when(settlement.getOwnerId())
+                .thenReturn(OWNER_ID);
+
+        assertThatThrownBy(
+                () -> invitationValidator
+                        .validateInvitableSettlement(
+                                settlement,
+                                OTHER_USER_ID
+                        )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("종료된 정산에는 참여자를 초대할 수 없다")
+    void validateInvitableSettlementFailWhenClosed() {
+        SettlementDTO settlement = mock(SettlementDTO.class);
+
+        when(settlement.getOwnerId())
+                .thenReturn(OWNER_ID);
+
+        when(settlement.getSettlementStatus())
+                .thenReturn(SettlementStatus.CLOSED);
+
+        assertThatThrownBy(
+                () -> invitationValidator
+                        .validateInvitableSettlement(
+                                settlement,
+                                OWNER_ID
+                        )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("이미 참여 중인 회원은 초대할 수 없다")
+    void validateInviteTargetFailWhenAlreadyParticipant() {
+        when(
+                participantMapper.existsActiveParticipant(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).thenReturn(true);
+
+        assertThatThrownBy(
+                () -> invitationValidator.validateInviteTarget(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(
+                invitationMapper,
+                never()
+        ).existsInvitedInvitation(
+                SETTLEMENT_ID,
+                INVITED_USER_ID
+        );
+    }
+
+    @Test
+    @DisplayName("대기 중인 동일 초대가 있으면 다시 초대할 수 없다")
+    void validateInviteTargetFailWhenDuplicateInvitation() {
+        when(
+                participantMapper.existsActiveParticipant(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).thenReturn(false);
+
+        when(
+                invitationMapper.existsInvitedInvitation(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).thenReturn(true);
+
+        assertThatThrownBy(
+                () -> invitationValidator.validateInviteTarget(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("참여자와 대기 중 초대가 없으면 초대할 수 있다")
+    void validateInviteTargetSuccess() {
+        when(
+                participantMapper.existsActiveParticipant(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).thenReturn(false);
+
+        when(
+                invitationMapper.existsInvitedInvitation(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).thenReturn(false);
+
+        assertThatCode(
+                () -> invitationValidator.validateInviteTarget(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                )
+        ).doesNotThrowAnyException();
+
+        verify(participantMapper)
+                .existsActiveParticipant(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                );
+
+        verify(invitationMapper)
+                .existsInvitedInvitation(
+                        SETTLEMENT_ID,
+                        INVITED_USER_ID
+                );
+    }
+}


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #45 

## 🛠 작업 사항

- 회원토큰을 이용한 공동정산 참여자 초대 전송 API 구현
- 정산 존재 여부 및 정산 소유자 권한 검증
- 종료된 정산에 대한 초대 요청 방지
- 본인 초대 방지 및 초대 대상 회원 조회 로직 적용
- 이미 참여 중인 회원에 대한 중복 초대 방지
- 동일 정산의 대기 중 초대 중복 생성 방지
- 정산 초대 상태 INVITED 저장 처리
- 정산 초대 요청·응답 DTO 및 상태 Enum 구현
- 정산 초대 MyBatis Mapper와 XML 쿼리 구현
- 초대 검증 로직을 SettlementInvitationValidator로 분리
- 정산 초대 관련 예외 코드 추가

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 정산 초대까지만 구현되어 있습니다. 이어 정산 조회 및 수락/거절 은 별도의 이슈에서 관리할 예정입니다
- 동일 정산에서 같은 회원에게 중복 초대가 생성되는 것을 방지하기 위해 (settlement_id, user_id) 조합에 UNIQUE 제약조건을 적용했습니다.
이에 따라 초대 상태가 REJECTED 또는 EXPIRED로 변경된 이후에도 같은 정산과 회원 조합으로 새로운 초대 행을 다시 생성할 수 없습니다.
재초대 기능이 필요해질 경우 기존 초대 행의 상태를 INVITED로 변경하여 재사용하거나, INVITED 상태에만 중복 제한이 적용되도록 테이블 구조를 변경해야 합니다.
이번 PR에서는 공동정산 MVP 범위에 맞춰 정산과 회원 사이의 초대 관계를 한 건으로 관리합니다.