### PR TITLE
feat(#54): 계약서 상세 조회 화면 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
@@ -28,10 +28,6 @@ public class ContractChangeRequest {
     private BigDecimal newInterestRate;
 
     @NotBlank(message = "상환 방식은 필수입니다.")
-    @Pattern(
-            regexp = "EQUAL_PRINCIPAL_AND_INTEREST|EQUAL_PRINCIPAL|BULLET_REPAYMENT",
-            message = "상환 방식이 올바르지 않습니다."
-    )
     private String newRepaymentType;
 
     @NotNull(message = "변경 상환일은 필수입니다.")

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -29,6 +28,10 @@ public class ContractChangeRequest {
     private BigDecimal newInterestRate;
 
     @NotBlank(message = "상환 방식은 필수입니다.")
+    @Pattern(
+            regexp = "EQUAL_PRINCIPAL_AND_INTEREST|EQUAL_PRINCIPAL|BULLET_REPAYMENT",
+            message = "상환 방식이 올바르지 않습니다."
+    )
     private String newRepaymentType;
 
     @NotNull(message = "변경 상환일은 필수입니다.")

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailController.java
@@ -1,0 +1,25 @@
+package org.teamsai.saibackend.domain.contractdetail.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
+import org.teamsai.saibackend.domain.contractdetail.service.ContractDetailService;
+
+@RestController
+@RequestMapping("/api/contracts")
+@RequiredArgsConstructor
+public class ContractDetailController {
+
+    private final ContractDetailService contractDetailService;
+
+
+    @GetMapping("/{contractId}/contract-detail")
+    public ContractDetailResponse responseDetail(
+            @PathVariable Long contractId,
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        return contractDetailService.getCheck(contractId, userId);
+    }
+}
+

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
@@ -1,12 +1,11 @@
 package org.teamsai.saibackend.domain.contractdetail.controller;
 
-import org.springframework.ui.Model;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
 import org.teamsai.saibackend.domain.contractdetail.service.ContractDetailService;
 
 @Controller
@@ -21,9 +20,9 @@ public class ContractDetailPageController {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             Model model
     ) {
-       ContractDetailResponse result = contractDetailService.getCheck(contractId, userId);
+        boolean canRequestChange = contractDetailService.canRequestChange(contractId, userId);
        model.addAttribute("contractId", contractId);
-       model.addAttribute("canRequestChange", result.isCanRequestChange());
+       model.addAttribute("canRequestChange", canRequestChange);
        return "contractdetail/detail";
 
     }

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
@@ -24,7 +24,7 @@ public class ContractDetailPageController {
        ContractDetailResponse result = contractDetailService.getCheck(contractId, userId);
        model.addAttribute("contractId", contractId);
        model.addAttribute("canRequestChange", result.isCanRequestChange());
-       return "contractdetail/response";
+       return "contractdetail/detail";
 
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/controller/ContractDetailPageController.java
@@ -1,0 +1,30 @@
+package org.teamsai.saibackend.domain.contractdetail.controller;
+
+import org.springframework.ui.Model;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
+import org.teamsai.saibackend.domain.contractdetail.service.ContractDetailService;
+
+@Controller
+@RequiredArgsConstructor
+public class ContractDetailPageController {
+
+    private final ContractDetailService contractDetailService;
+
+    @GetMapping("/contracts/{contractId}/contract-detail")
+    public String detailResponsePage(
+            @PathVariable Long contractId,
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            Model model
+    ) {
+       ContractDetailResponse result = contractDetailService.getCheck(contractId, userId);
+       model.addAttribute("contractId", contractId);
+       model.addAttribute("canRequestChange", result.isCanRequestChange());
+       return "contractdetail/response";
+
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/dto/response/ContractDetailResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/dto/response/ContractDetailResponse.java
@@ -1,0 +1,13 @@
+package org.teamsai.saibackend.domain.contractdetail.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+
+@Getter@Builder
+
+public class ContractDetailResponse {
+
+   private LoanContractResponse contract;
+   private boolean canRequestChange;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/dto/response/ContractDetailResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/dto/response/ContractDetailResponse.java
@@ -10,4 +10,5 @@ public class ContractDetailResponse {
 
    private LoanContractResponse contract;
    private boolean canRequestChange;
+   private String address;
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
@@ -1,0 +1,25 @@
+package org.teamsai.saibackend.domain.contractdetail.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
+import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
+
+@Service
+@RequiredArgsConstructor
+public class ContractDetailService {
+
+    private final LoanContractService loanContractService;
+
+    public ContractDetailResponse getCheck(Long contractId, Long userId){
+        LoanContractResponse contract = loanContractService.findContract(contractId, userId);
+
+        boolean canRequestChange = contract.getCreditorId().equals(userId);
+
+        return ContractDetailResponse.builder()
+                .contract(contract)
+                .canRequestChange(canRequestChange)
+                .build();
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
@@ -12,14 +12,25 @@ public class ContractDetailService {
 
     private final LoanContractService loanContractService;
 
+    public boolean canRequestChange(Long contractId, Long userID) {
+        LoanContractResponse contract = loanContractService.findContract(contractId, userID);
+        return contract.getCreditorId().equals(userID);
+    }
+
+
     public ContractDetailResponse getCheck(Long contractId, Long userId){
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
         boolean canRequestChange = contract.getCreditorId().equals(userId);
 
+        String address = canRequestChange
+                ? contract.getCreditorAddress()
+                : contract.getDebtorAddress();
+
         return ContractDetailResponse.builder()
                 .contract(contract)
                 .canRequestChange(canRequestChange)
+                .address(address)
                 .build();
     }
 }

--- a/src/main/resources/static/css/contractdetail/contractdetail.css
+++ b/src/main/resources/static/css/contractdetail/contractdetail.css
@@ -1,0 +1,57 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, "Malgun Gothic", sans-serif;
+    background-color: #f5f6f7;
+    margin: 0;
+    padding: 40px;
+}
+
+.page {
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.page h1 {
+    font-size: 28px;
+}
+
+.page > p {
+    color: #666;
+    margin-bottom: 32px;
+}
+
+.contract-card {
+    background: #FFFFFF;
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.contract-card dl {
+    margin: 0;
+}
+
+.contract-card dt {
+    font-size: 13px;
+    color: #888;
+    margin-top: 16px;
+}
+
+.contract-card dd {
+    font-size: 17px;
+    font-weight: 600;
+    margin: 4px 0 0;
+}
+
+#changeButton {
+    margin-top: 24px;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    background: #0b3d2e;
+    color: white;
+    cursor: pointer;
+}

--- a/src/main/resources/static/js/contractdetail/contractdetail.js
+++ b/src/main/resources/static/js/contractdetail/contractdetail.js
@@ -16,17 +16,18 @@ fetch(`/api/contracts/${contractId}/contract-detail`)
         document.getElementById('maturityDate').textContent = data.contract.maturityDate;
         document.getElementById('repaymentType').textContent = data.contract.repaymentType;
         document.getElementById('repaymentDay').textContent = data.contract.repaymentDay;
-        document.getElementById('address').textContent = data.contract.address;
         document.getElementById('terms').textContent = data.contract.terms;
+        if (canRequestChange) {
+            document.getElementById('address').textContent = data.contract.creditorAddress;
+        } else {
+            document.getElementById('address').textContent = data.contract.debtorAddress;
+        }
     })
     .catch(() => {
         alert('계약 정보를 불러오는 중 오류가 발생했습니다.')
     });
 
-if (!canRequestChange) {
-    document.getElementById('changeButton').style.display = 'none';
 
-}
 
 document.getElementById('changeButton').addEventListener('click', function () {
     window.location.href = `/contracts/${contractId}/change-request`;

--- a/src/main/resources/static/js/contractdetail/contractdetail.js
+++ b/src/main/resources/static/js/contractdetail/contractdetail.js
@@ -17,11 +17,7 @@ fetch(`/api/contracts/${contractId}/contract-detail`)
         document.getElementById('repaymentType').textContent = data.contract.repaymentType;
         document.getElementById('repaymentDay').textContent = data.contract.repaymentDay;
         document.getElementById('terms').textContent = data.contract.terms;
-        if (canRequestChange) {
-            document.getElementById('address').textContent = data.contract.creditorAddress;
-        } else {
-            document.getElementById('address').textContent = data.contract.debtorAddress;
-        }
+        document.getElementById('address').textContent = data.address;
     })
     .catch(() => {
         alert('계약 정보를 불러오는 중 오류가 발생했습니다.')

--- a/src/main/resources/static/js/contractdetail/contractdetail.js
+++ b/src/main/resources/static/js/contractdetail/contractdetail.js
@@ -1,0 +1,33 @@
+const contractId = document.getElementById('contractId').value;
+const canRequestChange = document.getElementById('canRequestChange').value === 'true';
+
+fetch(`/api/contracts/${contractId}/contract-detail`)
+    .then(response => {
+        if(!response.ok) {
+            throw new Error("금전차용계약서 조회 실패")
+        }
+        return response.json();
+    })
+    .then(data => {
+
+        document.getElementById('principalAmount').textContent = data.contract.principalAmount;
+        document.getElementById('interestRate').textContent = data.contract.interestRate;
+        document.getElementById('startDate').textContent = data.contract.startDate;
+        document.getElementById('maturityDate').textContent = data.contract.maturityDate;
+        document.getElementById('repaymentType').textContent = data.contract.repaymentType;
+        document.getElementById('repaymentDay').textContent = data.contract.repaymentDay;
+        document.getElementById('address').textContent = data.contract.address;
+        document.getElementById('terms').textContent = data.contract.terms;
+    })
+    .catch(() => {
+        alert('계약 정보를 불러오는 중 오류가 발생했습니다.')
+    });
+
+if (!canRequestChange) {
+    document.getElementById('changeButton').style.display = 'none';
+
+}
+
+document.getElementById('changeButton').addEventListener('click', function () {
+    window.location.href = `/contracts/${contractId}/change-request`;
+});

--- a/src/main/resources/templates/contractchange/request.html
+++ b/src/main/resources/templates/contractchange/request.html
@@ -27,9 +27,9 @@
             <label for="newRepaymentType">상환 방식</label>
             <select id="newRepaymentType">
                 <option value="">선택해주세요</option>
-                <option value="EQUAL_PRINCIPAL_AND_INTEREST">원리금균등상환</option>
-                <option value="EQUAL_PRINCIPAL">원금균등상환</option>
-                <option value="BULLET_REPAYMENT">만기일시상환</option>
+                <option value="원리금균등상환">원리금균등상환</option>
+                <option value="원금균등상환">원금균등상환</option>
+                <option value="만기일시상환">만기일시상환</option>
             </select>
 
             <label for="newRepaymentDate">상환일 변경</label>

--- a/src/main/resources/templates/contractchange/request.html
+++ b/src/main/resources/templates/contractchange/request.html
@@ -27,13 +27,13 @@
             <label for="newRepaymentType">상환 방식</label>
             <select id="newRepaymentType">
                 <option value="">선택해주세요</option>
-                <option value="원리금균등상환">원리금균등상환</option>
-                <option value="원금균등상환">원금균등상환</option>
-                <option value="만기일시상환">만기일시상환</option>
+                <option value="EQUAL_PRINCIPAL_AND_INTEREST">원리금균등상환</option>
+                <option value="EQUAL_PRINCIPAL">원금균등상환</option>
+                <option value="BULLET_REPAYMENT">만기일시상환</option>
             </select>
 
             <label for="newRepaymentDate">상환일 변경</label>
-            <input type="date" id="newRepaymentDate">
+            <input type="number" id="newRepaymentDate">
 
             <button type="button" id="cancelButton">변경 취소</button>
             <button type="submit" id="submitButton">변경 요청 보내기</button>

--- a/src/main/resources/templates/contractdetail/detail.html
+++ b/src/main/resources/templates/contractdetail/detail.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>금전차용계약서 조회</title>
+    <link rel="stylesheet" th:href="@{/css/contractdetail/contractdetail.css}">
+</head>
+<body>
+<input type="hidden" id="canRequestChange" th:value="${canRequestChange}">
+<input type="hidden" id="contractId" th:value="${contractId}">
+
+<div class="page">
+    <h1>금전차용계약서</h1>
+    <p>최근 체결된 금전차용계약서 입니다.</p>
+
+    <div class="contract-card">
+        <dl>
+            <dt>대출원금</dt><dd id="principalAmount">-</dd>
+            <dt>연이자율</dt><dd id="interestRate">-</dd>
+            <dt>대출시작일</dt><dd id="startDate">-</dd>
+            <dt>만기일</dt><dd id="maturityDate">-</dd>
+            <dt>상환방식</dt><dd id="repaymentType">-</dd>
+            <dt>매월상환일</dt><dd id="repaymentDay">-</dd>
+            <dt>주소</dt><dd id="adress">-</dd>
+            <dt>특약</dt><dd id="terms">-</dd>
+        </dl>
+    </div>
+
+    <button id="changeButton">계약변경</button>
+
+    <script th:src="@{/js/contractdetail/contractdetail.js"></script>
+</div>
+
+
+
+
+
+
+</body>
+</html>

--- a/src/main/resources/templates/contractdetail/detail.html
+++ b/src/main/resources/templates/contractdetail/detail.html
@@ -21,20 +21,17 @@
             <dt>만기일</dt><dd id="maturityDate">-</dd>
             <dt>상환방식</dt><dd id="repaymentType">-</dd>
             <dt>매월상환일</dt><dd id="repaymentDay">-</dd>
-            <dt>주소</dt><dd id="adress">-</dd>
+            <dt>주소</dt><dd id="address">-</dd>
             <dt>특약</dt><dd id="terms">-</dd>
         </dl>
     </div>
 
-    <button id="changeButton">계약변경</button>
 
-    <script th:src="@{/js/contractdetail/contractdetail.js"></script>
 </div>
 
+<button id="changeButton">계약변경</button>
 
-
-
-
+<script th:src="@{/js/contractdetail/contractdetail.js}"></script>
 
 </body>
 </html>

--- a/src/test/java/org/teamsai/saibackend/domain/contractdetail/ContractDetailTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractdetail/ContractDetailTest.java
@@ -1,0 +1,71 @@
+package org.teamsai.saibackend.domain.contractdetail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+import org.teamsai.saibackend.domain.contract.service.contract.LoanContractService;
+import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
+import org.teamsai.saibackend.domain.contractdetail.service.ContractDetailService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContractDetailService 단위 테스트")
+public class ContractDetailTest {
+
+    private static final Long CONTRACT_ID = 1L;
+    private static final Long CREDITOR_ID = 10L;
+    private static final Long DEBTOR_ID = 20L;
+
+    @Mock
+    private LoanContractService loanContractService;
+
+    @InjectMocks
+    private ContractDetailService contractDetailService;
+
+    @Nested
+    @DisplayName("채권자 확인")
+    class GetContract{
+
+        @Test
+        @DisplayName("채권자면 계약 버튼 활성화")
+        void getContractCreditor(){
+            given(loanContractService.findContract(CONTRACT_ID, CREDITOR_ID))
+                    .willReturn(createContract());
+
+            ContractDetailResponse result = contractDetailService.getCheck(CONTRACT_ID, CREDITOR_ID);
+
+            assertThat(result.isCanRequestChange()).isTrue();
+
+        }
+
+        @Test
+        @DisplayName("채무자이면 계약 버튼 비활성화")
+        void getContractDebtor(){
+            given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID))
+                    .willReturn(createContract());
+
+            ContractDetailResponse result = contractDetailService.getCheck(CONTRACT_ID, DEBTOR_ID);
+
+            assertThat(result.isCanRequestChange()).isFalse();
+
+        }
+    }
+
+    private LoanContractResponse createContract() {
+        return LoanContractResponse.builder()
+                .contractId(CONTRACT_ID)
+                .creditorId(CREDITOR_ID)
+                .debtorId(DEBTOR_ID)
+                .build();
+
+    }
+
+
+}


### PR DESCRIPTION
## 🔗 연관 이슈
- 이 PR이 해결하는 이슈: #54

## 🛠 작업 사항
- 계약서 상세 조회 API 구현 (GET /api/contracts/{contractId}/contract-detail)
  - LoanContractService.findContract(contractId, userId) 재사용
  - 로그인한 사용자가 채권자인지 여부(canRequestChange)를 함께 응답
- 계약서 상세 조회 화면(HTML/CSS/JS) 구현
  - 계약서 원문 정보(원금, 이율, 만기일, 상환방식, 상환일, 주소, 특약) 표시
  - "계약변경" 버튼: 채권자면 표시, 채무자면 숨김 처리
  - 버튼 클릭 시 계약변경요청 화면(/contracts/{contractId}/change-request)으로 이동
- 단위 테스트 작성 (채권자/채무자에 따른 canRequestChange 값 검증)

## ✅ 테스트
- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
- LoanContractResponse를 새 DTO로 다시 옮겨 담지 않고, 
  ContractDetailResponse가 그대로 감싸서 응답하는 방식으로 구현했습니다 
  (필드가 대부분 그대로 필요해서, 불필요한 중복을 피하기 위함).
- #36 브랜치와 겹치는 파일이 없어 충돌 없이 병합 가능할 것으로 예상됩니다.