### PR TITLE
feat(#47): 받은 정산 초대 조회 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
@@ -13,13 +13,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse;
 import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
+
+import java.util.List;
 
 @Tag(
         name = "정산 초대 API",
@@ -85,6 +85,31 @@ public class SettlementInvitationController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
+    }
+    @Operation(
+            summary = "받은 정산 초대 목록 조회",
+            description = "로그인한 회원에게 도착한 대기 중인 정산 초대 목록을 최신순으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "받은 정산 초대 목록 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요하거나 토큰이 유효하지 않음"
+            )
+    })
+    @ResponseBody
+    @GetMapping("/api/settlements/received")
+    public ResponseEntity<List<ReceivedSettlementInvitationResponse>> findReceivedInvitation(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId
+    ){
+        List<ReceivedSettlementInvitationResponse> response = service.findReceivedInvitations(userId);
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationService.java
@@ -7,6 +7,7 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
@@ -15,6 +16,7 @@ import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.service.UserService;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -85,4 +87,9 @@ public class SettlementInvitationService {
                                 ::toException
                 );
     }
+
+    public List<ReceivedSettlementInvitationResponse> findReceivedInvitations(Long userId){
+        return invitationMapper.findReceivedInvitations(userId);
+    }
+
 }

--- a/src/main/resources/mapper/settlement/SettlementInvitationMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementInvitationMapper.xml
@@ -113,12 +113,8 @@
         JOIN users owner
         ON owner.user_id = s.owner_id
         WHERE si.user_id = #{userId}
-        ORDER BY
-        CASE
-        WHEN si.invitation_status = 'INVITED' THEN 0
-        ELSE 1
-        END,
-        si.invited_at DESC
+        AND si.invitation_status = 'INVITED'
+        ORDER BY si.invited_at DESC
 
     </select>
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationServiceTest.java
@@ -12,6 +12,7 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
@@ -21,6 +22,8 @@ import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.service.UserService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -208,5 +211,95 @@ class SettlementInvitationServiceTest {
 
         verify(invitationMapper)
                 .insert(any(SettlementInvitationDTO.class));
+    }
+    @Test
+    @DisplayName("로그인한 회원이 받은 정산 초대 목록을 조회한다")
+    void findReceivedInvitationsSuccess() {
+        Long userId = 2L;
+
+        ReceivedSettlementInvitationResponse firstInvitation =
+                ReceivedSettlementInvitationResponse.builder()
+                        .invitationId(3L)
+                        .settlementId(2L)
+                        .settlementTitle("제주도")
+                        .ownerName("김사이")
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .invitedAt(
+                                LocalDateTime.of(2026, 8, 4, 16, 0, 31
+                                )
+                        )
+                        .acceptedAt(null)
+                        .build();
+
+        ReceivedSettlementInvitationResponse secondInvitation =
+                ReceivedSettlementInvitationResponse.builder()
+                        .invitationId(1L)
+                        .settlementId(1L)
+                        .settlementTitle("제주도 여행비 정산")
+                        .ownerName("김사이")
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .invitedAt(
+                                LocalDateTime.of(2026, 8, 4, 15, 13, 46
+                                )
+                        )
+                        .acceptedAt(null)
+                        .build();
+
+        List<ReceivedSettlementInvitationResponse> invitations =
+                List.of(
+                        firstInvitation,
+                        secondInvitation
+                );
+
+        when(invitationMapper.findReceivedInvitations(userId))
+                .thenReturn(invitations);
+
+        List<ReceivedSettlementInvitationResponse> response =
+                settlementInvitationService
+                        .findReceivedInvitations(userId);
+
+        assertThat(response)
+                .hasSize(2)
+                .containsExactly(
+                        firstInvitation,
+                        secondInvitation
+                );
+
+        assertThat(response.get(0).getInvitationId())
+                .isEqualTo(3L);
+
+        assertThat(response.get(0).getSettlementTitle())
+                .isEqualTo("제주도");
+
+        assertThat(response.get(0).getInvitationStatus())
+                .isEqualTo(SettlementInvitationStatus.INVITED);
+
+        assertThat(response.get(0).getAcceptedAt())
+                .isNull();
+
+        assertThat(response.get(1).getInvitationId())
+                .isEqualTo(1L);
+
+        verify(invitationMapper)
+                .findReceivedInvitations(userId);
+    }
+
+    @Test
+    @DisplayName("받은 정산 초대가 없으면 빈 목록을 반환한다")
+    void findReceivedInvitationsReturnsEmptyList() {
+        Long userId = 2L;
+
+        when(invitationMapper.findReceivedInvitations(userId))
+                .thenReturn(List.of());
+
+        List<ReceivedSettlementInvitationResponse> response =
+                settlementInvitationService
+                        .findReceivedInvitations(userId);
+
+        assertThat(response)
+                .isEmpty();
+
+        verify(invitationMapper)
+                .findReceivedInvitations(userId);
     }
 }


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #47

## 🛠 작업 사항

- 로그인 회원의 받은 정산 초대 목록 조회 API 구현
- 대기 중인 정산 초대를 최신순으로 반환하도록 Controller 연결
- SettlementInvitationService에 받은 초대 목록 조회 로직 추가
- 받은 초대가 없는 경우 빈 목록을 반환하도록 처리
- 받은 초대 목록 조회 Service 단위 테스트 추가
- 조회 결과와 빈 목록 반환 케이스 검증
테스트

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

-