### PR TITLE
feat(#72): 정산 수취 계좌 연결 

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/account/service/LinkedBankAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/account/service/LinkedBankAccountService.java
@@ -106,6 +106,34 @@ public class LinkedBankAccountService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public boolean isOwnedLinkedAccount(
+        Long userId,
+        Long linkedAccountId
+    ) {
+        if (userId == null || linkedAccountId == null) {
+            return false;
+        }
+
+        List<LinkedBankAccountDTO> linkedAccounts =
+            linkedBankAccountMapper
+                .selectLinkedAccountsByUserId(userId);
+
+        if (linkedAccounts == null) {
+            return false;
+        }
+
+        return linkedAccounts.stream()
+            .anyMatch(account ->
+                Objects.equals(
+                    account.getLinkedAccountId(),
+                    linkedAccountId
+                )
+                    && account.getConnectionStatus()
+                    == ConnectionStatus.AVAILABLE
+            );
+    }
+
     private List<LinkedBankAccountDTO> insertAllSkippingDuplicates(List<LinkedBankAccountDTO> candidates) {
         List<LinkedBankAccountDTO> savedDtos = new ArrayList<>();
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementAccountController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementAccountController.java
@@ -1,0 +1,120 @@
+package org.teamsai.saibackend.domain.settlement.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.teamsai.saibackend.domain.settlement.dto.request.SelectSettlementAccountRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementAccountResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementAccountService;
+
+@Tag(
+        name = "정산 계좌 API",
+        description = "정산 수취 계좌 설정 및 조회 API"
+)
+@Controller
+@RequiredArgsConstructor
+public class SettlementAccountController {
+
+    private final SettlementAccountService
+            settlementAccountService;
+
+    @Operation(
+            summary = "정산 수취 계좌 설정",
+            description = """
+                    사용자가 연동한 계좌 중 하나를
+                    해당 정산의 수취 계좌로 설정합니다.
+                    기존 수취 계좌가 있으면 새 계좌로 변경합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "정산 수취 계좌 설정 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "사용할 수 없는 연동 계좌"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "정산 계좌 설정 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "정산을 찾을 수 없음"
+            )
+    })
+    @ResponseBody
+    @PutMapping(
+            "/api/settlements/{settlementId}/account"
+    )
+    public ResponseEntity<SettlementAccountResponse>
+    selectAccount(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(
+                    expression = "userId"
+            )
+            Long userId,
+
+            @PathVariable("settlementId")
+            Long settlementId,
+
+            @Valid
+            @RequestBody
+            SelectSettlementAccountRequest request
+    ) {
+        SettlementAccountResponse response =
+                settlementAccountService
+                        .selectAccount(
+                                userId,
+                                settlementId,
+                                request
+                        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "현재 정산 수취 계좌 조회"
+    )
+    @ResponseBody
+    @GetMapping(
+            "/api/settlements/{settlementId}/account"
+    )
+    public ResponseEntity<SettlementAccountResponse>
+    findCurrentAccount(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(
+                    expression = "userId"
+            )
+            Long userId,
+
+            @PathVariable("settlementId")
+            Long settlementId
+    ) {
+        SettlementAccountResponse response =
+                settlementAccountService
+                        .findCurrentAccount(
+                                userId,
+                                settlementId
+                        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementAccountController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementAccountController.java
@@ -84,7 +84,7 @@ public class SettlementAccountController {
                         .selectAccount(
                                 userId,
                                 settlementId,
-                                request
+                                request.getLinkedAccountId()
                         );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementAccountDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/SettlementAccountDTO.java
@@ -1,0 +1,23 @@
+package org.teamsai.saibackend.domain.settlement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementAccountDTO {
+
+    private Long settlementAccountId;
+    private Long settlementId;
+    private Long linkedAccountId;
+    private SettlementAccountStatus accountStatus;
+    private LocalDateTime selectedAt;
+    private LocalDateTime endedAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateSharedSettlementRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateSharedSettlementRequest.java
@@ -33,6 +33,9 @@ public class CreateSharedSettlementRequest {
     @Digits(integer = 13, fraction = 0, message = "총 금액은 원 단위로 입력해 주세요.")
     private BigDecimal totalAmount;
 
+    @NotNull(message = "정산 수취 계좌를 선택해 주세요.")
+    private Long linkedAccountId;
+
 
     @Valid
     @NotEmpty(message = "납부자를 한 명 이상 선택해 주세요.")

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/SelectSettlementAccountRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/SelectSettlementAccountRequest.java
@@ -1,0 +1,17 @@
+package org.teamsai.saibackend.domain.settlement.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectSettlementAccountRequest {
+
+    @NotNull(message = "정산 수취 계좌를 선택해 주세요.")
+    private Long linkedAccountId;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementAccountResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementAccountResponse.java
@@ -1,0 +1,28 @@
+package org.teamsai.saibackend.domain.settlement.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
+import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SettlementAccountResponse {
+    private Long settlementAccountId;
+    private Long settlementId;
+    private Long linkedAccountId;
+    private SettlementAccountStatus accountStatus;
+    private LocalDateTime selectedAt;
+
+    public static SettlementAccountResponse from(SettlementAccountDTO account){
+        return SettlementAccountResponse.builder()
+                .settlementAccountId(account.getSettlementAccountId())
+                .settlementId(account.getSettlementId())
+                .linkedAccountId(account.getLinkedAccountId())
+                .accountStatus(account.getAccountStatus())
+                .selectedAt(account.getSelectedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/exception/SettlementErrorCode.java
@@ -87,7 +87,26 @@ public enum SettlementErrorCode implements BaseErrorCode<DomainException> {
     SETTLEMENT_PARTICIPANT_STATUS_UPDATE_FAILED(
             HttpStatus.BAD_REQUEST,
             "참여자 상태 변경에 실패했습니다."
+    ),SETTLEMENT_ACCOUNT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "정산 수취 계좌가 설정되어 있지 않습니다."
+    ),
+
+    INVALID_SETTLEMENT_ACCOUNT(
+            HttpStatus.BAD_REQUEST,
+            "본인에게 연동된 계좌만 정산 수취 계좌로 설정할 수 있습니다."
+    ),
+
+    SETTLEMENT_ACCOUNT_CREATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "정산 수취 계좌 설정에 실패했습니다."
+    ),
+
+    SETTLEMENT_ACCOUNT_UPDATE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "정산 수취 계좌 변경에 실패했습니다."
     );
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementAccountMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementAccountMapper.java
@@ -1,0 +1,25 @@
+package org.teamsai.saibackend.domain.settlement.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
+import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Mapper
+public interface SettlementAccountMapper {
+
+    int insert(SettlementAccountDTO settlementAccount);
+
+    Optional<SettlementAccountDTO> findActiveBySettlementId(Long settlementId);
+
+    Optional<SettlementAccountDTO> findActiveBySettlementIdForUpdate(Long settlementId);
+
+    int updateStatus(
+            @Param("settlementAccountId") Long settlementAccountId,
+            @Param("accountStatus")SettlementAccountStatus accountStatus,
+            @Param("endedAt")LocalDateTime endedAt
+            );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
@@ -1,0 +1,101 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.SelectSettlementAccountRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementAccountResponse;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementAccountMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementAccountService {
+
+    private final SettlementMapper settlementMapper;
+    private final SettlementAccountMapper settlementAccountMapper;
+    private final LinkedBankAccountService linkedBankAccountService;
+
+    @Transactional
+    public SettlementAccountResponse selectAccount(Long userId, Long settlementId, SelectSettlementAccountRequest request){
+
+        SettlementDTO settlement = findSettlement(settlementId);
+
+        validatorOwner(settlement, userId);
+        validateLinkedAccountOwner(userId, request.getLinkedAccountId());
+
+        Optional<SettlementAccountDTO> currentAccount = settlementAccountMapper.findActiveBySettlementIdForUpdate(settlementId);
+
+        if(currentAccount.isPresent() && currentAccount.get().getLinkedAccountId().equals(request.getLinkedAccountId())){
+            return SettlementAccountResponse.from(currentAccount.get());
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        currentAccount.ifPresent(account-> replaceCurrentAccount(account,now));
+
+        SettlementAccountDTO newAccount = SettlementAccountDTO.builder()
+                .settlementId(settlementId)
+                .linkedAccountId(request.getLinkedAccountId())
+                .accountStatus(SettlementAccountStatus.ACTIVE)
+                .selectedAt(now)
+                .endedAt(null)
+                .build();
+
+        int insertedCount = settlementAccountMapper.insert(newAccount);
+
+        if(insertedCount != 1){
+            throw SettlementErrorCode.SETTLEMENT_ACCOUNT_CREATE_FAILED.toException();
+        }
+
+        return SettlementAccountResponse.from(newAccount);
+
+    }
+
+    private void validateLinkedAccountOwner(Long userId, Long linkedAccountId
+    ) {
+        if (!linkedBankAccountService.isOwnedLinkedAccount(userId, linkedAccountId)) {
+            throw SettlementErrorCode.INVALID_SETTLEMENT_ACCOUNT.toException();
+        }
+    }
+
+    private void validatorOwner(SettlementDTO settlement, Long userId) {
+        if(!settlement.getOwnerId().equals(userId)){
+            throw SettlementErrorCode.SETTLEMENT_ACCESS_DENIED.toException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public SettlementAccountResponse findCurrentAccount(Long userId, Long settlementId){
+        SettlementDTO settlement = findSettlement(settlementId);
+
+        validatorOwner(settlement,userId);
+
+        SettlementAccountDTO account = settlementAccountMapper.findActiveBySettlementId(settlementId)
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_ACCOUNT_NOT_FOUND::toException);
+
+        return SettlementAccountResponse.from(account);
+    }
+
+
+    private SettlementDTO findSettlement(Long settlementId){
+        return settlementMapper.findById(settlementId).orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+    }
+
+    private void replaceCurrentAccount(SettlementAccountDTO account, LocalDateTime endedAt){
+        int updatedCount = settlementAccountMapper.updateStatus(account.getSettlementAccountId(), SettlementAccountStatus.REPLACED,endedAt);
+
+        if(updatedCount != 1){
+            throw SettlementErrorCode.SETTLEMENT_ACCOUNT_UPDATE_FAILED.toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
-import org.teamsai.saibackend.domain.settlement.dto.request.SelectSettlementAccountRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.SettlementAccountResponse;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementAccountMapper;
@@ -14,7 +13,6 @@ import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -26,16 +24,16 @@ public class SettlementAccountService {
     private final LinkedBankAccountService linkedBankAccountService;
 
     @Transactional
-    public SettlementAccountResponse selectAccount(Long userId, Long settlementId, SelectSettlementAccountRequest request){
+    public SettlementAccountResponse selectAccount(Long userId, Long settlementId, Long linkedAccountId){
 
         SettlementDTO settlement = findSettlement(settlementId);
 
         validatorOwner(settlement, userId);
-        validateLinkedAccountOwner(userId, request.getLinkedAccountId());
+        validateLinkedAccountOwner(userId, linkedAccountId);
 
         Optional<SettlementAccountDTO> currentAccount = settlementAccountMapper.findActiveBySettlementIdForUpdate(settlementId);
 
-        if(currentAccount.isPresent() && currentAccount.get().getLinkedAccountId().equals(request.getLinkedAccountId())){
+        if(currentAccount.isPresent() && currentAccount.get().getLinkedAccountId().equals(linkedAccountId)){
             return SettlementAccountResponse.from(currentAccount.get());
         }
 
@@ -45,7 +43,7 @@ public class SettlementAccountService {
 
         SettlementAccountDTO newAccount = SettlementAccountDTO.builder()
                 .settlementId(settlementId)
-                .linkedAccountId(request.getLinkedAccountId())
+                .linkedAccountId(linkedAccountId)
                 .accountStatus(SettlementAccountStatus.ACTIVE)
                 .selectedAt(now)
                 .endedAt(null)

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SharedSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SharedSettlementService.java
@@ -28,6 +28,7 @@ public class SharedSettlementService {
 
     private final SettlementMapper settlementMapper;
     private final SettlementInvitationService invitationService;
+    private final SettlementAccountService settlementAccountService;
 
     @Transactional
     public CreateSharedSettlementResponse create(
@@ -78,6 +79,10 @@ public class SharedSettlementService {
                 settlement.getSettlementId(),
                 request.getInvitations(),
                 perPersonAmount
+        );
+
+        settlementAccountService.selectAccount(
+            ownerId,settlement.getSettlementId(),request.getLinkedAccountId()
         );
 
         return CreateSharedSettlementResponse.builder()

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementAccountStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/type/SettlementAccountStatus.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.settlement.type;
+
+public enum SettlementAccountStatus {
+    ACTIVE,
+    REPLACED,
+    DISABLED
+}

--- a/src/main/resources/mapper/settlement/SettlementAccountMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementAccountMapper.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementAccountMapper">
+
+    <resultMap
+            id="SettlementAccountResultMap"
+            type="org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO">
+
+        <id
+                property="settlementAccountId"
+                column="settlement_account_id"
+        />
+
+        <result
+                property="settlementId"
+                column="settlement_id"
+        />
+
+        <result
+                property="linkedAccountId"
+                column="linked_account_id"
+        />
+
+        <result
+                property="accountStatus"
+                column="account_status"
+        />
+
+        <result
+                property="selectedAt"
+                column="selected_at"
+        />
+
+        <result
+                property="endedAt"
+                column="ended_at"
+        />
+
+    </resultMap>
+
+
+    <insert
+            id="insert"
+            useGeneratedKeys="true"
+            keyProperty="settlementAccountId">
+
+        INSERT INTO settlement_account (
+        settlement_id,
+        linked_account_id,
+        account_status,
+        selected_at,
+        ended_at
+        )
+        VALUES (
+        #{settlementId},
+        #{linkedAccountId},
+        #{accountStatus},
+        #{selectedAt},
+        #{endedAt}
+        )
+
+    </insert>
+
+
+    <select
+            id="findActiveBySettlementId"
+            resultMap="SettlementAccountResultMap">
+
+        SELECT
+        settlement_account_id,
+        settlement_id,
+        linked_account_id,
+        account_status,
+        selected_at,
+        ended_at
+        FROM settlement_account
+        WHERE settlement_id = #{settlementId}
+        AND account_status = 'ACTIVE'
+        AND ended_at IS NULL
+
+    </select>
+
+
+    <select
+            id="findActiveBySettlementIdForUpdate"
+            resultMap="SettlementAccountResultMap">
+
+        SELECT
+        settlement_account_id,
+        settlement_id,
+        linked_account_id,
+        account_status,
+        selected_at,
+        ended_at
+        FROM settlement_account
+        WHERE settlement_id = #{settlementId}
+        AND account_status = 'ACTIVE'
+        AND ended_at IS NULL
+        FOR UPDATE
+
+    </select>
+
+
+    <update id="updateStatus">
+
+        UPDATE settlement_account
+        SET
+        account_status = #{accountStatus},
+        ended_at = #{endedAt}
+        WHERE settlement_account_id =
+        #{settlementAccountId}
+        AND account_status = 'ACTIVE'
+
+    </update>
+
+</mapper>

--- a/src/main/resources/static/js/settlement/settlement-create.js
+++ b/src/main/resources/static/js/settlement/settlement-create.js
@@ -366,12 +366,19 @@ document.addEventListener("DOMContentLoaded", () => {
             settlementCategory: categorySelect.value,
             title: titleInput.value.trim(),
             dueDate: dueDateInput.value,
-            totalAmount: rawTotalAmount ? Number(rawTotalAmount) : null,
-            invitations: Array.from(selectedParticipants.values()).map(
-                (participant) => ({
-                    userToken: participant.userToken
-                })
-            )
+            totalAmount: rawTotalAmount
+                ? Number(rawTotalAmount)
+                : null,
+
+            linkedAccountId: settlementAccountSelect.value
+                ? Number(settlementAccountSelect.value)
+                : null,
+
+            invitations:
+                Array.from(selectedParticipants.values())
+                    .map((participant) => ({
+                        userToken: participant.userToken
+                    }))
         };
 
         if (!validate(payload)) {
@@ -416,13 +423,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 );
             }
 
-            await selectSettlementAccount(
-                responseBody.settlementId,
-                Number(settlementAccountSelect.value),
-                token
-            );
-
-
             const recentSettlement = {
                 ...responseBody,
                 settlementCategory:
@@ -432,10 +432,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 totalAmount: payload.totalAmount,
                 participantCount:
                     payload.invitations.length + 1,
-                linkedAccountId:
-                    Number(
-                        settlementAccountSelect.value
-                    )
+                linkedAccountId:payload.linkedAccountId
             };
 
             sessionStorage.setItem(
@@ -489,7 +486,7 @@ document.addEventListener("DOMContentLoaded", () => {
             valid = false;
         }
 
-        if (!settlementAccountSelect.value) {
+        if (!payload.linkedAccountId) {
             setError(
                 "linkedAccountId",
                 "정산 수취 계좌를 선택해 주세요."
@@ -582,57 +579,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    async function selectSettlementAccount(
-        settlementId,
-        linkedAccountId,
-        token
-    ) {
-      console.log(
-                          "수취계좌 설정 요청:",
-                          {
-                              settlementId,
-                              linkedAccountId
-                          }
-                      );
-        const response = await fetch(
-            `/api/settlements/${settlementId}/account`,
-            {
-                method: "PUT",
-                headers: {
-                    "Content-Type":
-                        "application/json",
-                    Authorization:
-                        `Bearer ${token}`
-                },
-                credentials: "include",
-                body: JSON.stringify({
-                    linkedAccountId:
-                        linkedAccountId
-                })
-            }
-        );
 
-        if (response.status === 401) {
-            clearStoredAuth();
-            window.location.href =
-                "/login?required=true";
-            throw new Error(
-                "로그인이 필요합니다."
-            );
-        }
-
-        const responseBody =
-            await readJsonSafely(response);
-
-        if (!response.ok) {
-            throw new Error(
-                responseBody?.message ||
-                "정산 수취 계좌 설정에 실패했습니다."
-            );
-        }
-
-        return responseBody;
-    }
 
     function formatDate(value) {
         if (!value) {

--- a/src/main/resources/static/js/settlement/settlement-create.js
+++ b/src/main/resources/static/js/settlement/settlement-create.js
@@ -7,6 +7,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const categorySelect = document.getElementById("settlement-category");
     const dueDateInput = document.getElementById("due-date");
     const totalAmountInput = document.getElementById("total-amount");
+    const settlementAccountSelect = document.getElementById("settlement-account");
+    const summaryAccount = document.getElementById("summary-account");
     const participantTokenInput = document.getElementById("participant-token");
     const lookupParticipantButton = document.getElementById("lookup-participant-button");
     const participantChips = document.getElementById("participant-chips");
@@ -29,8 +31,10 @@ document.addEventListener("DOMContentLoaded", () => {
     bindChoiceCards();
     bindTotalAmount();
     bindParticipantLookup();
+    bindSettlementAccount();
     updateParticipantView();
     loadCurrentUser();
+    loadLinkedAccounts();
 
     form.addEventListener("submit", submitSharedSettlement);
 
@@ -187,6 +191,72 @@ document.addEventListener("DOMContentLoaded", () => {
             setParticipantLookupLoading(false);
         }
     }
+    async function loadLinkedAccounts() {
+        const token = getAccessToken();
+
+        if (!token) {
+            return;
+        }
+
+        try {
+            const response = await fetch(
+                "/api/linked-accounts",
+                {
+                    method: "GET",
+                    headers: {
+                        "Accept": "application/json",
+                        Authorization: `Bearer ${token}`
+                    }
+                }
+            );
+
+            if (response.status === 401 || response.status === 403) {
+                clearStoredAuth();
+                window.location.href = "/login?required=true";
+                return;
+            }
+
+            if (!response.ok) {
+                throw new Error(
+                    "연동 계좌를 불러오지 못했습니다."
+                );
+            }
+
+            const responseBody = await readJsonSafely(response);
+
+            const accounts =
+                responseBody?.data ??
+                responseBody ??
+                [];
+
+            settlementAccountSelect.innerHTML =
+                '<option value="">계좌를 선택해 주세요</option>';
+
+            accounts.forEach((account) => {
+                const option =
+                    document.createElement("option");
+
+                option.value =
+                    account.linkedAccountId;
+
+                option.textContent = [
+                    account.bankName,
+                    account.accountAlias,
+                    account.maskedAccountNumber
+                ]
+                    .filter(Boolean)
+                    .join(" ");
+
+                settlementAccountSelect.appendChild(option);
+            });
+
+        } catch (error) {
+            console.error(
+                "연동 계좌 조회 실패",
+                error
+            );
+        }
+    }
 
     function normalizeLookupUser(user, requestedToken) {
         return {
@@ -335,7 +405,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 return;
             }
 
-            const responseBody = await readJsonSafely(response);
+            const responseBody =
+                await readJsonSafely(response);
 
             if (!response.ok) {
                 throw new Error(
@@ -345,13 +416,26 @@ document.addEventListener("DOMContentLoaded", () => {
                 );
             }
 
+            await selectSettlementAccount(
+                responseBody.settlementId,
+                Number(settlementAccountSelect.value),
+                token
+            );
+
+
             const recentSettlement = {
                 ...responseBody,
-                settlementCategory: payload.settlementCategory,
+                settlementCategory:
+                    payload.settlementCategory,
                 splitType: "EQUAL",
                 dueDate: payload.dueDate,
                 totalAmount: payload.totalAmount,
-                participantCount: payload.invitations.length + 1
+                participantCount:
+                    payload.invitations.length + 1,
+                linkedAccountId:
+                    Number(
+                        settlementAccountSelect.value
+                    )
             };
 
             sessionStorage.setItem(
@@ -360,7 +444,9 @@ document.addEventListener("DOMContentLoaded", () => {
             );
 
             window.location.href =
-                `/settlements?created=${encodeURIComponent(responseBody.settlementId)}`;
+                `/settlements?created=${encodeURIComponent(
+                    responseBody.settlementId
+                )}`;
         } catch (error) {
             showToast(error.message || "요청 처리 중 오류가 발생했습니다.", true);
         } finally {
@@ -400,6 +486,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!Array.isArray(payload.invitations) || payload.invitations.length === 0) {
             setError("invitations", "납부자를 한 명 이상 추가해 주세요.");
+            valid = false;
+        }
+
+        if (!settlementAccountSelect.value) {
+            setError(
+                "linkedAccountId",
+                "정산 수취 계좌를 선택해 주세요."
+            );
             valid = false;
         }
 
@@ -488,6 +582,58 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    async function selectSettlementAccount(
+        settlementId,
+        linkedAccountId,
+        token
+    ) {
+      console.log(
+                          "수취계좌 설정 요청:",
+                          {
+                              settlementId,
+                              linkedAccountId
+                          }
+                      );
+        const response = await fetch(
+            `/api/settlements/${settlementId}/account`,
+            {
+                method: "PUT",
+                headers: {
+                    "Content-Type":
+                        "application/json",
+                    Authorization:
+                        `Bearer ${token}`
+                },
+                credentials: "include",
+                body: JSON.stringify({
+                    linkedAccountId:
+                        linkedAccountId
+                })
+            }
+        );
+
+        if (response.status === 401) {
+            clearStoredAuth();
+            window.location.href =
+                "/login?required=true";
+            throw new Error(
+                "로그인이 필요합니다."
+            );
+        }
+
+        const responseBody =
+            await readJsonSafely(response);
+
+        if (!response.ok) {
+            throw new Error(
+                responseBody?.message ||
+                "정산 수취 계좌 설정에 실패했습니다."
+            );
+        }
+
+        return responseBody;
+    }
+
     function formatDate(value) {
         if (!value) {
             return "";
@@ -506,5 +652,22 @@ document.addEventListener("DOMContentLoaded", () => {
         showToast.timer = window.setTimeout(() => {
             toast.classList.remove("visible");
         }, 3000);
+    }
+
+    function bindSettlementAccount() {
+        settlementAccountSelect.addEventListener(
+            "change",
+            () => {
+                const selectedOption =
+                    settlementAccountSelect.options[
+                        settlementAccountSelect.selectedIndex
+                    ];
+
+                summaryAccount.textContent =
+                    settlementAccountSelect.value
+                        ? selectedOption.text
+                        : "아직 설정되지 않음";
+            }
+        );
     }
 });

--- a/src/main/resources/templates/settlement/settlement-create.html
+++ b/src/main/resources/templates/settlement/settlement-create.html
@@ -181,22 +181,32 @@
                 <small class="field-error" data-error-for="invitations"></small>
             </section>
 
-            <section class="form-card pending-card">
-                <div class="card-title card-title-between">
-                    <div>
-                        <span class="card-icon">▥</span>
-                        <h2>정산 확인 계좌</h2>
-                    </div>
-                    <button type="button" class="inline-action" disabled>계좌 선택</button>
+            <section class="form-card">
+                <div class="card-title">
+                    <span class="card-icon">▥</span>
+                    <h2>정산 수취 계좌</h2>
                 </div>
 
-                <div class="disabled-account">
-                    <span class="account-icon">▣</span>
-                    <div>
-                        <strong>정산 생성 후 계좌를 설정합니다.</strong>
-                        <p>SettlementAccount 기능이 연결되면 연동 계좌를 선택할 수 있습니다.</p>
-                    </div>
-                </div>
+                <label class="form-field">
+                    <span>수취 계좌 <em>(필수)</em></span>
+
+                    <select
+                        id="settlement-account"
+                        name="linkedAccountId"
+                        required
+                    >
+                        <option value="">계좌를 선택해 주세요</option>
+                    </select>
+
+                    <small>
+                        사이원장에 연동한 본인 계좌 중 정산금을 받을 계좌를 선택해 주세요.
+                    </small>
+
+                    <small
+                        class="field-error"
+                        data-error-for="linkedAccountId"
+                    ></small>
+                </label>
             </section>
         </form>
 
@@ -235,7 +245,9 @@
 
                 <div class="account-summary">
                     <span>▣ 정산 계좌</span>
-                    <strong>아직 설정되지 않음</strong>
+                    <strong id="summary-account">
+                        아직 설정되지 않음
+                    </strong>
                 </div>
 
                 <dl class="summary-list compact">

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
@@ -108,7 +108,8 @@ class SettlementAccountServiceTest {
                     settlementAccountService.selectAccount(
                             OWNER_ID,
                             SETTLEMENT_ID,
-                            request
+                        request.getLinkedAccountId()
+
                     );
 
             ArgumentCaptor<SettlementAccountDTO> captor =
@@ -188,7 +189,7 @@ class SettlementAccountServiceTest {
                     settlementAccountService.selectAccount(
                             OWNER_ID,
                             SETTLEMENT_ID,
-                            request
+                            request.getLinkedAccountId()
                     );
 
             assertThat(response.getSettlementAccountId())
@@ -264,7 +265,7 @@ class SettlementAccountServiceTest {
                     settlementAccountService.selectAccount(
                             OWNER_ID,
                             SETTLEMENT_ID,
-                            request
+                            request.getLinkedAccountId()
                     );
 
             ArgumentCaptor<LocalDateTime> endedAtCaptor =
@@ -325,7 +326,7 @@ class SettlementAccountServiceTest {
                             .selectAccount(
                                     OTHER_USER_ID,
                                     SETTLEMENT_ID,
-                                    request
+                                    request.getLinkedAccountId()
                             )
             ).isInstanceOf(DomainException.class);
 
@@ -357,7 +358,7 @@ class SettlementAccountServiceTest {
                             .selectAccount(
                                     OWNER_ID,
                                     SETTLEMENT_ID,
-                                    request
+                                    request.getLinkedAccountId()
                             )
             ).isInstanceOf(DomainException.class);
 
@@ -380,7 +381,7 @@ class SettlementAccountServiceTest {
                             .selectAccount(
                                     OWNER_ID,
                                     SETTLEMENT_ID,
-                                    request
+                                    request.getLinkedAccountId()
                             )
             ).isInstanceOf(DomainException.class);
 
@@ -432,7 +433,7 @@ class SettlementAccountServiceTest {
                             .selectAccount(
                                     OWNER_ID,
                                     SETTLEMENT_ID,
-                                    request
+                                    request.getLinkedAccountId()
                             )
             ).isInstanceOf(DomainException.class);
 
@@ -473,7 +474,7 @@ class SettlementAccountServiceTest {
                             .selectAccount(
                                     OWNER_ID,
                                     SETTLEMENT_ID,
-                                    request
+                                    request.getLinkedAccountId()
                             )
             ).isInstanceOf(DomainException.class);
         }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
@@ -1,0 +1,626 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.SelectSettlementAccountRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementAccountResponse;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementAccountMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.service.SettlementAccountService;
+import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SettlementAccountService 단위 테스트")
+class SettlementAccountServiceTest {
+
+    private static final Long OWNER_ID = 3L;
+    private static final Long OTHER_USER_ID = 4L;
+
+    private static final Long SETTLEMENT_ID = 6L;
+
+    private static final Long FIRST_LINKED_ACCOUNT_ID = 2L;
+    private static final Long SECOND_LINKED_ACCOUNT_ID = 3L;
+
+    private static final Long FIRST_SETTLEMENT_ACCOUNT_ID = 1L;
+    private static final Long SECOND_SETTLEMENT_ACCOUNT_ID = 2L;
+
+    @Mock
+    private SettlementMapper settlementMapper;
+
+    @Mock
+    private SettlementAccountMapper settlementAccountMapper;
+
+    @Mock
+    private LinkedBankAccountService linkedBankAccountService;
+
+    @InjectMocks
+    private SettlementAccountService settlementAccountService;
+
+    @Nested
+    @DisplayName("정산 수취 계좌 설정")
+    class SelectAccount {
+
+        @Test
+        @DisplayName("수취 계좌가 없으면 선택한 연동 계좌를 ACTIVE 상태로 등록한다")
+        void selectAccountSuccessWhenCurrentAccountDoesNotExist() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SelectSettlementAccountRequest request =
+                    createRequest(FIRST_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID,
+                            SECOND_LINKED_ACCOUNT_ID
+                    ));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementIdForUpdate(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.empty());
+
+            when(settlementAccountMapper.insert(
+                    any(SettlementAccountDTO.class)
+            )).thenAnswer(invocation -> {
+                SettlementAccountDTO account =
+                        invocation.getArgument(0);
+
+                ReflectionTestUtils.setField(
+                        account,
+                        "settlementAccountId",
+                        FIRST_SETTLEMENT_ACCOUNT_ID
+                );
+
+                return 1;
+            });
+
+            SettlementAccountResponse response =
+                    settlementAccountService.selectAccount(
+                            OWNER_ID,
+                            SETTLEMENT_ID,
+                            request
+                    );
+
+            ArgumentCaptor<SettlementAccountDTO> captor =
+                    ArgumentCaptor.forClass(
+                            SettlementAccountDTO.class
+                    );
+
+            verify(settlementAccountMapper)
+                    .insert(captor.capture());
+
+            SettlementAccountDTO savedAccount =
+                    captor.getValue();
+
+            assertThat(savedAccount.getSettlementId())
+                    .isEqualTo(SETTLEMENT_ID);
+
+            assertThat(savedAccount.getLinkedAccountId())
+                    .isEqualTo(FIRST_LINKED_ACCOUNT_ID);
+
+            assertThat(savedAccount.getAccountStatus())
+                    .isEqualTo(
+                            SettlementAccountStatus.ACTIVE
+                    );
+
+            assertThat(savedAccount.getSelectedAt())
+                    .isNotNull();
+
+            assertThat(savedAccount.getEndedAt())
+                    .isNull();
+
+            assertThat(response.getSettlementAccountId())
+                    .isEqualTo(FIRST_SETTLEMENT_ACCOUNT_ID);
+
+            assertThat(response.getSettlementId())
+                    .isEqualTo(SETTLEMENT_ID);
+
+            assertThat(response.getLinkedAccountId())
+                    .isEqualTo(FIRST_LINKED_ACCOUNT_ID);
+
+            assertThat(response.getAccountStatus())
+                    .isEqualTo(
+                            SettlementAccountStatus.ACTIVE
+                    );
+        }
+
+        @Test
+        @DisplayName("현재 수취 계좌와 같은 계좌를 다시 선택하면 새 행을 생성하지 않는다")
+        void selectSameAccountDoesNotInsertAgain() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SettlementAccountDTO currentAccount =
+                    createActiveSettlementAccount(
+                            FIRST_SETTLEMENT_ACCOUNT_ID,
+                            FIRST_LINKED_ACCOUNT_ID
+                    );
+
+            SelectSettlementAccountRequest request =
+                    createRequest(FIRST_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID
+                    ));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementIdForUpdate(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.of(currentAccount));
+
+            SettlementAccountResponse response =
+                    settlementAccountService.selectAccount(
+                            OWNER_ID,
+                            SETTLEMENT_ID,
+                            request
+                    );
+
+            assertThat(response.getSettlementAccountId())
+                    .isEqualTo(FIRST_SETTLEMENT_ACCOUNT_ID);
+
+            assertThat(response.getLinkedAccountId())
+                    .isEqualTo(FIRST_LINKED_ACCOUNT_ID);
+
+            verify(settlementAccountMapper, never())
+                    .updateStatus(
+                            any(),
+                            any(),
+                            any()
+                    );
+
+            verify(settlementAccountMapper, never())
+                    .insert(any());
+        }
+
+        @Test
+        @DisplayName("다른 계좌로 변경하면 기존 계좌를 REPLACED로 변경하고 새 ACTIVE 계좌를 등록한다")
+        void replaceSettlementAccountSuccess() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SettlementAccountDTO currentAccount =
+                    createActiveSettlementAccount(
+                            FIRST_SETTLEMENT_ACCOUNT_ID,
+                            FIRST_LINKED_ACCOUNT_ID
+                    );
+
+            SelectSettlementAccountRequest request =
+                    createRequest(SECOND_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID,
+                            SECOND_LINKED_ACCOUNT_ID
+                    ));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementIdForUpdate(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.of(currentAccount));
+
+            when(settlementAccountMapper.updateStatus(
+                    eq(FIRST_SETTLEMENT_ACCOUNT_ID),
+                    eq(SettlementAccountStatus.REPLACED),
+                    any(LocalDateTime.class)
+            )).thenReturn(1);
+
+            when(settlementAccountMapper.insert(
+                    any(SettlementAccountDTO.class)
+            )).thenAnswer(invocation -> {
+                SettlementAccountDTO account =
+                        invocation.getArgument(0);
+
+                ReflectionTestUtils.setField(
+                        account,
+                        "settlementAccountId",
+                        SECOND_SETTLEMENT_ACCOUNT_ID
+                );
+
+                return 1;
+            });
+
+            SettlementAccountResponse response =
+                    settlementAccountService.selectAccount(
+                            OWNER_ID,
+                            SETTLEMENT_ID,
+                            request
+                    );
+
+            ArgumentCaptor<LocalDateTime> endedAtCaptor =
+                    ArgumentCaptor.forClass(
+                            LocalDateTime.class
+                    );
+
+            verify(settlementAccountMapper)
+                    .updateStatus(
+                            eq(FIRST_SETTLEMENT_ACCOUNT_ID),
+                            eq(SettlementAccountStatus.REPLACED),
+                            endedAtCaptor.capture()
+                    );
+
+            assertThat(endedAtCaptor.getValue())
+                    .isNotNull();
+
+            ArgumentCaptor<SettlementAccountDTO> accountCaptor =
+                    ArgumentCaptor.forClass(
+                            SettlementAccountDTO.class
+                    );
+
+            verify(settlementAccountMapper)
+                    .insert(accountCaptor.capture());
+
+            SettlementAccountDTO newAccount =
+                    accountCaptor.getValue();
+
+            assertThat(newAccount.getLinkedAccountId())
+                    .isEqualTo(SECOND_LINKED_ACCOUNT_ID);
+
+            assertThat(newAccount.getAccountStatus())
+                    .isEqualTo(
+                            SettlementAccountStatus.ACTIVE
+                    );
+
+            assertThat(newAccount.getEndedAt())
+                    .isNull();
+
+            assertThat(response.getLinkedAccountId())
+                    .isEqualTo(SECOND_LINKED_ACCOUNT_ID);
+        }
+
+        @Test
+        @DisplayName("정산 생성자가 아니면 수취 계좌를 설정할 수 없다")
+        void selectAccountFailsWhenUserIsNotOwner() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SelectSettlementAccountRequest request =
+                    createRequest(FIRST_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .selectAccount(
+                                    OTHER_USER_ID,
+                                    SETTLEMENT_ID,
+                                    request
+                            )
+            ).isInstanceOf(DomainException.class);
+
+            verifyNoInteractions(
+                    linkedBankAccountService,
+                    settlementAccountMapper
+            );
+        }
+
+        @Test
+        @DisplayName("본인에게 연동되지 않은 계좌는 정산 수취 계좌로 설정할 수 없다")
+        void selectAccountFailsWhenLinkedAccountDoesNotBelongToUser() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SelectSettlementAccountRequest request =
+                    createRequest(SECOND_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID
+                    ));
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .selectAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID,
+                                    request
+                            )
+            ).isInstanceOf(DomainException.class);
+
+            verifyNoInteractions(
+                    settlementAccountMapper
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 정산에는 수취 계좌를 설정할 수 없다")
+        void selectAccountFailsWhenSettlementDoesNotExist() {
+            SelectSettlementAccountRequest request =
+                    createRequest(FIRST_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .selectAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID,
+                                    request
+                            )
+            ).isInstanceOf(DomainException.class);
+
+            verifyNoInteractions(
+                    linkedBankAccountService,
+                    settlementAccountMapper
+            );
+        }
+
+        @Test
+        @DisplayName("기존 수취 계좌 상태 변경에 실패하면 새 계좌를 등록하지 않는다")
+        void replaceAccountFailsWhenCurrentAccountUpdateFails() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SettlementAccountDTO currentAccount =
+                    createActiveSettlementAccount(
+                            FIRST_SETTLEMENT_ACCOUNT_ID,
+                            FIRST_LINKED_ACCOUNT_ID
+                    );
+
+            SelectSettlementAccountRequest request =
+                    createRequest(SECOND_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID,
+                            SECOND_LINKED_ACCOUNT_ID
+                    ));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementIdForUpdate(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.of(currentAccount));
+
+            when(settlementAccountMapper.updateStatus(
+                    eq(FIRST_SETTLEMENT_ACCOUNT_ID),
+                    eq(SettlementAccountStatus.REPLACED),
+                    any(LocalDateTime.class)
+            )).thenReturn(0);
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .selectAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID,
+                                    request
+                            )
+            ).isInstanceOf(DomainException.class);
+
+            verify(settlementAccountMapper, never())
+                    .insert(any());
+        }
+
+        @Test
+        @DisplayName("새 수취 계좌 저장에 실패하면 예외가 발생한다")
+        void selectAccountFailsWhenInsertFails() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SelectSettlementAccountRequest request =
+                    createRequest(FIRST_LINKED_ACCOUNT_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
+                    .thenReturn(List.of(
+                            FIRST_LINKED_ACCOUNT_ID
+                    ));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementIdForUpdate(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.empty());
+
+            when(settlementAccountMapper.insert(
+                    any(SettlementAccountDTO.class)
+            )).thenReturn(0);
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .selectAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID,
+                                    request
+                            )
+            ).isInstanceOf(DomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 정산 수취 계좌 조회")
+    class FindCurrentAccount {
+
+        @Test
+        @DisplayName("현재 ACTIVE 상태의 수취 계좌를 조회한다")
+        void findCurrentAccountSuccess() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            SettlementAccountDTO account =
+                    createActiveSettlementAccount(
+                            SECOND_SETTLEMENT_ACCOUNT_ID,
+                            SECOND_LINKED_ACCOUNT_ID
+                    );
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementId(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.of(account));
+
+            SettlementAccountResponse response =
+                    settlementAccountService
+                            .findCurrentAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID
+                            );
+
+            assertThat(response.getSettlementAccountId())
+                    .isEqualTo(
+                            SECOND_SETTLEMENT_ACCOUNT_ID
+                    );
+
+            assertThat(response.getSettlementId())
+                    .isEqualTo(SETTLEMENT_ID);
+
+            assertThat(response.getLinkedAccountId())
+                    .isEqualTo(
+                            SECOND_LINKED_ACCOUNT_ID
+                    );
+
+            assertThat(response.getAccountStatus())
+                    .isEqualTo(
+                            SettlementAccountStatus.ACTIVE
+                    );
+        }
+
+        @Test
+        @DisplayName("현재 설정된 수취 계좌가 없으면 예외가 발생한다")
+        void findCurrentAccountFailsWhenAccountDoesNotExist() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            when(
+                    settlementAccountMapper
+                            .findActiveBySettlementId(
+                                    SETTLEMENT_ID
+                            )
+            ).thenReturn(Optional.empty());
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .findCurrentAccount(
+                                    OWNER_ID,
+                                    SETTLEMENT_ID
+                            )
+            ).isInstanceOf(DomainException.class);
+        }
+
+        @Test
+        @DisplayName("정산 생성자가 아니면 현재 수취 계좌를 조회할 수 없다")
+        void findCurrentAccountFailsWhenUserIsNotOwner() {
+            SettlementDTO settlement =
+                    createSettlement(OWNER_ID);
+
+            when(settlementMapper.findById(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(settlement));
+
+            assertThatThrownBy(
+                    () -> settlementAccountService
+                            .findCurrentAccount(
+                                    OTHER_USER_ID,
+                                    SETTLEMENT_ID
+                            )
+            ).isInstanceOf(DomainException.class);
+
+            verify(
+                    settlementAccountMapper,
+                    never()
+            ).findActiveBySettlementId(
+                    SETTLEMENT_ID
+            );
+        }
+    }
+
+    private SettlementDTO createSettlement(
+            Long ownerId
+    ) {
+        return SettlementDTO.builder()
+                .settlementId(SETTLEMENT_ID)
+                .ownerId(ownerId)
+                .build();
+    }
+
+    private SelectSettlementAccountRequest createRequest(
+            Long linkedAccountId
+    ) {
+        return SelectSettlementAccountRequest.builder()
+                .linkedAccountId(linkedAccountId)
+                .build();
+    }
+
+    private SettlementAccountDTO createActiveSettlementAccount(
+            Long settlementAccountId,
+            Long linkedAccountId
+    ) {
+        return SettlementAccountDTO.builder()
+                .settlementAccountId(
+                        settlementAccountId
+                )
+                .settlementId(
+                        SETTLEMENT_ID
+                )
+                .linkedAccountId(
+                        linkedAccountId
+                )
+                .accountStatus(
+                        SettlementAccountStatus.ACTIVE
+                )
+                .selectedAt(
+                        LocalDateTime.now()
+                                .minusHours(1)
+                )
+                .endedAt(null)
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SharedSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SharedSettlementServiceTest.java
@@ -13,6 +13,7 @@ import org.teamsai.saibackend.domain.settlement.dto.request.CreateSharedSettleme
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSharedSettlementResponse;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.service.SettlementAccountService;
 import org.teamsai.saibackend.domain.settlement.service.SettlementInvitationService;
 import org.teamsai.saibackend.domain.settlement.service.SharedSettlementService;
 import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
@@ -29,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -41,11 +44,16 @@ class SharedSettlementServiceTest {
     private static final Long OWNER_ID = 1L;
     private static final Long SETTLEMENT_ID = 15L;
 
+    private static final Long LINKED_ACCOUNT_ID = 10L;
+
     @Mock
     private SettlementMapper settlementMapper;
 
     @Mock
     private SettlementInvitationService invitationService;
+
+    @Mock
+    private SettlementAccountService settlementAccountService;
 
     @InjectMocks
     private SharedSettlementService sharedSettlementService;
@@ -138,6 +146,12 @@ class SharedSettlementServiceTest {
                         same(request.getInvitations()),
                         expectedAmountCaptor.capture()
                 );
+        verify(settlementAccountService)
+            .selectAccount(
+                OWNER_ID,
+                SETTLEMENT_ID,
+                LINKED_ACCOUNT_ID
+            );
 
         assertThat(expectedAmountCaptor.getValue())
                 .isEqualByComparingTo("150000");
@@ -305,8 +319,71 @@ class SharedSettlementServiceTest {
                 .title("제주도 여행비 정산")
                 .dueDate(LocalDate.now().plusDays(7))
                 .totalAmount(totalAmount)
+                .linkedAccountId(LINKED_ACCOUNT_ID)
                 .invitations(invitations)
                 .build();
+    }
+
+    @Test
+    @DisplayName("수취 계좌 설정에 실패하면 정산 생성에 실패한다")
+    void failsWhenSettlementAccountSelectionFails() {
+
+        CreateSharedSettlementRequest request =
+            createRequest(
+                new BigDecimal("30000"),
+                List.of(
+                    invitation("SAI_USER_A")
+                )
+            );
+
+        given(settlementMapper
+            .insertSettlement(any(SettlementDTO.class)))
+            .willAnswer(invocation -> {
+                SettlementDTO settlement =
+                    invocation.getArgument(0);
+
+                settlement.setSettlementId(
+                    SETTLEMENT_ID
+                );
+
+                return 1;
+            });
+
+        given(
+            settlementAccountService.selectAccount(
+                OWNER_ID,
+                SETTLEMENT_ID,
+                LINKED_ACCOUNT_ID
+            )
+        ).willThrow(
+            SettlementErrorCode
+                .SETTLEMENT_ACCOUNT_CREATE_FAILED
+                .toException()
+        );
+
+        assertThatThrownBy(() ->
+            sharedSettlementService.create(
+                OWNER_ID,
+                request
+            )
+        ).isInstanceOf(DomainException.class);
+
+        then(invitationService)
+            .should()
+            .inviteAll(
+                OWNER_ID,
+                SETTLEMENT_ID,
+                request.getInvitations(),
+                new BigDecimal("15000")
+            );
+
+        then(settlementAccountService)
+            .should()
+            .selectAccount(
+                OWNER_ID,
+                SETTLEMENT_ID,
+                LINKED_ACCOUNT_ID
+            );
     }
 
     private CreateSettlementInvitationRequest invitation(


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #72 

## 🛠 작업 사항

- 정산별 수취 계좌를 저장하기 위한 SettlementAccount 기능 구현
- 정산 생성자가 본인에게 연동된 계좌만 수취 계좌로 선택할 수 있도록 검증 추가
- 최초 계좌 선택 시 ACTIVE 상태로 저장
- 기존 수취 계좌가 있는 상태에서 다른 계좌 선택 시
- 동일 계좌 재선택 시 중복 생성 없이 기존 계좌 반환
- 현재 정산 수취 계좌 조회 API 구현
- 수취 계좌 검증은 사이원장 linkedAccountId 기준으로 별도 처리
- SettlementAccountService 단위 테스트 추가
## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 정산 생성 도중 생성 실패시에도 정산 id가 계속해서 추가되는 상황을 발견하였습니다. 해당 이슈와 분리하여 추후 리팩토링 사항으로 남겨두겠습니다.

