### PR TITLE
feat(#84): 차용증 서명/채무자 연결 로직 변경

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/controller/LoanContractController.java
@@ -15,7 +15,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
-import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.service.LoanContractService;
@@ -91,30 +90,31 @@ public class LoanContractController {
     @PatchMapping(value = "/api/contracts/{contractId}/signature", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ContractStatus submitSignature(
             @PathVariable Long contractId,
+            @Parameter(description = "채무자 회원 토큰", example = "SAI_ABCD1234")
+            @RequestParam("debtorUserToken") String debtorUserToken,
             @RequestParam("signature") MultipartFile signature,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return contractService.submitCreditorSignature(contractId, userDetails.getUserId(), signature);
+        return contractService.submitCreditorSignature(contractId, userDetails.getUserId(), debtorUserToken, signature);
     }
 
     @Operation(
             summary = "채무자 계약 합류",
-            description = "본인인증을 완료한 채무자가 차용증에 채무자로 연결됩니다."
+            description = "로그인한 사용자를 차용증의 채무자로 연결합니다. 이미 로그인 세션에서 본인 확인이 되어 있으므로 별도의 본인인증 절차 없이 사용자 토큰(인증 정보)만으로 연결합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "채무자 연결 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "차용증을 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 채무자가 연결되었거나 본인인증이 완료되지 않음")
+            @ApiResponse(responseCode = "409", description = "이미 채무자가 연결되었거나 채권자 본인이 채무자로 연결을 시도함")
     })
     @ResponseBody
     @PatchMapping("/api/contracts/{contractId}/debtor")
     public void linkDebtor(
             @PathVariable Long contractId,
-            @Valid @RequestBody LoanContractDebtorLinkRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        contractService.linkDebtor(contractId, userDetails.getUserId(), request);
+        contractService.linkDebtor(contractId, userDetails.getUserId());
     }
 
     @Operation(

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/LoanContractDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/LoanContractDTO.java
@@ -1,7 +1,9 @@
 package org.teamsai.saibackend.domain.contract.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 
@@ -34,8 +36,8 @@ public class LoanContractDTO {
     private String contractAlias;
     private String terms;
 
-    private Long creditorId;            // (FK)
-    private Long debtorId;              // (FK)
+    private String creditorId;            // (FK)
+    private String debtorId;              // (FK)
 
     private String creditorSignature;
     private String debtorSignature;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractDebtorLinkRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractDebtorLinkRequest.java
@@ -1,9 +1,0 @@
-package org.teamsai.saibackend.domain.contract.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record LoanContractDebtorLinkRequest(
-        @NotBlank(message = "본인인증 식별값은 필수입니다.")
-        String identityVerificationId
-) {
-}

--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
@@ -14,7 +14,6 @@ import java.time.Period;
 @Builder
 public class LoanContractRequest {
 
-    @NotBlank(message = "본인인증 식별값은 필수입니다.")
     private String identityVerificationId;
 
     private Long contractId;
@@ -45,16 +44,13 @@ public class LoanContractRequest {
     @NotBlank(message = "주소를 입력해주세요.")
     private String creditorAddress;
 
-    @NotBlank(message = "채무자 이메일을 입력해주세요.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String debtorEmail;
-
     @NotBlank(message = "계약의 목적을 입력해주세요.")
     private String contractAlias;
 
     private String terms;
 
-    @NotNull(message = "대출금을 받을 계좌를 선택해주세요.")
+    // 계좌 연동이 아직 해결되지 않아 임시 주석 처리. 연동 정상화되면 복구할 것.
+    // @NotNull(message = "대출금을 받을 계좌를 선택해주세요.")
     private Long selectedLinkedAccountId;
 
     @AssertTrue(message = "대출 만기일은 시작일 이후여야 합니다.")

--- a/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/mapper/LoanContractMapper.java
@@ -26,6 +26,7 @@ public interface LoanContractMapper {
     void updateCreditorSignature(
             @Param("contractId") Long contractId,
             @Param("signatureData") String signatureData,
+            @Param("debtorId") Long debtorId,
             @Param("status") ContractStatus status
     );
 

--- a/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
-import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
@@ -55,7 +54,7 @@ public class LoanContractService {
     }
 
     @Transactional
-    public ContractStatus submitCreditorSignature(Long contractId, Long userId, MultipartFile signature) {
+    public ContractStatus submitCreditorSignature(Long contractId, Long userId, String debtorUserToken, MultipartFile signature) {
         LoanContractResponse contract = contractMapper.findContractById(contractId)
                 .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
 
@@ -64,13 +63,16 @@ public class LoanContractService {
         }
 
         String savedPath = fileService.saveSignatureFile(contractId, signature);
-        contractMapper.updateCreditorSignature(contractId, savedPath, ContractStatus.PENDING);
+
+        Long debtorId = userService.findRequestTarget(userId, debtorUserToken).getUserId();
+
+        contractMapper.updateCreditorSignature(contractId, savedPath, debtorId, ContractStatus.PENDING);
 
         return ContractStatus.PENDING;
     }
 
     @Transactional
-    public void linkDebtor(Long contractId, Long userId, LoanContractDebtorLinkRequest request) {
+    public void linkDebtor(Long contractId, Long userId) {
         LoanContractResponse contract = contractMapper.findContractById(contractId)
                 .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
 
@@ -81,12 +83,6 @@ public class LoanContractService {
         if (userId.equals(contract.getCreditorId())) {
             throw LoanContractErrorCode.CANNOT_CREATE_CONTRACT_TO_SELF.toException();
         }
-
-        identityService.consume(
-                userId,
-                request.identityVerificationId(),
-                IdentityPurpose.LOAN_CONTRACT
-        );
 
         userService.getMyInfo(userId);
 
@@ -108,7 +104,7 @@ public class LoanContractService {
         }
 
         if (contract.getStatus() == ContractStatus.COMPLETED) {
-            throw LoanContractErrorCode.CONTRACT_ALREADY_COMPLETED.toException();   // ← 추가
+            throw LoanContractErrorCode.CONTRACT_ALREADY_COMPLETED.toException();
         }
 
 
@@ -116,7 +112,7 @@ public class LoanContractService {
         contractMapper.updateDebtorSignature(contractId, debtorAddress, savedPath, ContractStatus.COMPLETED);
 
         if (contract.getPreviousContractId() != null) {
-            eventPublisher.publishEvent(new ContractChangeApprovedEvent(contractId));   // ← 추가
+            eventPublisher.publishEvent(new ContractChangeApprovedEvent(contractId));
         }
 
         return ContractStatus.COMPLETED;

--- a/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
@@ -62,9 +62,9 @@ public class LoanContractService {
             throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
         }
 
-        String savedPath = fileService.saveSignatureFile(contractId, signature);
-
         Long debtorId = userService.findRequestTarget(userId, debtorUserToken).getUserId();
+
+        String savedPath = fileService.saveSignatureFile(contractId, signature);
 
         contractMapper.updateCreditorSignature(contractId, savedPath, debtorId, ContractStatus.PENDING);
 
@@ -76,17 +76,18 @@ public class LoanContractService {
         LoanContractResponse contract = contractMapper.findContractById(contractId)
                 .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
 
-        if (contract.getDebtorId() != null) {
-            throw LoanContractErrorCode.DEBTOR_ALREADY_LINKED.toException();
-        }
-
         if (userId.equals(contract.getCreditorId())) {
             throw LoanContractErrorCode.CANNOT_CREATE_CONTRACT_TO_SELF.toException();
         }
 
-        userService.getMyInfo(userId);
+        if (contract.getDebtorId() != null && !contract.getDebtorId().equals(userId)) {
+            throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
+        }
 
-        contractMapper.updateDebtorId(contractId, userId);
+        if (contract.getDebtorId() == null) {
+            userService.getMyInfo(userId);
+            contractMapper.updateDebtorId(contractId, userId);
+        }
     }
 
     @Transactional

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -71,10 +71,7 @@ public class SecurityConfig {
                                         "/accounts/**",
                                         "/settlements",
                                         "/settlements/**",
-                                        "/contracts/new",
-                                        "/contracts/signature",
-                                        "/contracts/*/approve",
-                                        "/contracts/*/approve/signature"
+                                        "/contracts/**"
 
                                 )
                                 .permitAll()

--- a/src/main/resources/db/02_repayment_schedule.sql
+++ b/src/main/resources/db/02_repayment_schedule.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS repayment_schedule (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY (schedule_id),
-    CONSTRAINT fk_repayment_schedule_contract FOREIGN KEY (contract_id) REFERENCES loan_contract(contract_id)
+    CONSTRAINT fk_repayment_schedule_contract FOREIGN KEY (contract_id) REFERENCES loan_contract(contract_id) ON DELETE CASCADE
     ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -76,6 +76,7 @@
         UPDATE loan_contract
         SET
         creditor_signature = #{signatureData},
+        debtor_id = #{debtorId},
         status = #{status},
         updated_at = NOW()
         WHERE contract_id = #{contractId}

--- a/src/test/java/org/teamsai/saibackend/domain/contract/LoanContractServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contract/LoanContractServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
-import org.teamsai.saibackend.domain.contract.dto.request.LoanContractDebtorLinkRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.LoanContractRequest;
 import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
@@ -23,6 +22,7 @@ import org.teamsai.saibackend.domain.contract.service.LoanContractService;
 import org.teamsai.saibackend.domain.identity.exception.IdentityErrorCode;
 import org.teamsai.saibackend.domain.identity.service.IdentityService;
 import org.teamsai.saibackend.domain.identity.type.IdentityPurpose;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.dto.response.UserResponse;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
 import org.teamsai.saibackend.domain.user.service.UserService;
@@ -46,7 +46,7 @@ class LoanContractServiceTest {
     private static final Long CREDITOR_ID = 1L;
     private static final Long DEBTOR_ID = 2L;
     private static final Long OTHER_USER_ID = 999L;
-    private static final String DEBTOR_EMAIL = "debtor@example.com";
+    private static final String DEBTOR_USER_TOKEN = "SAI_ABCD1234";
     private static final Long CONTRACT_ID = 1L;
     private static final String IDENTITY_VERIFICATION_ID = "identity-verification-abc123";
 
@@ -144,20 +144,15 @@ class LoanContractServiceTest {
     @DisplayName("채무자 계약 합류")
     class LinkDebtor {
 
-        private final LoanContractDebtorLinkRequest linkRequest =
-                new LoanContractDebtorLinkRequest(IDENTITY_VERIFICATION_ID);
-
         @Test
-        @DisplayName("본인인증을 마친 채무자를 계약에 연결한다")
+        @DisplayName("로그인한 사용자를 본인인증 없이 채무자로 계약에 연결한다")
         void linkDebtorSuccess() {
             given(contractMapper.findContractById(CONTRACT_ID))
                     .willReturn(Optional.of(createResponseWithoutDebtor()));
 
-            loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest);
+            loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID);
 
-            verify(identityService).consume(
-                    DEBTOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT
-            );
+            verify(identityService, never()).consume(any(), any(), any());
             verify(contractMapper).updateDebtorId(CONTRACT_ID, DEBTOR_ID);
         }
 
@@ -166,7 +161,7 @@ class LoanContractServiceTest {
         void linkDebtorFailsWhenContractNotFound() {
             given(contractMapper.findContractById(CONTRACT_ID)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest))
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID))
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
@@ -177,19 +172,18 @@ class LoanContractServiceTest {
         }
 
         @Test
-        @DisplayName("이미 채무자가 연결되어 있으면 예외가 발생하고 본인인증을 실행하지 않는다")
+        @DisplayName("이미 채무자가 연결되어 있으면 예외가 발생하고 연결하지 않는다")
         void linkDebtorFailsWhenAlreadyLinked() {
             given(contractMapper.findContractById(CONTRACT_ID))
                     .willReturn(Optional.of(createResponse()));
 
-            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, OTHER_USER_ID, linkRequest))
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, OTHER_USER_ID))
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
                                     .isEqualTo(LoanContractErrorCode.DEBTOR_ALREADY_LINKED)
                     );
 
-            verify(identityService, never()).consume(any(), any(), any());
             verify(contractMapper, never()).updateDebtorId(any(), any());
         }
 
@@ -199,32 +193,11 @@ class LoanContractServiceTest {
             given(contractMapper.findContractById(CONTRACT_ID))
                     .willReturn(Optional.of(createResponseWithoutDebtor()));
 
-            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, CREDITOR_ID, linkRequest))
+            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, CREDITOR_ID))
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
                                     .isEqualTo(LoanContractErrorCode.CANNOT_CREATE_CONTRACT_TO_SELF)
-                    );
-
-            verify(identityService, never()).consume(any(), any(), any());
-            verify(contractMapper, never()).updateDebtorId(any(), any());
-        }
-
-        @Test
-        @DisplayName("본인인증을 완료하지 않았으면 예외가 발생하고 연결하지 않는다")
-        void linkDebtorFailsWhenIdentityNotVerified() {
-            given(contractMapper.findContractById(CONTRACT_ID))
-                    .willReturn(Optional.of(createResponseWithoutDebtor()));
-
-            willThrow(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED.toException())
-                    .given(identityService)
-                    .consume(DEBTOR_ID, IDENTITY_VERIFICATION_ID, IdentityPurpose.LOAN_CONTRACT);
-
-            assertThatThrownBy(() -> loanContractService.linkDebtor(CONTRACT_ID, DEBTOR_ID, linkRequest))
-                    .isInstanceOfSatisfying(
-                            DomainException.class,
-                            exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(IdentityErrorCode.IDENTITY_VERIFICATION_CONSUME_FAILED)
                     );
 
             verify(contractMapper, never()).updateDebtorId(any(), any());
@@ -242,11 +215,15 @@ class LoanContractServiceTest {
             given(contractMapper.findContractById(CONTRACT_ID)).willReturn(Optional.of(createResponse()));
             given(fileService.saveSignatureFile(CONTRACT_ID, signature))
                     .willReturn("uploads/signatures/1_signature.png");
+            given(userService.findRequestTarget(CREDITOR_ID, DEBTOR_USER_TOKEN))
+                    .willReturn(UserDTO.builder().userId(DEBTOR_ID).build());
 
-            ContractStatus status = loanContractService.submitCreditorSignature(CONTRACT_ID, CREDITOR_ID, signature);
+            ContractStatus status = loanContractService.submitCreditorSignature(
+                    CONTRACT_ID, CREDITOR_ID, DEBTOR_USER_TOKEN, signature
+            );
 
             verify(contractMapper).updateCreditorSignature(
-                    CONTRACT_ID, "uploads/signatures/1_signature.png", ContractStatus.PENDING
+                    CONTRACT_ID, "uploads/signatures/1_signature.png", DEBTOR_ID, ContractStatus.PENDING
             );
             assertThat(status).isEqualTo(ContractStatus.PENDING);
         }
@@ -258,7 +235,7 @@ class LoanContractServiceTest {
             given(contractMapper.findContractById(CONTRACT_ID)).willReturn(Optional.of(createResponse()));
 
             assertThatThrownBy(() ->
-                    loanContractService.submitCreditorSignature(CONTRACT_ID, OTHER_USER_ID, signature)
+                    loanContractService.submitCreditorSignature(CONTRACT_ID, OTHER_USER_ID, DEBTOR_USER_TOKEN, signature)
             )
                     .isInstanceOfSatisfying(
                             DomainException.class,
@@ -267,7 +244,7 @@ class LoanContractServiceTest {
                     );
 
             verify(fileService, never()).saveSignatureFile(any(), any());
-            verify(contractMapper, never()).updateCreditorSignature(any(), any(), any());
+            verify(contractMapper, never()).updateCreditorSignature(any(), any(), any(), any());
         }
 
         @Test
@@ -277,7 +254,7 @@ class LoanContractServiceTest {
             given(contractMapper.findContractById(CONTRACT_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() ->
-                    loanContractService.submitCreditorSignature(CONTRACT_ID, CREDITOR_ID, signature)
+                    loanContractService.submitCreditorSignature(CONTRACT_ID, CREDITOR_ID, DEBTOR_USER_TOKEN, signature)
             )
                     .isInstanceOfSatisfying(
                             DomainException.class,
@@ -286,7 +263,7 @@ class LoanContractServiceTest {
                     );
 
             verify(fileService, never()).saveSignatureFile(any(), any());
-            verify(contractMapper, never()).updateCreditorSignature(any(), any(), any());
+            verify(contractMapper, never()).updateCreditorSignature(any(), any(), any(), any());
         }
     }
 
@@ -463,7 +440,6 @@ class LoanContractServiceTest {
                 .maturityDate(LocalDate.of(2027, 1, 1))
                 .repaymentDay(15)
                 .creditorAddress("서울특별시 강남구 테헤란로 123")
-                .debtorEmail(DEBTOR_EMAIL)
                 .contractAlias("생활비 차용")
                 .terms(null)
                 .build();
@@ -521,6 +497,6 @@ class LoanContractServiceTest {
         );
         verify(userService).getMyInfo(CREDITOR_ID);
         verify(contractMapper).insertByContract(request, CREDITOR_ID);
-        verify(eventPublisher).publishEvent(any(ContractCreatedEvent.class));   // 추가
+        verify(eventPublisher).publishEvent(any(ContractCreatedEvent.class));
     }
 }


### PR DESCRIPTION
채권자 전자서명 제출 시 채무자 회원 토큰으로 채무자를 지정하도록 변경하고,
채무자 계약 합류 시 별도 본인인증 절차 없이 로그인 정보만으로 연결되도록 수정

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #84 

## 🛠 작업 사항

-채권자 서명 제출 시 debtorUserToken을 통해 채무자를 직접 지정하도록 수정

-채무자 계약 합류 시 로그인 세션 기반 연동으로 단순화, 대신 본인인증은 채무자가 맞는지만 확인
-미사용 DTO(LoanContractDebtorLinkRequest) 및 불필요한 필드 검증(debtoremail) 제거
-SecurityConfig 내 /contracts/** permitAll 경로 정리

## ✅ 테스트

- [O] 로컬 서버 테스트 완료
- [O] 핵심 기능 테스트 코드 작성 및 실행 완료
- [O] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

-