### PR TITLE
refactor(#89): SettlementAccountServiceTest 서비스 최신 로직에 맞게 수정

### DIFF
--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
@@ -21,17 +21,13 @@ import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SettlementAccountService 단위 테스트")
@@ -76,11 +72,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID,
-                            SECOND_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    FIRST_LINKED_ACCOUNT_ID
+            )).thenReturn(true);
 
             when(
                     settlementAccountMapper
@@ -173,10 +168,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    FIRST_LINKED_ACCOUNT_ID
+            )).thenReturn(true);
 
             when(
                     settlementAccountMapper
@@ -227,11 +222,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID,
-                            SECOND_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    SECOND_LINKED_ACCOUNT_ID
+            )).thenReturn(true);
 
             when(
                     settlementAccountMapper
@@ -348,10 +342,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    SECOND_LINKED_ACCOUNT_ID
+            )).thenReturn(false);
 
             assertThatThrownBy(
                     () -> settlementAccountService
@@ -409,11 +403,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID,
-                            SECOND_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    SECOND_LINKED_ACCOUNT_ID
+            )).thenReturn(true);
 
             when(
                     settlementAccountMapper
@@ -453,10 +446,10 @@ class SettlementAccountServiceTest {
             when(settlementMapper.findById(SETTLEMENT_ID))
                     .thenReturn(Optional.of(settlement));
 
-            when(linkedBankAccountService.getLinkedAccountIds(OWNER_ID))
-                    .thenReturn(List.of(
-                            FIRST_LINKED_ACCOUNT_ID
-                    ));
+            when(linkedBankAccountService.isOwnedLinkedAccount(
+                    OWNER_ID,
+                    FIRST_LINKED_ACCOUNT_ID
+            )).thenReturn(true);
 
             when(
                     settlementAccountMapper


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #89 

## 🛠 작업 사항
- 기존 getLinkedAccountIds() 기반 Stub 제거
- 현재 서비스 로직에 맞춰 isOwnedLinkedAccount(userId, linkedAccountId) 기반 Stub으로 변경
- 정상적인 수취 계좌 선택/변경 케이스에서 계좌 소유 여부가 true를 반환하도록 수정
- 본인 소유가 아닌 계좌 선택 케이스에서 계좌 소유 여부가 false를 반환하도록 수정
- 서비스에서 더 이상 호출하지 않는 기존 Stub 제거하여 UnnecessaryStubbingException 해결
- 변경된 계좌 소유권 검증 방식에 맞춰 수취 계좌 등록, 재선택, 변경 및 실패 케이스 테스트 정상화

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

