### PR TITLE
feat(#52): 초대 받은 정산 수락,거절 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementInvitationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSettlementInvitationResponse;
 import org.teamsai.saibackend.domain.settlement.dto.response.ReceivedSettlementInvitationResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationResponseService;
 import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
 
 import java.util.List;
@@ -29,6 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SettlementInvitationController {
     private final SettlementInvitationService service;
+    private final SettlementInvitationResponseService invitationResponseService;
 
     @Operation(
             summary = "공동정산 참여자 초대",
@@ -101,7 +104,7 @@ public class SettlementInvitationController {
             )
     })
     @ResponseBody
-    @GetMapping("/api/settlements/received")
+    @GetMapping("/api/settlement-invitations/received")
     public ResponseEntity<List<ReceivedSettlementInvitationResponse>> findReceivedInvitation(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "userId")
@@ -110,6 +113,100 @@ public class SettlementInvitationController {
         List<ReceivedSettlementInvitationResponse> response = service.findReceivedInvitations(userId);
 
         return ResponseEntity.ok(response);
+    }
+    @Operation(
+            summary = "정산 초대 수락",
+            description = "로그인한 회원이 자신에게 도착한 정산 초대를 수락하고 정산 참여자로 등록됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "정산 초대 수락 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "종료된 정산의 초대"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요하거나 토큰이 유효하지 않음"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 정산 초대를 처리할 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "정산 또는 정산 초대를 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 처리된 정산 초대"
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "정산 참여자 등록 실패"
+            )
+    })
+    @ResponseBody
+    @PostMapping("/api/settlement-invitations/{invitationId}/accept")
+    public ResponseEntity<Void> accept(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId,
+
+            @Parameter(
+                    description = "수락할 정산 초대 ID",
+                    example = "1"
+            )
+            @PathVariable
+            Long invitationId
+    ){
+        invitationResponseService.accept(userId, invitationId);
+        return ResponseEntity.noContent().build();
+    }
+    @Operation(
+            summary = "정산 초대 거절",
+            description = "로그인한 회원이 자신에게 도착한 정산 초대를 거절합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "정산 초대 거절 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요하거나 토큰이 유효하지 않음"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 정산 초대를 처리할 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "정산 초대를 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 처리된 정산 초대"
+            )
+    })
+    @ResponseBody
+    @PostMapping("/api/settlement-invitations/{invitationId}/reject")
+    public ResponseEntity<Void> reject(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userId")
+            Long userId,
+
+            @Parameter(
+                    description = "거절할 정산 초대 ID",
+                    example = "1"
+            )
+            @PathVariable
+            Long invitationId
+    ){
+        invitationResponseService.reject(userId, invitationId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
@@ -56,6 +56,10 @@ public enum SettlementErrorCode implements BaseErrorCode<DomainException> {
     SETTLEMENT_INVITATION_CREATE_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "정산 초대 생성에 실패했습니다."
+    ),
+    SETTLEMENT_PARTICIPANT_CREATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "정산 참여자 등록에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -13,4 +13,8 @@ public interface SettlementMapper {
     Optional<SettlementDTO> findById(
             @Param("settlementId") Long settlementId
     );
+
+    Optional<SettlementDTO> findByIdForUpdate(
+            @Param("settlementId") Long settlementId
+    );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
@@ -72,8 +72,8 @@ public class SettlementInvitationResponseService {
                 );
     }
 
-    private void acceptInvitation(Long invitationID, LocalDateTime acceptedAt){
-        int updateCount = invitationMapper.accept(invitationID, acceptedAt);
+    private void acceptInvitation(Long invitationId, LocalDateTime acceptedAt){
+        int updateCount = invitationMapper.accept(invitationId, acceptedAt);
 
         if(updateCount != 1){
             throw SettlementErrorCode.INVITATION_ALREADY_PROCESSED.toException();

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
@@ -1,0 +1,90 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantRole;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementInvitationResponseService {
+
+    private final SettlementInvitationMapper invitationMapper;
+    private final SettlementMapper settlementMapper;
+    private final SettlementParticipantMapper participantMapper;
+    private final SettlementInvitationValidator invitationValidator;
+
+    @Transactional
+    public void accept(Long userId, Long invitationId){
+        SettlementInvitationDTO invitation = findInvitation(invitationId);
+
+        invitationValidator.validateRespondableInvitation(invitation, userId);
+
+        SettlementDTO settlement = findSettlement(invitation.getSettlementId());
+
+        invitationValidator.validateAcceptableSettlement(settlement);
+
+        LocalDateTime acceptedAt = LocalDateTime.now();
+
+        acceptInvitation(invitationId, acceptedAt);
+
+        createdMemberParticipant(invitationId,acceptedAt);
+
+    }
+
+    @Transactional
+    public void reject(Long userId, Long invitationId){
+        SettlementInvitationDTO invitation = findInvitation(invitationId);
+
+        invitationValidator.validateRespondableInvitation(invitation, userId);
+
+        int updatedCount = invitationMapper.reject(invitationId);
+
+        if(updatedCount !=1 ){
+            throw SettlementErrorCode.INVITATION_ALREADY_PROCESSED.toException();
+        }
+    }
+
+    private SettlementInvitationDTO findInvitation(Long invitationId){
+        return invitationMapper.findById(invitationId)
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+    }
+
+    private SettlementDTO findSettlement(Long settlementId){
+        return settlementMapper.findById(settlementId)
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+    }
+
+    private void acceptInvitation(Long invitationID, LocalDateTime acceptedAt){
+        int updateCount = invitationMapper.accept(invitationID, acceptedAt);
+
+        if(updateCount != 1){
+            throw SettlementErrorCode.INVITATION_ALREADY_PROCESSED.toException();
+        }
+    }
+
+    private void createdMemberParticipant(Long invitationId, LocalDateTime joinedAt){
+        SettlementParticipantDTO participant = SettlementParticipantDTO.builder()
+                .invitationId(invitationId)
+                .participantRole(SettlementParticipantRole.MEMBER)
+                .participantStatus(SettlementParticipantStatus.ACTIVE)
+                .joinedAt(joinedAt)
+                .build();
+
+        int insertCount = participantMapper.insert(participant);
+
+        if(insertCount != 1){
+            throw  SettlementErrorCode.SETTLEMENT_INVITATION_CREATE_FAILED.toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationResponseService.java
@@ -30,7 +30,7 @@ public class SettlementInvitationResponseService {
 
         invitationValidator.validateRespondableInvitation(invitation, userId);
 
-        SettlementDTO settlement = findSettlement(invitation.getSettlementId());
+        SettlementDTO settlement = findSettlementForUpdate(invitation.getSettlementId());
 
         invitationValidator.validateAcceptableSettlement(settlement);
 
@@ -38,7 +38,7 @@ public class SettlementInvitationResponseService {
 
         acceptInvitation(invitationId, acceptedAt);
 
-        createdMemberParticipant(invitationId,acceptedAt);
+        createMemberParticipant(invitationId,acceptedAt);
 
     }
 
@@ -57,12 +57,19 @@ public class SettlementInvitationResponseService {
 
     private SettlementInvitationDTO findInvitation(Long invitationId){
         return invitationMapper.findById(invitationId)
-                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_INVITATION_NOT_FOUND::toException);
     }
 
-    private SettlementDTO findSettlement(Long settlementId){
-        return settlementMapper.findById(settlementId)
-                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+    private SettlementDTO findSettlementForUpdate(
+            Long settlementId
+    ) {
+        return settlementMapper
+                .findByIdForUpdate(settlementId)
+                .orElseThrow(
+                        SettlementErrorCode
+                                .SETTLEMENT_NOT_FOUND
+                                ::toException
+                );
     }
 
     private void acceptInvitation(Long invitationID, LocalDateTime acceptedAt){
@@ -73,7 +80,7 @@ public class SettlementInvitationResponseService {
         }
     }
 
-    private void createdMemberParticipant(Long invitationId, LocalDateTime joinedAt){
+    private void createMemberParticipant(Long invitationId, LocalDateTime joinedAt){
         SettlementParticipantDTO participant = SettlementParticipantDTO.builder()
                 .invitationId(invitationId)
                 .participantRole(SettlementParticipantRole.MEMBER)
@@ -84,7 +91,7 @@ public class SettlementInvitationResponseService {
         int insertCount = participantMapper.insert(participant);
 
         if(insertCount != 1){
-            throw  SettlementErrorCode.SETTLEMENT_INVITATION_CREATE_FAILED.toException();
+            throw  SettlementErrorCode.SETTLEMENT_PARTICIPANT_CREATE_FAILED.toException();
         }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementInvitationValidator.java
@@ -3,9 +3,11 @@ package org.teamsai.saibackend.domain.settlement.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
 import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
 
 import java.util.Objects;
@@ -40,6 +42,20 @@ public class SettlementInvitationValidator {
         );
     }
 
+    public void validateRespondableInvitation(
+            SettlementInvitationDTO invitation,
+            Long userId
+    ) {
+        validateInvitedUser(invitation, userId);
+        validatePendingStatus(invitation);
+    }
+
+    public void validateAcceptableSettlement(
+            SettlementDTO settlement
+    ) {
+        validateInProgress(settlement);
+    }
+
     private void validateOwner(
             SettlementDTO settlement,
             Long ownerId
@@ -54,12 +70,36 @@ public class SettlementInvitationValidator {
         }
     }
 
+    private void validateInvitedUser(
+            SettlementInvitationDTO invitation,
+            Long userId
+    ) {
+        if (!Objects.equals(
+                invitation.getInvitedUserId(),
+                userId
+        )) {
+            throw SettlementErrorCode
+                    .INVITATION_ACCESS_DENIED
+                    .toException();
+        }
+    }
+
+    private void validatePendingStatus(
+            SettlementInvitationDTO invitation
+    ) {
+        if (invitation.getInvitationStatus()
+                != SettlementInvitationStatus.INVITED) {
+            throw SettlementErrorCode
+                    .INVITATION_ALREADY_PROCESSED
+                    .toException();
+        }
+    }
+
     private void validateInProgress(
             SettlementDTO settlement
     ) {
         if (settlement.getSettlementStatus()
                 == SettlementStatus.CLOSED) {
-
             throw SettlementErrorCode
                     .ALREADY_CLOSED_SETTLEMENT
                     .toException();

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -74,4 +74,31 @@
         WHERE settlement_id = #{settlementId}
     </select>
 
+    <select
+            id="findByIdForUpdate"
+            resultMap="settlementResultMap">
+
+        SELECT
+        settlement_id,
+        owner_id,
+        settlement_type,
+        settlement_status,
+        settlement_category,
+        title,
+        split_type,
+        due_date,
+        cycle_rule,
+        start_date,
+        end_date,
+        created_at,
+        closed_at,
+        status,
+        cycle_date,
+        invitation_token
+        FROM settlement
+        WHERE settlement_id = #{settlementId}
+        FOR UPDATE
+
+    </select>
+
 </mapper>

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationResponseServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationResponseServiceTest.java
@@ -1,0 +1,310 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationResponseService;
+import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationValidator;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantRole;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementInvitationResponseServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long INVITATION_ID = 3L;
+    private static final Long SETTLEMENT_ID = 2L;
+
+    @Mock
+    private SettlementInvitationMapper invitationMapper;
+
+    @Mock
+    private SettlementMapper settlementMapper;
+
+    @Mock
+    private SettlementParticipantMapper participantMapper;
+
+    @Mock
+    private SettlementInvitationValidator invitationValidator;
+
+    @InjectMocks
+    private SettlementInvitationResponseService responseService;
+
+    @Test
+    @DisplayName("정산 초대를 수락하면 초대 상태를 변경하고 참여자를 등록한다")
+    void acceptSuccess() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .build();
+
+        SettlementDTO settlement =
+                SettlementDTO.builder()
+                        .settlementId(SETTLEMENT_ID)
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(invitationMapper.accept(
+                eq(INVITATION_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(1);
+
+        when(participantMapper.insert(
+                any(SettlementParticipantDTO.class)
+        )).thenReturn(1);
+
+        responseService.accept(
+                USER_ID,
+                INVITATION_ID
+        );
+
+        verify(invitationValidator)
+                .validateRespondableInvitation(
+                        invitation,
+                        USER_ID
+                );
+
+        verify(invitationValidator)
+                .validateAcceptableSettlement(settlement);
+
+        ArgumentCaptor<LocalDateTime> acceptedAtCaptor =
+                ArgumentCaptor.forClass(LocalDateTime.class);
+
+        verify(invitationMapper).accept(
+                eq(INVITATION_ID),
+                acceptedAtCaptor.capture()
+        );
+
+        ArgumentCaptor<SettlementParticipantDTO> participantCaptor =
+                ArgumentCaptor.forClass(
+                        SettlementParticipantDTO.class
+                );
+
+        verify(participantMapper)
+                .insert(participantCaptor.capture());
+
+        SettlementParticipantDTO participant =
+                participantCaptor.getValue();
+
+        assertThat(participant.getInvitationId())
+                .isEqualTo(INVITATION_ID);
+
+        assertThat(participant.getParticipantRole())
+                .isEqualTo(SettlementParticipantRole.MEMBER);
+
+        assertThat(participant.getParticipantStatus())
+                .isEqualTo(SettlementParticipantStatus.ACTIVE);
+
+        assertThat(participant.getJoinedAt())
+                .isEqualTo(acceptedAtCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정산 초대는 수락할 수 없다")
+    void acceptFailWhenInvitationNotFound() {
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> responseService.accept(
+                        USER_ID,
+                        INVITATION_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verifyNoInteractions(
+                settlementMapper,
+                participantMapper,
+                invitationValidator
+        );
+
+        verify(
+                invitationMapper,
+                never()
+        ).accept(
+                eq(INVITATION_ID),
+                any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    @DisplayName("초대 수락 상태 변경에 실패하면 참여자를 등록하지 않는다")
+    void acceptFailWhenInvitationUpdateFailed() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .build();
+
+        SettlementDTO settlement =
+                SettlementDTO.builder()
+                        .settlementId(SETTLEMENT_ID)
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(invitationMapper.accept(
+                eq(INVITATION_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(0);
+
+        assertThatThrownBy(
+                () -> responseService.accept(
+                        USER_ID,
+                        INVITATION_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(
+                participantMapper,
+                never()
+        ).insert(any(SettlementParticipantDTO.class));
+    }
+
+    @Test
+    @DisplayName("초대 수락 후 참여자 등록에 실패하면 예외가 발생한다")
+    void acceptFailWhenParticipantInsertFailed() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .build();
+
+        SettlementDTO settlement =
+                SettlementDTO.builder()
+                        .settlementId(SETTLEMENT_ID)
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(settlementMapper.findById(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(invitationMapper.accept(
+                eq(INVITATION_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(1);
+
+        when(participantMapper.insert(
+                any(SettlementParticipantDTO.class)
+        )).thenReturn(0);
+
+        assertThatThrownBy(
+                () -> responseService.accept(
+                        USER_ID,
+                        INVITATION_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(participantMapper)
+                .insert(any(SettlementParticipantDTO.class));
+    }
+
+    @Test
+    @DisplayName("정산 초대를 거절하면 초대 상태만 변경한다")
+    void rejectSuccess() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(invitationMapper.reject(INVITATION_ID))
+                .thenReturn(1);
+
+        responseService.reject(
+                USER_ID,
+                INVITATION_ID
+        );
+
+        verify(invitationValidator)
+                .validateRespondableInvitation(
+                        invitation,
+                        USER_ID
+                );
+
+        verify(invitationMapper)
+                .reject(INVITATION_ID);
+
+        verifyNoInteractions(
+                settlementMapper,
+                participantMapper
+        );
+    }
+
+    @Test
+    @DisplayName("초대 거절 상태 변경에 실패하면 예외가 발생한다")
+    void rejectFailWhenInvitationUpdateFailed() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(SettlementInvitationStatus.INVITED)
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(invitationMapper.reject(INVITATION_ID))
+                .thenReturn(0);
+
+        assertThatThrownBy(
+                () -> responseService.reject(
+                        USER_ID,
+                        INVITATION_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verifyNoInteractions(
+                settlementMapper,
+                participantMapper
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationResponseServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationResponseServiceTest.java
@@ -25,12 +25,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SettlementInvitationResponseServiceTest {
@@ -73,7 +69,7 @@ class SettlementInvitationResponseServiceTest {
         when(invitationMapper.findById(INVITATION_ID))
                 .thenReturn(Optional.of(invitation));
 
-        when(settlementMapper.findById(SETTLEMENT_ID))
+        when(settlementMapper.findByIdForUpdate(SETTLEMENT_ID))
                 .thenReturn(Optional.of(settlement));
 
         when(invitationMapper.accept(
@@ -178,7 +174,7 @@ class SettlementInvitationResponseServiceTest {
         when(invitationMapper.findById(INVITATION_ID))
                 .thenReturn(Optional.of(invitation));
 
-        when(settlementMapper.findById(SETTLEMENT_ID))
+        when(settlementMapper.findByIdForUpdate(SETTLEMENT_ID))
                 .thenReturn(Optional.of(settlement));
 
         when(invitationMapper.accept(
@@ -218,7 +214,7 @@ class SettlementInvitationResponseServiceTest {
         when(invitationMapper.findById(INVITATION_ID))
                 .thenReturn(Optional.of(invitation));
 
-        when(settlementMapper.findById(SETTLEMENT_ID))
+        when(settlementMapper.findByIdForUpdate(SETTLEMENT_ID))
                 .thenReturn(Optional.of(settlement));
 
         when(invitationMapper.accept(
@@ -305,6 +301,112 @@ class SettlementInvitationResponseServiceTest {
         verifyNoInteractions(
                 settlementMapper,
                 participantMapper
+        );
+    }
+    @Test
+    @DisplayName("정산 초대 수락 시 정산을 잠금 조회한다")
+    void acceptUsesSettlementForUpdate() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(
+                                SettlementInvitationStatus.INVITED
+                        )
+                        .build();
+
+        SettlementDTO settlement =
+                mock(SettlementDTO.class);
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(settlementMapper.findByIdForUpdate(SETTLEMENT_ID))
+                .thenReturn(Optional.of(settlement));
+
+        when(
+                invitationMapper.accept(
+                        eq(INVITATION_ID),
+                        any(LocalDateTime.class)
+                )
+        ).thenReturn(1);
+
+        when(
+                participantMapper.insert(
+                        any(SettlementParticipantDTO.class)
+                )
+        ).thenReturn(1);
+
+        responseService.accept(
+                USER_ID,
+                INVITATION_ID
+        );
+
+        verify(settlementMapper)
+                .findByIdForUpdate(SETTLEMENT_ID);
+
+        verify(
+                settlementMapper,
+                never()
+        ).findById(anyLong());
+
+        verify(invitationValidator)
+                .validateAcceptableSettlement(settlement);
+
+        verify(invitationMapper)
+                .accept(
+                        eq(INVITATION_ID),
+                        any(LocalDateTime.class)
+                );
+
+        verify(participantMapper)
+                .insert(
+                        any(SettlementParticipantDTO.class)
+                );
+    }
+    @Test
+    @DisplayName("잠금 조회에서 정산을 찾지 못하면 초대와 참여자를 변경하지 않는다")
+    void acceptFailWhenSettlementNotFoundForUpdate() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitationId(INVITATION_ID)
+                        .settlementId(SETTLEMENT_ID)
+                        .invitedUserId(USER_ID)
+                        .invitationStatus(
+                                SettlementInvitationStatus.INVITED
+                        )
+                        .build();
+
+        when(invitationMapper.findById(INVITATION_ID))
+                .thenReturn(Optional.of(invitation));
+
+        when(settlementMapper.findByIdForUpdate(SETTLEMENT_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> responseService.accept(
+                        USER_ID,
+                        INVITATION_ID
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verify(settlementMapper)
+                .findByIdForUpdate(SETTLEMENT_ID);
+
+        verify(
+                invitationMapper,
+                never()
+        ).accept(
+                anyLong(),
+                any(LocalDateTime.class)
+        );
+
+        verify(
+                participantMapper,
+                never()
+        ).insert(
+                any(SettlementParticipantDTO.class)
         );
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationValidatorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementInvitationValidatorTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementInvitationDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementInvitationMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
 import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationValidator;
+import org.teamsai.saibackend.domain.settlement.type.SettlementInvitationStatus;
 import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -185,5 +187,95 @@ class SettlementInvitationValidatorTest {
                         SETTLEMENT_ID,
                         INVITED_USER_ID
                 );
+    }
+
+    @Test
+    @DisplayName("초대 대상 회원이고 INVITED 상태이면 초대에 응답할 수 있다")
+    void validateRespondableInvitationSuccess() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitedUserId(OTHER_USER_ID)
+                        .invitationStatus(
+                                SettlementInvitationStatus.INVITED
+                        )
+                        .build();
+
+        assertThatCode(
+                () -> invitationValidator
+                        .validateRespondableInvitation(
+                                invitation,
+                                OTHER_USER_ID
+                        )
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("초대 대상 회원이 아니면 초대를 처리할 수 없다")
+    void validateRespondableInvitationFailWhenNotInvitedUser() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitedUserId(INVITED_USER_ID)
+                        .invitationStatus(
+                                SettlementInvitationStatus.INVITED
+                        )
+                        .build();
+
+        assertThatThrownBy(
+                () -> invitationValidator
+                        .validateRespondableInvitation(
+                                invitation,
+                                OTHER_USER_ID
+                        )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("이미 처리된 초대에는 다시 응답할 수 없다")
+    void validateRespondableInvitationFailWhenAlreadyProcessed() {
+        SettlementInvitationDTO invitation =
+                SettlementInvitationDTO.builder()
+                        .invitedUserId(OTHER_USER_ID)
+                        .invitationStatus(
+                                SettlementInvitationStatus.ACCEPTED
+                        )
+                        .build();
+
+        assertThatThrownBy(
+                () -> invitationValidator
+                        .validateRespondableInvitation(
+                                invitation,
+                                OTHER_USER_ID
+                        )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("진행 중인 정산의 초대는 수락할 수 있다")
+    void validateAcceptableSettlementSuccess() {
+        SettlementDTO settlement =
+                mock(SettlementDTO.class);
+
+        when(settlement.getSettlementStatus())
+                .thenReturn(SettlementStatus.IN_PROGRESS);
+
+        assertThatCode(
+                () -> invitationValidator
+                        .validateAcceptableSettlement(settlement)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("종료된 정산의 초대는 수락할 수 없다")
+    void validateAcceptableSettlementFailWhenClosed() {
+        SettlementDTO settlement =
+                mock(SettlementDTO.class);
+
+        when(settlement.getSettlementStatus())
+                .thenReturn(SettlementStatus.CLOSED);
+
+        assertThatThrownBy(
+                () -> invitationValidator
+                        .validateAcceptableSettlement(settlement)
+        ).isInstanceOf(DomainException.class);
     }
 }


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #52

## 🛠 작업 사항

- 받은 정산 초대 수락 및 거절 API 구현
- 초대 수락 시 초대 상태를 ACCEPTED로 변경하고 수락 일시 저장, 정산 참여자 테이블에 MEMBER, ACTIVE 상태로 참여자 등록
- 초대 거절 시 초대 상태를 REJECTED로 변경하고 참여자는 생성하지 않도록 처리
- 초대 상태 변경과 참여자 등록을 하나의 트랜잭션으로 처리
- 초대 대상 회원과 로그인 회원의 일치 여부 검증 추가
- INVITED 상태의 초대만 수락·거절할 수 있도록 검증 로직 추가
- 이미 처리된 초대에 대한 중복 수락·거절 요청 방지
- 종료된 정산의 초대를 수락하지 못하도록 검증 추가
- 수락·거절 처리 로직을 SettlementInvitationResponseService로 분리
- 조건부 UPDATE를 적용하여 동시 수락·거절 요청 중 하나만 처리되도록 구현
- 받은 정산 초대 조회 API 경로를 수락·거절 API와 통일성 있게 수정
- 정산 초대 수락·거절 Swagger API 명세 추가
- 수락·거절 Service 및 Validator 단위 테스트 추가

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 초대 받은 정산 조회, 수락, 거절은 '통합 알림 센터' 에서 금전 소비 대차 요청과 함께 사용될 예정이므로, 아직 연결된 화면은 없습니다.
- 추후 알림함 구현 시 현재 개발한 API를 이용합니다. 