### PR TITLE
feat(#48): 연결 계좌 기준 정산 자동매칭 및 거래 상태 변경 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingExecutionResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingExecutionResult.java
@@ -1,11 +1,44 @@
 package org.teamsai.saibackend.domain.matching.model;
 
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+
+import java.util.List;
+
 public record AutoMatchingExecutionResult(
         int totalTransactionCount,
         int appliedCount,
         int needsCheckCount,
         int unmatchedCount,
         int duplicateCount,
-        int failedCount
+        int failedCount,
+        List<AutoMatchingTransactionResult> transactionResults
 ) {
+
+    public AutoMatchingExecutionResult {
+        if (transactionResults == null
+                || transactionResults.stream().anyMatch(result -> result == null)
+                || totalTransactionCount < 0
+                || appliedCount < 0
+                || needsCheckCount < 0
+                || unmatchedCount < 0
+                || duplicateCount < 0
+                || failedCount < 0) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        int resultCount = transactionResults.size();
+
+        int countedTotal = appliedCount
+                + needsCheckCount
+                + unmatchedCount
+                + duplicateCount
+                + failedCount;
+
+        if (totalTransactionCount != resultCount
+                || totalTransactionCount != countedTotal) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        transactionResults = List.copyOf(transactionResults);
+    }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingTransactionResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingTransactionResult.java
@@ -1,0 +1,16 @@
+package org.teamsai.saibackend.domain.matching.model;
+
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+
+public record AutoMatchingTransactionResult(
+        Long transactionId,
+        AutoMatchingProcessStatus processStatus
+) {
+
+    public AutoMatchingTransactionResult {
+        if (transactionId == null || processStatus == null) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/model/MatchingTransaction.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/model/MatchingTransaction.java
@@ -4,12 +4,14 @@ import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 public record MatchingTransaction(
         Long transactionId,
         AutoMatchingTransactionType transactionType,
         BigDecimal amount,
-        String counterpartyName
+        String counterpartyName,
+        LocalDateTime transactionAt
 ) {
 
     public MatchingTransaction {
@@ -18,7 +20,8 @@ public record MatchingTransaction(
                 || amount == null
                 || counterpartyName == null
                 || counterpartyName.isBlank()
-                || amount.signum() <= 0) {
+                || amount.signum() <= 0
+                || transactionAt == null) {
             throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
         }
     }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/AutoMatchingService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/AutoMatchingService.java
@@ -6,14 +6,17 @@ import org.springframework.stereotype.Service;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingResult;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.policy.AutoMatchingJudge;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
 import org.teamsai.saibackend.domain.payment.service.PaymentService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,6 +41,8 @@ public class AutoMatchingService {
         int duplicateCount = 0;
         int failedCount = 0;
         Set<AppliedCandidateKey> appliedCandidateKeys = new HashSet<>();
+        List<AutoMatchingTransactionResult> transactionResults =
+                new ArrayList<>();
 
         for (MatchingTransaction transaction : transactions) {
             List<MatchingCandidate> availableCandidates =
@@ -45,6 +50,13 @@ public class AutoMatchingService {
 
             AutoMatchingProcessResult processResult =
                     processTransactionSafely(transaction, availableCandidates);
+
+            transactionResults.add(
+                    new AutoMatchingTransactionResult(
+                            transaction.transactionId(),
+                            processResult.status()
+                    )
+            );
 
             switch (processResult.status()) {
                 case APPLIED -> {
@@ -66,7 +78,8 @@ public class AutoMatchingService {
                 needsCheckCount,
                 unmatchedCount,
                 duplicateCount,
-                failedCount
+                failedCount,
+                transactionResults
         );
     }
 
@@ -248,13 +261,5 @@ public class AutoMatchingService {
                     null
             );
         }
-    }
-
-    private enum AutoMatchingProcessStatus {
-        APPLIED,
-        NEEDS_CHECK,
-        UNMATCHED,
-        DUPLICATE,
-        FAILED
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
@@ -1,0 +1,227 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BankMatchingService {
+
+    private final BankTransactionService bankTransactionService;
+    private final PaymentObligationMapper paymentObligationMapper;
+    private final AutoMatchingService autoMatchingService;
+
+    public AutoMatchingExecutionResult execute(Long linkedAccountId) {
+        validateLinkedAccountId(linkedAccountId);
+
+        List<BankTransactionDTO> bankTransactions =
+                bankTransactionService.findPendingDepositsByLinkedAccountId(
+                        linkedAccountId
+                );
+
+        if (bankTransactions.isEmpty()) {
+            return emptyResult();
+        }
+
+        if (bankTransactions.stream()
+                .noneMatch(this::hasMatchableCounterpartyName)) {
+            AutoMatchingExecutionResult executionResult =
+                    toExecutionResult(
+                            toNeedsCheckResults(bankTransactions)
+                    );
+            updateBankTransactionStatuses(executionResult);
+
+            return executionResult;
+        }
+
+        AutoMatchingExecutionResult executionResult =
+                toExecutionResult(
+                        processTransactions(
+                                linkedAccountId,
+                                bankTransactions
+                        )
+                );
+        updateBankTransactionStatuses(executionResult);
+
+        return executionResult;
+    }
+
+    private void validateLinkedAccountId(Long linkedAccountId) {
+        if (linkedAccountId == null || linkedAccountId <= 0) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+    }
+
+    private AutoMatchingExecutionResult emptyResult() {
+        return new AutoMatchingExecutionResult(
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                List.of()
+        );
+    }
+
+    private List<AutoMatchingTransactionResult> processTransactions(
+            Long linkedAccountId,
+            List<BankTransactionDTO> bankTransactions
+    ) {
+        return bankTransactions.stream()
+                .map(bankTransaction -> processTransaction(
+                        linkedAccountId,
+                        bankTransaction
+                ))
+                .toList();
+    }
+
+    private AutoMatchingTransactionResult processTransaction(
+            Long linkedAccountId,
+            BankTransactionDTO bankTransaction
+    ) {
+        if (!hasMatchableCounterpartyName(bankTransaction)) {
+            return new AutoMatchingTransactionResult(
+                    bankTransaction.getBankTransactionId(),
+                    AutoMatchingProcessStatus.NEEDS_CHECK
+            );
+        }
+
+        MatchingTransaction matchingTransaction =
+                toMatchingTransaction(bankTransaction);
+
+        List<MatchingCandidate> candidates =
+                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                        linkedAccountId,
+                        matchingTransaction.transactionAt()
+                );
+
+        AutoMatchingExecutionResult matchingResult =
+                autoMatchingService.execute(
+                        List.of(matchingTransaction),
+                        candidates
+                );
+
+        if (matchingResult.transactionResults().size() != 1) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        return matchingResult.transactionResults().get(0);
+    }
+
+    private boolean hasMatchableCounterpartyName(
+            BankTransactionDTO bankTransaction
+    ) {
+        String counterpartyName = bankTransaction.getCounterpartyName();
+
+        return counterpartyName != null && !counterpartyName.isBlank();
+    }
+
+    private MatchingTransaction toMatchingTransaction(
+            BankTransactionDTO bankTransaction
+    ) {
+        return new MatchingTransaction(
+                bankTransaction.getBankTransactionId(),
+                toMatchingTransactionType(bankTransaction.getTransactionType()),
+                bankTransaction.getAmount(),
+                bankTransaction.getCounterpartyName(),
+                bankTransaction.getTransactionAt()
+        );
+    }
+
+    private AutoMatchingTransactionType toMatchingTransactionType(
+            BankTransactionType transactionType
+    ) {
+        return switch (transactionType) {
+            case DEPOSIT -> AutoMatchingTransactionType.DEPOSIT;
+            case WITHDRAWAL -> AutoMatchingTransactionType.WITHDRAWAL;
+        };
+    }
+
+    private List<AutoMatchingTransactionResult> toNeedsCheckResults(
+            List<BankTransactionDTO> bankTransactions
+    ) {
+        return bankTransactions.stream()
+                .map(transaction ->
+                        new AutoMatchingTransactionResult(
+                                transaction.getBankTransactionId(),
+                                AutoMatchingProcessStatus.NEEDS_CHECK
+                        )
+                )
+                .toList();
+    }
+
+    private AutoMatchingExecutionResult toExecutionResult(
+            List<AutoMatchingTransactionResult> transactionResults
+    ) {
+        int appliedCount = 0;
+        int needsCheckCount = 0;
+        int unmatchedCount = 0;
+        int duplicateCount = 0;
+        int failedCount = 0;
+
+        for (AutoMatchingTransactionResult result : transactionResults) {
+            switch (result.processStatus()) {
+                case APPLIED -> appliedCount++;
+                case NEEDS_CHECK -> needsCheckCount++;
+                case UNMATCHED -> unmatchedCount++;
+                case DUPLICATE -> duplicateCount++;
+                case FAILED -> failedCount++;
+            }
+        }
+
+        return new AutoMatchingExecutionResult(
+                transactionResults.size(),
+                appliedCount,
+                needsCheckCount,
+                unmatchedCount,
+                duplicateCount,
+                failedCount,
+                transactionResults
+        );
+    }
+
+    private void updateBankTransactionStatuses(
+            AutoMatchingExecutionResult executionResult
+    ) {
+        for (AutoMatchingTransactionResult transactionResult
+                : executionResult.transactionResults()) {
+            bankTransactionService.updateStatus(
+                    transactionResult.transactionId(),
+                    BankTransactionProcessingStatus.PENDING,
+                    toBankTransactionProcessingStatus(
+                            transactionResult.processStatus()
+                    )
+            );
+        }
+    }
+
+    private BankTransactionProcessingStatus toBankTransactionProcessingStatus(
+            AutoMatchingProcessStatus processStatus
+    ) {
+        return switch (processStatus) {
+            case APPLIED, DUPLICATE ->
+                    BankTransactionProcessingStatus.APPLIED;
+            case NEEDS_CHECK ->
+                    BankTransactionProcessingStatus.NEEDS_CHECK;
+            case UNMATCHED ->
+                    BankTransactionProcessingStatus.UNMATCHED;
+            case FAILED ->
+                    BankTransactionProcessingStatus.FAILED;
+        };
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/AutoMatchingProcessStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/AutoMatchingProcessStatus.java
@@ -1,0 +1,9 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum AutoMatchingProcessStatus {
+    APPLIED,
+    NEEDS_CHECK,
+    UNMATCHED,
+    DUPLICATE,
+    FAILED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -2,9 +2,12 @@ package org.teamsai.saibackend.domain.payment.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
 import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -16,6 +19,11 @@ public interface PaymentObligationMapper {
     int updatePaymentStatus(
             @Param("paymentObligationId") Long paymentObligationId,
             @Param("paymentStatus") PaymentStatus paymentStatus
+    );
+
+    List<MatchingCandidate> findMatchCandidatesByLinkedAccountId(
+            @Param("linkedAccountId") Long linkedAccountId,
+            @Param("transactionAt") LocalDateTime transactionAt
     );
 }
 

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
@@ -24,6 +24,10 @@ public interface BankTransactionMapper {
 
     List<BankTransactionDTO> findPendingDeposits();
 
+    List<BankTransactionDTO> findPendingDepositsByLinkedAccountId(
+            @Param("linkedAccountId") Long linkedAccountId
+    );
+
     int updateStatus(
             @Param("bankTransactionId") Long bankTransactionId,
             @Param("currentStatus")

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -37,6 +37,14 @@ public class BankTransactionService {
         return bankTransactionMapper.findPendingDeposits();
     }
 
+    public List<BankTransactionDTO> findPendingDepositsByLinkedAccountId(
+            Long linkedAccountId
+    ) {
+        return bankTransactionMapper.findPendingDepositsByLinkedAccountId(
+                linkedAccountId
+        );
+    }
+
     @Transactional
     public void updateStatus(
             Long bankTransactionId,

--- a/src/main/resources/db/settlement_account.sql
+++ b/src/main/resources/db/settlement_account.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS settlement_account (
+    settlement_account_id BIGINT NOT NULL AUTO_INCREMENT,
+    settlement_id BIGINT NOT NULL,
+    linked_account_id BIGINT NOT NULL,
+    account_status VARCHAR(30) NOT NULL DEFAULT 'ACTIVE' CHECK (
+        account_status IN ('ACTIVE', 'REPLACED', 'DISABLED')
+    ),
+
+    selected_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ended_at DATETIME NULL,
+
+    active_key TINYINT
+        GENERATED ALWAYS AS (
+            CASE
+                WHEN account_status = 'ACTIVE'
+                    AND ended_at IS NULL
+                THEN 1
+                ELSE NULL
+            END
+        ) STORED,
+
+    PRIMARY KEY (settlement_account_id),
+
+    INDEX idx_settlement_account_linked_account (
+        linked_account_id,
+        account_status,
+        ended_at
+    ),
+
+    INDEX idx_settlement_account_active (
+        settlement_id,
+        account_status,
+        ended_at
+    ),
+
+    CONSTRAINT uk_settlement_account_active
+    UNIQUE (
+               settlement_id,
+               active_key
+           ),
+
+    CONSTRAINT fk_settlement_account_settlement
+        FOREIGN KEY (settlement_id)
+        REFERENCES settlement (settlement_id),
+
+    CONSTRAINT fk_settlement_account_linked_account
+        FOREIGN KEY (linked_account_id)
+        REFERENCES linked_bank_account (linked_account_id)
+) ENGINE=InnoDB
+DEFAULT CHARSET=utf8mb4
+COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -14,6 +14,22 @@
         <result property="reviewStatus" column="review_status"/>
         <result property="obligationStatus" column="obligation_status"/>
     </resultMap>
+    <resultMap id="MatchingCandidateResultMap"
+               type="org.teamsai.saibackend.domain.matching.model.MatchingCandidate">
+        <constructor>
+            <arg column="target_type"
+                 javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
+            <arg column="obligation_id"
+                 javaType="java.lang.Long"/>
+            <arg column="participant_id"
+                 javaType="java.lang.Long"/>
+            <arg column="participant_name"
+                 javaType="java.lang.String"/>
+            <arg column="remaining_amount"
+                 javaType="java.math.BigDecimal"/>
+        </constructor>
+    </resultMap>
+
     <select id="findByIdForUpdate"
             resultMap="PaymentObligationResultMap">
         SELECT
@@ -35,4 +51,44 @@
         WHERE payment_obligation_id = #{paymentObligationId}
     </update>
 
+    <select id="findMatchCandidatesByLinkedAccountId"
+            resultMap="MatchingCandidateResultMap">
+        SELECT
+        'SETTLEMENT' AS target_type,
+        po.payment_obligation_id AS obligation_id,
+        po.participant_id AS participant_id,
+        u.name AS participant_name,
+        po.expected_amount - COALESCE(SUM(pr.amount), 0) AS remaining_amount
+        FROM payment_obligation po
+        JOIN settlement_participant sp
+        ON sp.participant_id = po.participant_id
+        JOIN settlement_invitation si
+        ON si.invitation_id = sp.invitation_id
+        JOIN settlement s
+        ON s.settlement_id = si.settlement_id
+        JOIN settlement_account sa
+        ON sa.settlement_id = s.settlement_id
+        JOIN users u
+        ON u.user_id = si.user_id
+        LEFT JOIN payment_record pr
+        ON pr.obligation_id = po.payment_obligation_id
+        AND pr.record_status = 'CONFIRMED'
+        WHERE sa.linked_account_id = #{linkedAccountId}
+        AND sa.selected_at &lt;= #{transactionAt}
+        AND (
+        sa.ended_at IS NULL
+        OR sa.ended_at &gt; #{transactionAt}
+        )
+        AND s.created_at &lt;= #{transactionAt}
+        AND s.settlement_status = 'IN_PROGRESS'
+        AND po.obligation_status = 'ACTIVE'
+        AND po.payment_status != 'PAID'
+        AND sp.participant_status = 'ACTIVE'
+        GROUP BY
+        po.payment_obligation_id,
+        po.participant_id,
+        u.name,
+        po.expected_amount
+        HAVING po.expected_amount - COALESCE(SUM(pr.amount), 0) &gt; 0
+    </select>
 </mapper>

--- a/src/main/resources/mapper/transaction/BankTransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/BankTransactionMapper.xml
@@ -89,6 +89,17 @@
         ORDER BY transaction_at ASC, bank_transaction_id ASC
     </select>
 
+    <select id="findPendingDepositsByLinkedAccountId"
+            resultMap="BankTransactionResultMap">
+        SELECT
+        <include refid="BankTransactionColumns"/>
+        FROM bank_transaction
+        WHERE linked_account_id = #{linkedAccountId}
+        AND processing_status = 'PENDING'
+        AND transaction_type = 'DEPOSIT'
+        ORDER BY transaction_at ASC, bank_transaction_id ASC
+    </select>
+
     <update id="updateStatus">
         UPDATE bank_transaction
         SET processing_status = #{nextStatus}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingJudgeTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingJudgeTest.java
@@ -15,6 +15,7 @@ import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -238,7 +239,8 @@ class AutoMatchingJudgeTest {
                 1L,
                 type,
                 new BigDecimal(amount),
-                counterpartyName
+                counterpartyName,
+                LocalDateTime.of(2026, 8, 5, 10, 0)
         );
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingServiceTest.java
@@ -13,6 +13,7 @@ import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.policy.AutoMatchingJudge;
 import org.teamsai.saibackend.domain.matching.service.AutoMatchingService;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
@@ -20,6 +21,7 @@ import org.teamsai.saibackend.domain.payment.service.PaymentService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -85,6 +87,19 @@ class AutoMatchingServiceTest {
             assertThat(result.appliedCount()).isEqualTo(1);
             assertThat(result.needsCheckCount()).isZero();
             assertThat(result.unmatchedCount()).isZero();
+            assertThat(result.transactionResults())
+                    .extracting(
+                            transactionResult -> transactionResult
+                                    .transactionId(),
+                            transactionResult -> transactionResult
+                                    .processStatus()
+                    )
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(
+                                    101L,
+                                    AutoMatchingProcessStatus.APPLIED
+                            )
+                    );
         }
 
         @Test
@@ -119,6 +134,19 @@ class AutoMatchingServiceTest {
             assertThat(result.appliedCount()).isZero();
             assertThat(result.needsCheckCount()).isZero();
             assertThat(result.unmatchedCount()).isEqualTo(1);
+            assertThat(result.transactionResults())
+                    .extracting(
+                            transactionResult -> transactionResult
+                                    .transactionId(),
+                            transactionResult -> transactionResult
+                                    .processStatus()
+                    )
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(
+                                    101L,
+                                    AutoMatchingProcessStatus.UNMATCHED
+                            )
+                    );
         }
 
         @Test
@@ -159,6 +187,19 @@ class AutoMatchingServiceTest {
             assertThat(result.appliedCount()).isZero();
             assertThat(result.needsCheckCount()).isEqualTo(1);
             assertThat(result.unmatchedCount()).isZero();
+            assertThat(result.transactionResults())
+                    .extracting(
+                            transactionResult -> transactionResult
+                                    .transactionId(),
+                            transactionResult -> transactionResult
+                                    .processStatus()
+                    )
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(
+                                    101L,
+                                    AutoMatchingProcessStatus.NEEDS_CHECK
+                            )
+                    );
         }
 
         @Test
@@ -428,6 +469,19 @@ class AutoMatchingServiceTest {
             assertThat(result.unmatchedCount()).isZero();
             assertThat(result.duplicateCount()).isEqualTo(1);
             assertThat(result.failedCount()).isZero();
+            assertThat(result.transactionResults())
+                    .extracting(
+                            transactionResult -> transactionResult
+                                    .transactionId(),
+                            transactionResult -> transactionResult
+                                    .processStatus()
+                    )
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(
+                                    101L,
+                                    AutoMatchingProcessStatus.DUPLICATE
+                            )
+                    );
         }
 
         @Test
@@ -485,7 +539,8 @@ class AutoMatchingServiceTest {
                 transactionId,
                 type,
                 new BigDecimal(amount),
-                counterpartyName
+                counterpartyName,
+                LocalDateTime.of(2026, 8, 5, 10, 0)
         );
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingServiceTest.java
@@ -1,0 +1,562 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
+import org.teamsai.saibackend.domain.matching.service.AutoMatchingService;
+import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankMatchingService 단위 테스트")
+class BankMatchingServiceTest {
+
+    private static final Long LINKED_ACCOUNT_ID = 1L;
+
+    @Mock
+    private BankTransactionService bankTransactionService;
+
+    @Mock
+    private PaymentObligationMapper paymentObligationMapper;
+
+    @Mock
+    private AutoMatchingService autoMatchingService;
+
+    @InjectMocks
+    private BankMatchingService bankMatchingService;
+
+    @Nested
+    @DisplayName("연결 계좌 기준 자동매칭 실행")
+    class Execute {
+
+        @Test
+        @DisplayName("처리 대기 입금 거래가 없으면 빈 결과를 반환한다")
+        void returnsEmptyResultWhenPendingDepositsDoNotExist() {
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of());
+
+            AutoMatchingExecutionResult result =
+                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            assertThat(result.totalTransactionCount()).isZero();
+            assertThat(result.transactionResults()).isEmpty();
+            verify(paymentObligationMapper, never())
+                    .findMatchCandidatesByLinkedAccountId(any(), any());
+            verify(autoMatchingService, never()).execute(any(), any());
+        }
+
+        @Test
+        @DisplayName("유효한 입금 거래와 정산 후보로 자동매칭을 실행한다")
+        void executesAutoMatchingWithPendingDepositsAndCandidates() {
+            BankTransactionDTO transaction = bankTransaction(
+                    101L,
+                    "Hong Gil Dong"
+            );
+            MatchingCandidate candidate = candidate();
+            AutoMatchingExecutionResult matchingResult = executionResult(
+                    result(101L, AutoMatchingProcessStatus.APPLIED)
+            );
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(transaction));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(
+                            LINKED_ACCOUNT_ID,
+                            transaction.getTransactionAt()
+                    ))
+                    .willReturn(List.of(candidate));
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(matchingResult);
+
+            AutoMatchingExecutionResult result =
+                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            ArgumentCaptor<List<MatchingTransaction>> transactionsCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(autoMatchingService).execute(
+                    transactionsCaptor.capture(),
+                    org.mockito.ArgumentMatchers.eq(List.of(candidate))
+            );
+
+            assertThat(transactionsCaptor.getValue())
+                    .extracting(
+                            MatchingTransaction::transactionId,
+                            MatchingTransaction::transactionType,
+                            MatchingTransaction::amount,
+                            MatchingTransaction::counterpartyName,
+                            MatchingTransaction::transactionAt
+                    )
+                    .containsExactly(tuple(
+                            101L,
+                            AutoMatchingTransactionType.DEPOSIT,
+                            new BigDecimal("10000.00"),
+                            "Hong Gil Dong",
+                            transaction.getTransactionAt()
+                    ));
+            assertThat(result.transactionResults())
+                    .extracting(
+                            AutoMatchingTransactionResult::transactionId,
+                            AutoMatchingTransactionResult::processStatus
+                    )
+                    .containsExactly(tuple(
+                            101L,
+                            AutoMatchingProcessStatus.APPLIED
+                    ));
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+        }
+
+        @Test
+        @DisplayName("입금자명이 없으면 자동매칭 없이 확인 필요로 처리한다")
+        void classifiesBlankCounterpartyNameAsNeedsCheck() {
+            BankTransactionDTO transaction = bankTransaction(101L, " ");
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(transaction));
+
+            AutoMatchingExecutionResult result =
+                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            assertThat(result.totalTransactionCount()).isEqualTo(1);
+            assertThat(result.needsCheckCount()).isEqualTo(1);
+            assertThat(result.transactionResults())
+                    .extracting(
+                            AutoMatchingTransactionResult::transactionId,
+                            AutoMatchingTransactionResult::processStatus
+                    )
+                    .containsExactly(tuple(
+                            101L,
+                            AutoMatchingProcessStatus.NEEDS_CHECK
+                    ));
+            verify(paymentObligationMapper, never())
+                    .findMatchCandidatesByLinkedAccountId(any(), any());
+            verify(autoMatchingService, never()).execute(any(), any());
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.NEEDS_CHECK
+            );
+        }
+
+        @Test
+        @DisplayName("원본 거래 조회 순서대로 최종 결과를 재조합한다")
+        void preservesOriginalTransactionOrder() {
+            BankTransactionDTO first = bankTransaction(101L, "Hong Gil Dong");
+            BankTransactionDTO second = bankTransaction(102L, null);
+            BankTransactionDTO third = bankTransaction(103L, "Kim Chul Soo");
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(first, second, third));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(any(), any()))
+                    .willReturn(List.of(candidate()));
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(
+                            executionResult(
+                                    result(
+                                            101L,
+                                            AutoMatchingProcessStatus.APPLIED
+                                    )
+                            ),
+                            executionResult(
+                                    result(
+                                            103L,
+                                            AutoMatchingProcessStatus.UNMATCHED
+                                    )
+                            )
+                    );
+
+            AutoMatchingExecutionResult result =
+                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            assertThat(result.transactionResults())
+                    .extracting(
+                            AutoMatchingTransactionResult::transactionId,
+                            AutoMatchingTransactionResult::processStatus
+                    )
+                    .containsExactly(
+                            tuple(101L, AutoMatchingProcessStatus.APPLIED),
+                            tuple(102L, AutoMatchingProcessStatus.NEEDS_CHECK),
+                            tuple(103L, AutoMatchingProcessStatus.UNMATCHED)
+                    );
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+            verify(bankTransactionService).updateStatus(
+                    102L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.NEEDS_CHECK
+            );
+            verify(bankTransactionService).updateStatus(
+                    103L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.UNMATCHED
+            );
+        }
+
+        @Test
+        @DisplayName("자동매칭 결과별 은행 거래 상태를 변경한다")
+        void doesNotReuseCandidateAfterPreviousTransactionIsApplied() {
+            BankTransactionDTO first = bankTransaction(
+                    101L,
+                    "Hong Gil Dong",
+                    LocalDateTime.of(2026, 8, 5, 10, 0)
+            );
+            BankTransactionDTO second = bankTransaction(
+                    102L,
+                    "Hong Gil Dong",
+                    LocalDateTime.of(2026, 8, 5, 11, 0)
+            );
+            MatchingCandidate candidate = candidate();
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(first, second));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(
+                            LINKED_ACCOUNT_ID,
+                            first.getTransactionAt()
+                    ))
+                    .willReturn(List.of(candidate));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(
+                            LINKED_ACCOUNT_ID,
+                            second.getTransactionAt()
+                    ))
+                    .willReturn(List.of());
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(
+                            executionResult(
+                                    result(
+                                            101L,
+                                            AutoMatchingProcessStatus.APPLIED
+                                    )
+                            ),
+                            executionResult(
+                                    result(
+                                            102L,
+                                            AutoMatchingProcessStatus.UNMATCHED
+                                    )
+                            )
+                    );
+
+            AutoMatchingExecutionResult result =
+                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            ArgumentCaptor<List<MatchingCandidate>> candidatesCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(autoMatchingService, org.mockito.Mockito.times(2))
+                    .execute(any(), candidatesCaptor.capture());
+
+            assertThat(candidatesCaptor.getAllValues())
+                    .containsExactly(List.of(candidate), List.of());
+            assertThat(result.transactionResults())
+                    .extracting(
+                            AutoMatchingTransactionResult::transactionId,
+                            AutoMatchingTransactionResult::processStatus
+                    )
+                    .containsExactly(
+                            tuple(101L, AutoMatchingProcessStatus.APPLIED),
+                            tuple(102L, AutoMatchingProcessStatus.UNMATCHED)
+                    );
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+            verify(bankTransactionService).updateStatus(
+                    102L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.UNMATCHED
+            );
+        }
+
+        @Test
+        @DisplayName("자동매칭 결과별 은행 거래 상태를 변경한다")
+        void updatesBankTransactionStatusByResultStatus() {
+            BankTransactionDTO applied = bankTransaction(
+                    101L,
+                    "Hong Gil Dong"
+            );
+            BankTransactionDTO needsCheck = bankTransaction(
+                    102L,
+                    "Kim Chul Soo"
+            );
+            BankTransactionDTO unmatched = bankTransaction(
+                    103L,
+                    "Lee Young Hee"
+            );
+            BankTransactionDTO failed = bankTransaction(
+                    104L,
+                    "Park Min Soo"
+            );
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(
+                            applied,
+                            needsCheck,
+                            unmatched,
+                            failed
+                    ));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(any(), any()))
+                    .willReturn(List.of(candidate()));
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(
+                            executionResult(
+                                    result(
+                                            101L,
+                                            AutoMatchingProcessStatus.APPLIED
+                                    )
+                            ),
+                            executionResult(
+                                    result(
+                                            102L,
+                                            AutoMatchingProcessStatus.NEEDS_CHECK
+                                    )
+                            ),
+                            executionResult(
+                                    result(
+                                            103L,
+                                            AutoMatchingProcessStatus.UNMATCHED
+                                    )
+                            ),
+                            executionResult(
+                                    result(
+                                            104L,
+                                            AutoMatchingProcessStatus.FAILED
+                                    )
+                            )
+                    );
+
+            bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+            verify(bankTransactionService).updateStatus(
+                    102L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.NEEDS_CHECK
+            );
+            verify(bankTransactionService).updateStatus(
+                    103L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.UNMATCHED
+            );
+            verify(bankTransactionService).updateStatus(
+                    104L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("중복 결과는 자동 반영 상태로 저장한다")
+        void updatesDuplicatedResultAsApplied() {
+            BankTransactionDTO transaction = bankTransaction(
+                    101L,
+                    "Hong Gil Dong"
+            );
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(transaction));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(
+                            LINKED_ACCOUNT_ID,
+                            transaction.getTransactionAt()
+                    ))
+                    .willReturn(List.of(candidate()));
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(executionResult(
+                            result(
+                                    101L,
+                                    AutoMatchingProcessStatus.DUPLICATE
+                            )
+                    ));
+
+            bankMatchingService.execute(LINKED_ACCOUNT_ID);
+
+            verify(bankTransactionService).updateStatus(
+                    101L,
+                    BankTransactionProcessingStatus.PENDING,
+                    BankTransactionProcessingStatus.APPLIED
+            );
+        }
+
+        @Test
+        @DisplayName("상태 변경 실패 예외는 그대로 전파한다")
+        void propagatesStatusUpdateFailure() {
+            BankTransactionDTO transaction = bankTransaction(
+                    101L,
+                    "Hong Gil Dong"
+            );
+
+            given(bankTransactionService
+                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                    .willReturn(List.of(transaction));
+            given(paymentObligationMapper
+                    .findMatchCandidatesByLinkedAccountId(
+                            LINKED_ACCOUNT_ID,
+                            transaction.getTransactionAt()
+                    ))
+                    .willReturn(List.of(candidate()));
+            given(autoMatchingService.execute(any(), any()))
+                    .willReturn(executionResult(
+                            result(101L, AutoMatchingProcessStatus.FAILED)
+                    ));
+            willThrow(BankTransactionErrorCode
+                    .BANK_TRANSACTION_STATUS_UPDATE_FAILED
+                    .toException())
+                    .given(bankTransactionService)
+                    .updateStatus(
+                            101L,
+                            BankTransactionProcessingStatus.PENDING,
+                            BankTransactionProcessingStatus.FAILED
+                    );
+
+            assertThatThrownBy(
+                    () -> bankMatchingService.execute(LINKED_ACCOUNT_ID)
+            ).isInstanceOf(DomainException.class);
+        }
+
+        @Test
+        @DisplayName("연결 계좌 ID가 올바르지 않으면 예외가 발생한다")
+        void throwsExceptionWhenLinkedAccountIdIsInvalid() {
+            assertThatThrownBy(() -> bankMatchingService.execute(0L))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(
+                                            MatchingErrorCode
+                                                    .INVALID_MATCHING_REQUEST
+                                    )
+                    );
+        }
+    }
+
+    private BankTransactionDTO bankTransaction(
+            Long bankTransactionId,
+            String counterpartyName
+    ) {
+        return bankTransaction(
+                bankTransactionId,
+                counterpartyName,
+                LocalDateTime.of(2026, 8, 5, 10, 0)
+        );
+    }
+
+    private BankTransactionDTO bankTransaction(
+            Long bankTransactionId,
+            String counterpartyName,
+            LocalDateTime transactionAt
+    ) {
+        return BankTransactionDTO.builder()
+                .bankTransactionId(bankTransactionId)
+                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .externalTransactionId("external-" + bankTransactionId)
+                .amount(new BigDecimal("10000.00"))
+                .transactionType(BankTransactionType.DEPOSIT)
+                .processingStatus(BankTransactionProcessingStatus.PENDING)
+                .transactionAt(transactionAt)
+                .counterpartyName(counterpartyName)
+                .syncedAt(LocalDateTime.of(2026, 8, 5, 10, 5))
+                .build();
+    }
+
+    private MatchingCandidate candidate() {
+        return new MatchingCandidate(
+                MatchingTargetType.SETTLEMENT,
+                1L,
+                1L,
+                "Hong Gil Dong",
+                new BigDecimal("10000.00")
+        );
+    }
+
+    private AutoMatchingTransactionResult result(
+            Long transactionId,
+            AutoMatchingProcessStatus processStatus
+    ) {
+        return new AutoMatchingTransactionResult(
+                transactionId,
+                processStatus
+        );
+    }
+
+    private AutoMatchingExecutionResult executionResult(
+            AutoMatchingTransactionResult... transactionResults
+    ) {
+        int appliedCount = 0;
+        int needsCheckCount = 0;
+        int unmatchedCount = 0;
+        int duplicateCount = 0;
+        int failedCount = 0;
+
+        for (AutoMatchingTransactionResult transactionResult
+                : transactionResults) {
+            switch (transactionResult.processStatus()) {
+                case APPLIED -> appliedCount++;
+                case NEEDS_CHECK -> needsCheckCount++;
+                case UNMATCHED -> unmatchedCount++;
+                case DUPLICATE -> duplicateCount++;
+                case FAILED -> failedCount++;
+            }
+        }
+
+        return new AutoMatchingExecutionResult(
+                transactionResults.length,
+                appliedCount,
+                needsCheckCount,
+                unmatchedCount,
+                duplicateCount,
+                failedCount,
+                List.of(transactionResults)
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/MatchingTransactionTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/MatchingTransactionTest.java
@@ -10,6 +10,7 @@ import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,7 +30,8 @@ class MatchingTransactionTest {
                             null,
                             AutoMatchingTransactionType.DEPOSIT,
                             new BigDecimal("10000"),
-                            "HongGilDong"
+                            "HongGilDong",
+                            transactionAt()
                     )
             );
         }
@@ -42,7 +44,8 @@ class MatchingTransactionTest {
                             1L,
                             null,
                             new BigDecimal("10000"),
-                            "HongGilDong"
+                            "HongGilDong",
+                            transactionAt()
                     )
             );
         }
@@ -55,7 +58,8 @@ class MatchingTransactionTest {
                             1L,
                             AutoMatchingTransactionType.DEPOSIT,
                             null,
-                            "HongGilDong"
+                            "HongGilDong",
+                            transactionAt()
                     )
             );
         }
@@ -68,7 +72,8 @@ class MatchingTransactionTest {
                             1L,
                             AutoMatchingTransactionType.DEPOSIT,
                             BigDecimal.ZERO,
-                            "HongGilDong"
+                            "HongGilDong",
+                            transactionAt()
                     )
             );
         }
@@ -81,7 +86,8 @@ class MatchingTransactionTest {
                             1L,
                             AutoMatchingTransactionType.DEPOSIT,
                             new BigDecimal("10000"),
-                            null
+                            null,
+                            transactionAt()
                     )
             );
         }
@@ -94,10 +100,29 @@ class MatchingTransactionTest {
                             1L,
                             AutoMatchingTransactionType.DEPOSIT,
                             new BigDecimal("10000"),
-                            " "
+                            " ",
+                            transactionAt()
                     )
             );
         }
+
+        @Test
+        @DisplayName("거래 시간이 null이면 잘못된 매칭 요청 예외가 발생한다")
+        void failsWhenTransactionAtIsNull() {
+            assertInvalidMatchingRequestThrownBy(
+                    () -> new MatchingTransaction(
+                            1L,
+                            AutoMatchingTransactionType.DEPOSIT,
+                            new BigDecimal("10000"),
+                            "HongGilDong",
+                            null
+                    )
+            );
+        }
+    }
+
+    private LocalDateTime transactionAt() {
+        return LocalDateTime.of(2026, 8, 5, 10, 0);
     }
 
     private void assertInvalidMatchingRequestThrownBy(

--- a/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
@@ -1,0 +1,323 @@
+package org.teamsai.saibackend.domain.payment;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("dev")
+@Sql(scripts = {
+        "/db/user.sql",
+        "/db/linked_bank_account.sql",
+        "/db/settlement.sql",
+        "/db/settlement_invitation.sql",
+        "/db/settlement_participant.sql",
+        "/db/settlement_account.sql",
+        "/db/payment.sql"
+})
+@DisplayName("PaymentObligationMapper 통합 테스트")
+class PaymentObligationMapperTest {
+
+    private static final Long LINKED_ACCOUNT_ID = 9001L;
+    private static final Long OTHER_LINKED_ACCOUNT_ID = 9002L;
+    private static final LocalDateTime MATCHING_TRANSACTION_AT =
+            LocalDateTime.of(2099, 1, 1, 0, 0);
+
+    @Autowired
+    private PaymentObligationMapper paymentObligationMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @Transactional
+    @DisplayName("연결 계좌를 사용하는 진행 중 정산의 유효 매칭 후보를 조회한다")
+    void findMatchCandidatesByLinkedAccountIdReturnsValidCandidates() {
+        insertUser(9101L, "Owner");
+        insertUser(9102L, "Hong Gil Dong");
+        insertUser(9103L, "Kim Chul Soo");
+        insertLinkedAccount(LINKED_ACCOUNT_ID, 9101L);
+        insertLinkedAccount(OTHER_LINKED_ACCOUNT_ID, 9101L);
+
+        insertSettlement(9201L, 9101L, "IN_PROGRESS");
+        insertSettlement(9202L, 9101L, "IN_PROGRESS");
+        insertSettlement(9203L, 9101L, "IN_PROGRESS");
+        insertSettlement(9204L, 9101L, "CLOSED");
+        insertActiveSettlementAccount(9201L, LINKED_ACCOUNT_ID);
+        insertActiveSettlementAccount(9202L, LINKED_ACCOUNT_ID);
+        insertActiveSettlementAccount(9203L, OTHER_LINKED_ACCOUNT_ID);
+        insertActiveSettlementAccount(9204L, LINKED_ACCOUNT_ID);
+
+        insertAcceptedParticipant(9301L, 9201L, 9102L, 9401L, "ACTIVE");
+        insertAcceptedParticipant(9302L, 9202L, 9103L, 9402L, "ACTIVE");
+        insertAcceptedParticipant(9303L, 9203L, 9103L, 9403L, "ACTIVE");
+        insertAcceptedParticipant(9304L, 9204L, 9103L, 9404L, "ACTIVE");
+        insertAcceptedParticipant(9305L, 9201L, 9103L, 9405L, "REMOVED");
+
+        insertPaymentObligation(9501L, 9401L, "10000.00", "UNPAID", "ACTIVE");
+        insertPaymentObligation(9502L, 9402L, "20000.00", "PARTIALLY_PAID", "ACTIVE");
+        insertPaymentObligation(9503L, 9403L, "30000.00", "UNPAID", "ACTIVE");
+        insertPaymentObligation(9504L, 9404L, "40000.00", "UNPAID", "ACTIVE");
+        insertPaymentObligation(9505L, 9405L, "50000.00", "UNPAID", "ACTIVE");
+        insertPaymentObligation(9506L, 9401L, "10000.00", "PAID", "ACTIVE");
+        insertPaymentObligation(9507L, 9401L, "10000.00", "UNPAID", "EXCLUDED");
+        insertConfirmedPaymentRecord(9601L, 9502L, "5000.00");
+        insertCancelledPaymentRecord(9602L, 9502L, "3000.00");
+
+        List<MatchingCandidate> result =
+                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                        LINKED_ACCOUNT_ID,
+                        MATCHING_TRANSACTION_AT
+                );
+
+        assertThat(result)
+                .extracting(
+                        MatchingCandidate::targetType,
+                        MatchingCandidate::obligationId,
+                        MatchingCandidate::participantId,
+                        MatchingCandidate::participantName,
+                        candidate -> candidate.remainingAmount()
+                                .stripTrailingZeros()
+                )
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple(
+                                MatchingTargetType.SETTLEMENT,
+                                9501L,
+                                9401L,
+                                "Hong Gil Dong",
+                                new BigDecimal("10000").stripTrailingZeros()
+                        ),
+                        org.assertj.core.groups.Tuple.tuple(
+                                MatchingTargetType.SETTLEMENT,
+                                9502L,
+                                9402L,
+                                "Kim Chul Soo",
+                                new BigDecimal("15000").stripTrailingZeros()
+                        )
+                );
+    }
+
+    private void insertUser(Long userId, String name) {
+        String unique = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                """
+                INSERT INTO users (
+                    user_id,
+                    user_token,
+                    email,
+                    password,
+                    name,
+                    birth_date
+                )
+                VALUES (?, ?, ?, ?, ?, '2000-01-01')
+                """,
+                userId,
+                unique,
+                unique + "@example.com",
+                "password",
+                name
+        );
+    }
+
+    private void insertLinkedAccount(Long linkedAccountId, Long userId) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO linked_bank_account (
+                    linked_account_id,
+                    user_id,
+                    bank_code,
+                    account_number,
+                    account_holder_name,
+                    connection_status,
+                    account_id
+                )
+                VALUES (?, ?, '001', ?, 'Owner', 'AVAILABLE', ?)
+                """,
+                linkedAccountId,
+                userId,
+                "account-" + linkedAccountId,
+                linkedAccountId
+        );
+    }
+
+    private void insertSettlement(
+            Long settlementId,
+            Long ownerId,
+            String settlementStatus
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id,
+                    owner_id,
+                    settlement_type,
+                    settlement_status,
+                    settlement_category,
+                    title,
+                    created_at
+                )
+                VALUES (?, ?, 'SHARED', ?, 'FOOD', ?, NOW())
+                """,
+                settlementId,
+                ownerId,
+                settlementStatus,
+                "settlement-" + settlementId
+        );
+    }
+
+    private void insertActiveSettlementAccount(
+            Long settlementId,
+            Long linkedAccountId
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement_account (
+                    settlement_id,
+                    linked_account_id,
+                    account_status,
+                    selected_at
+                )
+                VALUES (?, ?, 'ACTIVE', NOW())
+                """,
+                settlementId,
+                linkedAccountId
+        );
+    }
+
+    private void insertAcceptedParticipant(
+            Long invitationId,
+            Long settlementId,
+            Long userId,
+            Long participantId,
+            String participantStatus
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement_invitation (
+                    invitation_id,
+                    settlement_id,
+                    user_id,
+                    invitation_status,
+                    invited_at,
+                    accepted_at
+                )
+                VALUES (?, ?, ?, 'ACCEPTED', NOW(), NOW())
+                """,
+                invitationId,
+                settlementId,
+                userId
+        );
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement_participant (
+                    participant_id,
+                    invitation_id,
+                    participant_role,
+                    participant_status,
+                    joined_at
+                )
+                VALUES (?, ?, 'MEMBER', ?, NOW())
+                """,
+                participantId,
+                invitationId,
+                participantStatus
+        );
+    }
+
+    private void insertPaymentObligation(
+            Long obligationId,
+            Long participantId,
+            String expectedAmount,
+            String paymentStatus,
+            String obligationStatus
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO payment_obligation (
+                    payment_obligation_id,
+                    participant_id,
+                    expected_amount,
+                    payment_status,
+                    review_status,
+                    obligation_status
+                )
+                VALUES (?, ?, ?, ?, 'NORMAL', ?)
+                """,
+                obligationId,
+                participantId,
+                new BigDecimal(expectedAmount),
+                paymentStatus,
+                obligationStatus
+        );
+    }
+
+    private void insertConfirmedPaymentRecord(
+            Long paymentRecordId,
+            Long obligationId,
+            String amount
+    ) {
+        insertPaymentRecord(
+                paymentRecordId,
+                obligationId,
+                amount,
+                "CONFIRMED"
+        );
+    }
+
+    private void insertCancelledPaymentRecord(
+            Long paymentRecordId,
+            Long obligationId,
+            String amount
+    ) {
+        insertPaymentRecord(
+                paymentRecordId,
+                obligationId,
+                amount,
+                "CANCELLED"
+        );
+    }
+
+    private void insertPaymentRecord(
+            Long paymentRecordId,
+            Long obligationId,
+            String amount,
+            String recordStatus
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO payment_record (
+                    payment_record_id,
+                    bank_transaction_id,
+                    obligation_id,
+                    amount,
+                    source_type,
+                    record_status,
+                    recorded_at
+                )
+                VALUES (?, ?, ?, ?, 'AUTO_MATCH', ?, NOW())
+                """,
+                paymentRecordId,
+                paymentRecordId,
+                obligationId,
+                new BigDecimal(amount),
+                recordStatus
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionMapperTest.java
@@ -22,12 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("BankTransactionMapper 통합 테스트")
 @ActiveProfiles("dev")
 @Sql(scripts = "/db/transaction.sql")
-@DisplayName("BankTransactionMapper 통합 테스트")
 class BankTransactionMapperTest {
 
     private static final Long LINKED_ACCOUNT_ID = 1L;
+    private static final Long OTHER_LINKED_ACCOUNT_ID = 2L;
 
     @Autowired
     private BankTransactionMapper bankTransactionMapper;
@@ -116,6 +117,14 @@ class BankTransactionMapperTest {
 
         assertThat(updatedCount).isEqualTo(1);
         assertThat(staleUpdatedCount).isZero();
+
+        BankTransactionDTO savedTransaction =
+                bankTransactionMapper.findById(
+                        bankTransaction.getBankTransactionId()
+                ).orElseThrow();
+
+        assertThat(savedTransaction.getProcessingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.APPLIED);
     }
 
     @Test
@@ -170,18 +179,149 @@ class BankTransactionMapperTest {
                 );
     }
 
+    @Test
+    @Transactional
+    @DisplayName("입금자명이 없거나 공백이어도 연결 계좌 기준 처리 대기 입금 거래로 조회한다")
+    void findPendingDepositsByLinkedAccountIdIncludesNullOrBlankCounterpartyName() {
+        BankTransactionDTO nullCounterpartyName = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0),
+                null
+        );
+        BankTransactionDTO blankCounterpartyName = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 11, 0),
+                " "
+        );
+
+        bankTransactionMapper.insertOrGetId(nullCounterpartyName);
+        bankTransactionMapper.insertOrGetId(blankCounterpartyName);
+
+        List<BankTransactionDTO> result =
+                bankTransactionMapper.findPendingDepositsByLinkedAccountId(
+                        LINKED_ACCOUNT_ID
+                );
+
+        assertThat(result)
+                .extracting(BankTransactionDTO::getBankTransactionId)
+                .contains(
+                        nullCounterpartyName.getBankTransactionId(),
+                        blankCounterpartyName.getBankTransactionId()
+                );
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("연결 계좌 기준 처리 대기 입금 거래만 거래 시각과 ID 순서로 조회한다")
+    void findPendingDepositsByLinkedAccountIdReturnsOnlyMatchingAccountDeposits() {
+        BankTransactionDTO laterDeposit = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 11, 0)
+        );
+        BankTransactionDTO earlierDeposit = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 10, 0)
+        );
+        BankTransactionDTO otherAccountDeposit = transaction(
+                OTHER_LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 9, 0)
+        );
+        BankTransactionDTO withdrawal = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.WITHDRAWAL,
+                LocalDateTime.of(2026, 8, 4, 8, 0)
+        );
+        BankTransactionDTO appliedDeposit = transaction(
+                LINKED_ACCOUNT_ID,
+                uniqueExternalTransactionId(),
+                BankTransactionType.DEPOSIT,
+                LocalDateTime.of(2026, 8, 4, 7, 0)
+        );
+
+        bankTransactionMapper.insertOrGetId(laterDeposit);
+        bankTransactionMapper.insertOrGetId(earlierDeposit);
+        bankTransactionMapper.insertOrGetId(otherAccountDeposit);
+        bankTransactionMapper.insertOrGetId(withdrawal);
+        bankTransactionMapper.insertOrGetId(appliedDeposit);
+        bankTransactionMapper.updateStatus(
+                appliedDeposit.getBankTransactionId(),
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.APPLIED
+        );
+
+        List<BankTransactionDTO> result =
+                bankTransactionMapper.findPendingDepositsByLinkedAccountId(
+                        LINKED_ACCOUNT_ID
+                );
+
+        assertThat(result)
+                .extracting(BankTransactionDTO::getBankTransactionId)
+                .containsSubsequence(
+                        earlierDeposit.getBankTransactionId(),
+                        laterDeposit.getBankTransactionId()
+                );
+        assertThat(result)
+                .extracting(BankTransactionDTO::getBankTransactionId)
+                .doesNotContain(
+                        otherAccountDeposit.getBankTransactionId(),
+                        withdrawal.getBankTransactionId(),
+                        appliedDeposit.getBankTransactionId()
+                );
+    }
+
     private BankTransactionDTO transaction(
             String externalTransactionId,
             BankTransactionType transactionType,
             LocalDateTime transactionAt
     ) {
+        return transaction(
+                LINKED_ACCOUNT_ID,
+                externalTransactionId,
+                transactionType,
+                transactionAt
+        );
+    }
+
+    private BankTransactionDTO transaction(
+            Long linkedAccountId,
+            String externalTransactionId,
+            BankTransactionType transactionType,
+            LocalDateTime transactionAt
+    ) {
+        return transaction(
+                linkedAccountId,
+                externalTransactionId,
+                transactionType,
+                transactionAt,
+                "Hong Gil Dong"
+        );
+    }
+
+    private BankTransactionDTO transaction(
+            Long linkedAccountId,
+            String externalTransactionId,
+            BankTransactionType transactionType,
+            LocalDateTime transactionAt,
+            String counterpartyName
+    ) {
         return BankTransactionDTO.builder()
-                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .linkedAccountId(linkedAccountId)
                 .externalTransactionId(externalTransactionId)
                 .amount(new BigDecimal("10000.00"))
                 .transactionType(transactionType)
                 .transactionAt(transactionAt)
-                .counterpartyName("Hong Gil Dong")
+                .counterpartyName(counterpartyName)
                 .memo("deposit")
                 .syncedAt(LocalDateTime.of(2026, 8, 4, 12, 0))
                 .build();

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -148,6 +148,25 @@ class BankTransactionServiceTest {
 
             assertThat(result).containsExactly(bankTransaction);
         }
+
+        @Test
+        @DisplayName("연결 계좌 기준 처리 대기 입금 거래 목록을 반환한다")
+        void returnsPendingDepositTransactionsByLinkedAccountId() {
+            BankTransactionDTO bankTransaction =
+                    transaction(BANK_TRANSACTION_ID);
+
+            given(bankTransactionMapper.findPendingDepositsByLinkedAccountId(
+                    LINKED_ACCOUNT_ID
+            )).willReturn(List.of(bankTransaction));
+
+            List<BankTransactionDTO> result =
+                    bankTransactionService
+                            .findPendingDepositsByLinkedAccountId(
+                                    LINKED_ACCOUNT_ID
+                            );
+
+            assertThat(result).containsExactly(bankTransaction);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #48 

## 🛠 작업 사항

### 자동매칭 실행 기반 추가

- 연결 계좌 기준 PENDING 입금 거래 조회 구현
- 연결 계좌 기준 IN_PROGRESS 정산의 자동매칭 후보 조회 구현
- BankMatchingService 추가
  - linkedAccountId 기준 자동매칭 실행
  - 입금자명이 null 또는 blank인 거래는 NEEDS_CHECK 처리
  - 자동매칭 결과에 따라 bank_transaction.processing_status 변경
- AutoMatchingExecutionResult에 거래별 실행 결과 목록 추가

### 정산 계좌 관리

- settlement_account 테이블 추가
  - 정산별 연결 계좌 이력 관리
  - ACTIVE, REPLACED, DISABLED 상태 관리

## ✅ 테스트

- [ ] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 자동매칭은 settlementId가 아닌 linkedAccountId 기준으로 수행됩니다.
- 같은 연결 계좌를 사용하는 모든 IN_PROGRESS 정산을 자동매칭 후보로 조회합니다.
- counterpartyName이 null 또는 blank인 거래는 자동 판정이 불가능하므로 NEEDS_CHECK로 처리합니다.
- settlement_account 생성·수정 API는 이번 PR 범위에 포함하지 않습니다.
- linkedAccountId 권한 검증은 호출 계층에서 처리합니다.
- FAILED 거래의 재처리 정책은 별도 작업에서 다룰 예정입니다.
- 현재 전체 테스트 실행 시 기존 context/file/auth/user 관련 실패가 존재하여, 이번 변경 범위의 테스트만 별도로 검증했습니다.
- 거래 처리 상태는 아래 정책에 따라 변경됩니다.

### 상태 매핑 정책
- APPLIED → APPLIED
- DUPLICATE → APPLIED
- NEEDS_CHECK → NEEDS_CHECK
- UNMATCHED → UNMATCHED
- FAILED → FAILED