### PR TITLE
feat(#102) : 정산 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/account/dto/response/LinkedBankAccountResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/account/dto/response/LinkedBankAccountResponse.java
@@ -19,7 +19,9 @@ public record LinkedBankAccountResponse(
         BigDecimal balance,
         String connectionStatus
 ) {
-    public static LinkedBankAccountResponse from(LinkedBankAccountDTO dto) {
+    public static LinkedBankAccountResponse from(
+            LinkedBankAccountDTO dto
+    ) {
         return LinkedBankAccountResponse.builder()
                 .linkedAccountId(dto.getLinkedAccountId())
                 .bankCode(dto.getBankCode())

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/SettlementController.java
@@ -12,10 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSharedSettlementRequest;
-import org.teamsai.saibackend.domain.settlement.dto.response.CreateSharedSettlementResponse;
-import org.teamsai.saibackend.domain.settlement.dto.response.SettlementCloseResponse;
-import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
-import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentStatusResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.*;
 import org.teamsai.saibackend.domain.settlement.service.SettlementCloseService;
 import org.teamsai.saibackend.domain.settlement.service.SettlementPaymentStatusService;
 import org.teamsai.saibackend.domain.settlement.service.SharedSettlementService;
@@ -43,6 +40,13 @@ public class SettlementController {
     @GetMapping("/settlements/new")
     public String settlementCreatePage() {
         return "settlement/settlement-create";
+    }
+
+    @GetMapping("/settlements/{settlementId}")
+    public String settlementDetailPage(
+            @PathVariable Long settlementId
+    ) {
+        return "settlement/settlement-detail";
     }
 
     @Operation(
@@ -201,6 +205,25 @@ public class SettlementController {
     ) {
         List<SettlementListResponse> response =
                 sharedSettlementService.getSettlementList(
+                        userDetails.getUserId()
+                );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "정산 상세 조회",
+            description = "현재 사용자가 생성하거나 참여 중인 정산의 기본 정보를 조회합니다."
+    )
+    @GetMapping("/api/settlements/{settlementId}")
+    @ResponseBody
+    public ResponseEntity<SettlementDetailResponse> getSettlementDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long settlementId
+    ) {
+        SettlementDetailResponse response =
+                sharedSettlementService.getSettlementDetail(
+                        settlementId,
                         userDetails.getUserId()
                 );
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementAccountResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementAccountResponse.java
@@ -2,6 +2,7 @@ package org.teamsai.saibackend.domain.settlement.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
 import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
 
@@ -10,18 +11,31 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class SettlementAccountResponse {
+
     private Long settlementAccountId;
     private Long settlementId;
     private Long linkedAccountId;
+
     private SettlementAccountStatus accountStatus;
+
+    private String bankName;
+    private String maskedAccountNumber;
+    private String accountHolderName;
+
     private LocalDateTime selectedAt;
 
-    public static SettlementAccountResponse from(SettlementAccountDTO account){
+    public static SettlementAccountResponse from(
+            SettlementAccountDTO account,
+            LinkedBankAccountResponse linkedAccount
+    ) {
         return SettlementAccountResponse.builder()
                 .settlementAccountId(account.getSettlementAccountId())
                 .settlementId(account.getSettlementId())
                 .linkedAccountId(account.getLinkedAccountId())
                 .accountStatus(account.getAccountStatus())
+                .bankName(linkedAccount.bankName())
+                .maskedAccountNumber(linkedAccount.maskedAccountNumber())
+                .accountHolderName(linkedAccount.accountHolderName())
                 .selectedAt(account.getSelectedAt())
                 .build();
     }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementDetailResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementDetailResponse.java
@@ -1,0 +1,17 @@
+package org.teamsai.saibackend.domain.settlement.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record SettlementDetailResponse(
+        Long settlementId,
+        String title,
+        String settlementCategory,
+        String settlementType,
+        String settlementStatus,
+        String splitType,
+        LocalDate dueDate,
+        LocalDateTime createdAt,
+        String role
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementPaymentObligationResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementPaymentObligationResponse.java
@@ -16,7 +16,7 @@ public class SettlementPaymentObligationResponse {
 
     private Long paymentObligationId;
     private Long participantId;
-
+    private String participantName;
     private BigDecimal expectedAmount;
     private BigDecimal paidAmount;
     private BigDecimal remainingAmount;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -3,6 +3,7 @@ package org.teamsai.saibackend.domain.settlement.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementDetailResponse;
 import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
 
 import java.time.LocalDateTime;
@@ -27,5 +28,10 @@ public interface SettlementMapper {
     );
 
     List<SettlementListResponse> findAllByUserId(Long userId);
+
+    Optional<SettlementDetailResponse> findDetailById(
+            @Param("settlementId") Long settlementId,
+            @Param("userId") Long userId
+    );
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
@@ -1,8 +1,10 @@
 package org.teamsai.saibackend.domain.settlement.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
 import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementAccountDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
@@ -13,8 +15,9 @@ import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.type.SettlementAccountStatus;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Optional;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SettlementAccountService {
@@ -24,39 +27,132 @@ public class SettlementAccountService {
     private final LinkedBankAccountService linkedBankAccountService;
 
     @Transactional
-    public SettlementAccountResponse selectAccount(Long userId, Long settlementId, Long linkedAccountId){
+    public SettlementAccountResponse selectAccount(
+            Long userId,
+            Long settlementId,
+            Long linkedAccountId
+    ) {
+        log.info(
+                "[정산계좌] 설정 시작 userId={}, settlementId={}, linkedAccountId={}",
+                userId,
+                settlementId,
+                linkedAccountId
+        );
 
         SettlementDTO settlement = findSettlement(settlementId);
 
-        validatorOwner(settlement, userId);
-        validateLinkedAccountOwner(userId, linkedAccountId);
+        validatorOwner(
+                settlement,
+                userId
+        );
 
-        Optional<SettlementAccountDTO> currentAccount = settlementAccountMapper.findActiveBySettlementIdForUpdate(settlementId);
+        validateLinkedAccountOwner(
+                userId,
+                linkedAccountId
+        );
 
-        if(currentAccount.isPresent() && currentAccount.get().getLinkedAccountId().equals(linkedAccountId)){
-            return SettlementAccountResponse.from(currentAccount.get());
+        Optional<SettlementAccountDTO> currentAccount =
+                settlementAccountMapper.findActiveBySettlementIdForUpdate(
+                        settlementId
+                );
+
+        log.info(
+                "[정산계좌] 기존 ACTIVE 계좌 존재={}",
+                currentAccount.isPresent()
+        );
+
+        if (currentAccount.isPresent()
+                && Objects.equals(
+                currentAccount.get().getLinkedAccountId(),
+                linkedAccountId
+        )) {
+
+            log.info(
+                    "[정산계좌] 이미 동일 계좌 설정됨 settlementId={}",
+                    settlementId
+            );
+
+            return toResponse(
+                    userId,
+                    currentAccount.get()
+            );
         }
 
         LocalDateTime now = LocalDateTime.now();
 
-        currentAccount.ifPresent(account-> replaceCurrentAccount(account,now));
+        currentAccount.ifPresent(
+                account -> replaceCurrentAccount(
+                        account,
+                        now
+                )
+        );
 
-        SettlementAccountDTO newAccount = SettlementAccountDTO.builder()
-                .settlementId(settlementId)
-                .linkedAccountId(linkedAccountId)
-                .accountStatus(SettlementAccountStatus.ACTIVE)
-                .selectedAt(now)
-                .endedAt(null)
-                .build();
+        SettlementAccountDTO newAccount =
+                SettlementAccountDTO.builder()
+                        .settlementId(settlementId)
+                        .linkedAccountId(linkedAccountId)
+                        .accountStatus(
+                                SettlementAccountStatus.ACTIVE
+                        )
+                        .selectedAt(now)
+                        .endedAt(null)
+                        .build();
 
-        int insertedCount = settlementAccountMapper.insert(newAccount);
+        log.info(
+                "[정산계좌] INSERT 직전 settlementId={}, linkedAccountId={}, status={}",
+                newAccount.getSettlementId(),
+                newAccount.getLinkedAccountId(),
+                newAccount.getAccountStatus()
+        );
 
-        if(insertedCount != 1){
-            throw SettlementErrorCode.SETTLEMENT_ACCOUNT_CREATE_FAILED.toException();
+        int insertedCount =
+                settlementAccountMapper.insert(
+                        newAccount
+                );
+
+        log.info(
+                "[정산계좌] INSERT 결과 count={}, generatedId={}",
+                insertedCount,
+                newAccount.getSettlementAccountId()
+        );
+
+        if (insertedCount != 1) {
+            throw SettlementErrorCode
+                    .SETTLEMENT_ACCOUNT_CREATE_FAILED
+                    .toException();
         }
 
-        return SettlementAccountResponse.from(newAccount);
+        return toResponse(
+                userId,
+                newAccount
+        );
+    }
 
+    private SettlementAccountResponse toResponse(
+            Long userId,
+            SettlementAccountDTO settlementAccount
+    ) {
+        LinkedBankAccountResponse linkedAccount =
+                linkedBankAccountService
+                        .getLinkedAccounts(userId)
+                        .stream()
+                        .filter(account ->
+                                Objects.equals(
+                                        account.linkedAccountId(),
+                                        settlementAccount.getLinkedAccountId()
+                                )
+                        )
+                        .findFirst()
+                        .orElseThrow(
+                                SettlementErrorCode
+                                        .INVALID_SETTLEMENT_ACCOUNT
+                                        ::toException
+                        );
+
+        return SettlementAccountResponse.from(
+                settlementAccount,
+                linkedAccount
+        );
     }
 
     private void validateLinkedAccountOwner(Long userId, Long linkedAccountId
@@ -81,7 +177,7 @@ public class SettlementAccountService {
         SettlementAccountDTO account = settlementAccountMapper.findActiveBySettlementId(settlementId)
                 .orElseThrow(SettlementErrorCode.SETTLEMENT_ACCOUNT_NOT_FOUND::toException);
 
-        return SettlementAccountResponse.from(account);
+        return toResponse(userId, account);
     }
 
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SharedSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SharedSettlementService.java
@@ -7,6 +7,7 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSharedSettlementRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSharedSettlementResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementDetailResponse;
 import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
@@ -98,6 +99,17 @@ public class SharedSettlementService {
     @Transactional(readOnly = true)
     public List<SettlementListResponse> getSettlementList(Long userId) {
         return settlementMapper.findAllByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public SettlementDetailResponse getSettlementDetail(Long settlementId, Long userId){
+        SettlementDetailResponse response = settlementMapper.findDetailById(settlementId,userId)
+                .orElseThrow(SettlementErrorCode.SETTLEMENT_NOT_FOUND::toException);
+
+        if("NONE".equals(response.role())){
+            throw SettlementErrorCode.SETTLEMENT_ACCESS_DENIED.toException();
+        }
+        return response;
     }
 
     private void validateCreateRequest(

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -64,6 +64,7 @@
         settlement_category,
         title,
         split_type,
+        total_amount,
         due_date,
         cycle_rule,
         start_date,
@@ -89,6 +90,7 @@
         settlement_category,
         title,
         split_type,
+        total_amount,
         due_date,
         cycle_rule,
         start_date,
@@ -143,6 +145,43 @@
         )
 
         ORDER BY s.settlement_id DESC
+
+    </select>
+    <select id="findDetailById"
+            resultType="org.teamsai.saibackend.domain.settlement.dto.response.SettlementDetailResponse">
+
+        SELECT
+        s.settlement_id AS settlementId,
+        s.title AS title,
+        s.settlement_category AS settlementCategory,
+        s.settlement_type AS settlementType,
+        s.settlement_status AS settlementStatus,
+        s.split_type AS splitType,
+        s.due_date AS dueDate,
+        s.created_at AS createdAt,
+
+        CASE
+        WHEN s.owner_id = #{userId}
+        THEN 'OWNER'
+
+        WHEN EXISTS (
+        SELECT 1
+        FROM settlement_invitation si
+        JOIN settlement_participant sp
+        ON sp.invitation_id = si.invitation_id
+
+        WHERE si.settlement_id = s.settlement_id
+        AND si.user_id = #{userId}
+        AND si.invitation_status = 'ACCEPTED'
+        AND sp.participant_status = 'ACTIVE'
+        )
+        THEN 'MEMBER'
+
+        ELSE 'NONE'
+        END AS role
+
+        FROM settlement s
+        WHERE s.settlement_id = #{settlementId}
 
     </select>
 

--- a/src/main/resources/mapper/settlement/SettlementPaymentStatusMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementPaymentStatusMapper.xml
@@ -7,12 +7,12 @@
         namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementPaymentStatusMapper">
 
     <select id="findPaymentObligationsBySettlementId"
-
             resultType="org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentObligationResponse">
 
         SELECT
         po.payment_obligation_id AS paymentObligationId,
         po.participant_id AS participantId,
+        u.name AS participantName,
         po.expected_amount AS expectedAmount,
 
         COALESCE(SUM(pr.amount), 0) AS paidAmount,
@@ -24,9 +24,9 @@
 
         CASE
         WHEN COALESCE(SUM(pr.amount), 0) = 0
-            THEN 'UNPAID'
+        THEN 'UNPAID'
         WHEN COALESCE(SUM(pr.amount), 0) &lt; po.expected_amount
-            THEN 'PARTIALLY_PAID'
+        THEN 'PARTIALLY_PAID'
         ELSE 'PAID'
         END AS paymentStatus
 
@@ -37,6 +37,9 @@
 
         JOIN settlement_invitation si
         ON si.invitation_id = sp.invitation_id
+
+        JOIN users u
+        ON u.user_id = si.user_id
 
         JOIN settlement s
         ON s.settlement_id = si.settlement_id
@@ -53,8 +56,11 @@
         GROUP BY
         po.payment_obligation_id,
         po.participant_id,
+        u.name,
         po.expected_amount
+
         ORDER BY po.payment_obligation_id
+
 
     </select>
 </mapper>

--- a/src/main/resources/static/css/settlement/settlement-detail.css
+++ b/src/main/resources/static/css/settlement/settlement-detail.css
@@ -1,0 +1,62 @@
+:root {
+  --bg:#f5f6f7; --card:#fff; --line:#dfe4e8; --text:#111827; --muted:#6b7280;
+  --navy:#102f45; --green:#0a8f61; --green-soft:#e9f8f2; --blue:#1177c9;
+  --blue-soft:#eaf4fc; --red:#c62828; --red-soft:#fcecec; --shadow:0 12px 30px rgba(15,23,42,.06);
+}
+*{box-sizing:border-box}
+body{margin:0;font-family:Pretendard,"Noto Sans KR",Arial,sans-serif;background:var(--bg);color:var(--text)}
+button,a{font:inherit}
+.site-header{height:72px;background:#fff;border-bottom:1px solid #eef1f3}
+.header-inner{max-width:1240px;height:100%;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:48px}
+.brand{display:flex;align-items:center;gap:12px;color:var(--text);text-decoration:none;font-weight:800}
+.brand-mark,.profile-chip{width:30px;height:30px;border-radius:8px;background:linear-gradient(135deg,#74e5bd,#0b8059)}
+.main-nav{display:flex;gap:34px;flex:1}
+.main-nav a{color:#39424c;text-decoration:none;font-size:14px}
+.main-nav a.active{color:#07734f;font-weight:800}
+.page-shell{max-width:1240px;margin:0 auto;padding:52px 24px 90px}
+.detail-heading{display:flex;justify-content:space-between;align-items:flex-end;gap:24px;margin-bottom:20px}
+.detail-heading h1{margin:10px 0 0;font-size:30px;letter-spacing:-.04em}
+.heading-badges,.heading-actions{display:flex;gap:8px;align-items:center}
+.badge{display:inline-flex;align-items:center;min-height:26px;padding:0 9px;border-radius:6px;font-size:12px;font-weight:800}
+.badge-progress{color:var(--blue);background:var(--blue-soft)}
+.badge-role{color:#07734f;background:var(--green-soft)}
+.button{min-height:42px;padding:0 18px;border:1px solid #cfd6dc;border-radius:6px;background:#fff;color:#26313d;text-decoration:none;font-weight:700;cursor:pointer}
+.button-primary{border-color:var(--navy);background:var(--navy);color:#fff}
+.button-small{min-height:36px;padding:0 14px;font-size:13px}
+.summary-card,.meta-card,.panel{background:var(--card);border:1px solid var(--line);box-shadow:var(--shadow)}
+.summary-card{display:grid;grid-template-columns:1fr 1fr 1fr 1.25fr;align-items:center;border-radius:8px;overflow:hidden}
+.summary-item,.summary-progress{min-height:112px;padding:24px 28px;display:flex;flex-direction:column;justify-content:center}
+.summary-item+.summary-item,.summary-progress{border-left:1px solid #edf0f2}
+.summary-item span,.progress-meta,.progress-count{font-size:12px;color:var(--muted)}
+.summary-item strong{margin-top:8px;font-size:21px}.text-success{color:#07734f}.text-danger{color:var(--red)!important}
+.progress-meta{display:flex;justify-content:space-between;margin-bottom:10px}.progress-meta strong{color:#07734f}
+.progress-track{height:7px;border-radius:999px;background:#e9edef;overflow:hidden}.progress-bar{width:0;height:100%;background:#63e6b1;transition:.25s}
+.progress-count{margin-top:8px;text-align:right;color:var(--navy)}
+.meta-card{min-height:50px;margin-top:18px;padding:0 20px;border-radius:5px;display:flex;align-items:center;gap:18px}
+.meta-item{display:flex;gap:8px;font-size:13px;white-space:nowrap}.meta-item span{color:var(--muted)}.meta-grow{flex:1}
+.meta-divider{width:1px;height:22px;background:var(--line)}
+.detail-grid{margin-top:34px;display:grid;grid-template-columns:330px minmax(0,1fr);gap:28px;align-items:start}
+.side-column{display:grid;gap:22px}.panel{border-radius:8px;overflow:hidden}
+.panel-header{min-height:68px;padding:0 22px;display:flex;align-items:center;justify-content:space-between;gap:16px;border-bottom:1px solid #edf0f2}
+.panel-header h2{margin:0;font-size:17px}.panel-header p{margin:5px 0 0;color:var(--muted);font-size:12px}
+.text-button{border:0;background:none;color:var(--navy);cursor:pointer;font-size:12px;font-weight:700}
+.account-card{margin:20px 22px 12px;padding:16px;display:flex;gap:13px;align-items:center;border-radius:6px;background:#eef1f3}
+.account-icon{width:38px;height:38px;display:grid;place-items:center;border-radius:8px;background:#fff;color:var(--navy);font-weight:800}
+.account-card span,.account-card small{display:block;color:var(--muted);font-size:11px}.account-card strong{display:block;margin:4px 0;font-size:14px}
+.info-list{margin:0;padding:6px 22px 18px}.info-list div{padding:13px 0;display:flex;justify-content:space-between;border-bottom:1px solid #edf0f2}.info-list div:last-child{border-bottom:0}
+.info-list dt,.info-list dd{margin:0;font-size:12px}.info-list dt{color:var(--muted)}.info-list dd{font-weight:700}
+.panel-side-text{color:#07734f;font-size:12px;font-weight:800}
+.participant-avatar-list{padding:20px 18px 24px;display:grid;grid-template-columns:repeat(3,1fr);gap:18px 10px}
+.participant-avatar{text-align:center;min-width:0}.avatar-circle{width:42px;height:42px;margin:0 auto 8px;display:grid;place-items:center;border-radius:12px;background:#eef1f3}
+.participant-avatar strong,.participant-avatar small{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.participant-avatar strong{font-size:12px}.participant-avatar small{margin-top:3px;color:var(--muted);font-size:10px}
+.participant-panel-header{min-height:82px}.table-scroll{overflow-x:auto}
+.payment-table{width:100%;min-width:820px;border-collapse:collapse}.payment-table th{padding:15px 18px;background:#f2f4f6;border-bottom:1px solid var(--line);font-size:12px;color:#4b5563}
+.payment-table td{padding:19px 18px;border-bottom:1px solid #edf0f2;text-align:center;font-size:13px}.name-cell{font-weight:800}
+.status-chip{display:inline-flex;align-items:center;padding:5px 8px;border-radius:999px;font-size:11px;font-weight:800}
+.status-unpaid{background:#f0f2f4;color:#626b74}.status-partial{background:#fff4d6;color:#9a6500}.status-paid{background:var(--green-soft);color:#07734f}.status-review{background:var(--red-soft);color:var(--red)}
+.manage-button{border:0;border-radius:5px;padding:6px 9px;background:var(--blue);color:#fff;font-size:11px;font-weight:800}.manage-button[disabled]{background:#e5e7eb;color:#7b8490}
+.empty-state{padding:70px 20px;text-align:center;color:var(--muted)}
+.toast{position:fixed;left:50%;bottom:28px;transform:translate(-50%,20px);min-width:260px;padding:13px 18px;border-radius:8px;background:#17212b;color:#fff;opacity:0;pointer-events:none;transition:.2s;z-index:50;text-align:center}
+.toast.visible{transform:translate(-50%,0);opacity:1}.toast.error{background:#a72222}
+@media(max-width:980px){.detail-grid{grid-template-columns:1fr}.side-column{grid-template-columns:repeat(2,1fr)}.summary-card{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:720px){.header-inner{padding:16px 20px;flex-wrap:wrap;height:auto}.site-header{height:auto}.main-nav{order:3;width:100%;overflow:auto}.detail-heading{flex-direction:column;align-items:flex-start}.summary-card{grid-template-columns:1fr}.summary-item+.summary-item,.summary-progress{border-left:0;border-top:1px solid #edf0f2}.meta-card{padding:16px 18px;flex-direction:column;align-items:flex-start}.meta-divider{width:100%;height:1px}.side-column{grid-template-columns:1fr}}

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -1,0 +1,911 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const token = sessionStorage.getItem("accessToken");
+    const settlementId = getSettlementIdFromPath();
+
+    const toast = document.getElementById("toast");
+    const closeButton = document.getElementById("close-button");
+    const syncButton = document.getElementById("sync-button");
+    const refreshButton = document.getElementById("refresh-button");
+    const changeAccountButton =
+        document.getElementById("change-account-button");
+
+    if (!settlementId) {
+        showToast(
+            "정산 ID를 확인할 수 없습니다.",
+            true
+        );
+        return;
+    }
+
+    if (!token) {
+        redirectToLogin();
+        return;
+    }
+
+    loadPage();
+
+    if (refreshButton) {
+        refreshButton.addEventListener(
+            "click",
+            loadPage
+        );
+    }
+
+    if (closeButton) {
+        closeButton.addEventListener(
+            "click",
+            closeSettlement
+        );
+    }
+    if (syncButton) {
+        syncButton.addEventListener(
+            "click",
+            () => {
+                showToast(
+                    "거래내역 동기화 API 연결 전입니다."
+                );
+            }
+        );
+    }
+
+
+    if (changeAccountButton) {
+        changeAccountButton.addEventListener(
+            "click",
+            () => {
+                showToast(
+                    "수취 계좌 변경 기능 연결 전입니다."
+                );
+            }
+        );
+    }
+
+    async function loadPage() {
+        try {
+            setLoading(true);
+
+            const [
+                detail,
+                paymentStatus
+            ] = await Promise.all([
+                requestJson(
+                    `/api/settlements/${settlementId}`
+                ),
+                requestJson(
+                    `/api/settlements/${settlementId}/payment-status`
+                )
+            ]);
+
+            renderDetail(detail);
+            renderPaymentStatus(paymentStatus);
+
+            await loadSettlementAccount();
+
+            const syncTime =
+                document.getElementById(
+                    "sync-time"
+                );
+
+            if (syncTime) {
+                syncTime.textContent =
+                    formatDateTime(new Date());
+            }
+
+        } catch (error) {
+            console.error(
+                "정산 상세 조회 실패:",
+                error
+            );
+
+            showToast(
+                error.message ||
+                "정산 상세 정보를 불러오지 못했습니다.",
+                true
+            );
+
+        } finally {
+            setLoading(false);
+        }
+    }
+    async function loadSettlementAccount() {
+        try {
+            const account =
+                await requestSettlementAccount();
+
+            renderSettlementAccount(
+                account
+            );
+
+        } catch (error) {
+            console.error(
+                "수취 계좌 조회 실패:",
+                error
+            );
+
+            renderSettlementAccount(null);
+        }
+    }
+
+    async function requestSettlementAccount() {
+        const response =
+            await fetch(
+                `/api/settlements/${settlementId}/account`,
+                {
+                    method: "GET",
+                    headers: {
+                        "Authorization":
+                            `Bearer ${token}`
+                    }
+                }
+            );
+
+        if (response.status === 401) {
+            sessionStorage.removeItem(
+                "accessToken"
+            );
+
+            redirectToLogin();
+
+            throw new Error(
+                "로그인이 필요합니다."
+            );
+        }
+
+        if (response.status === 403) {
+            throw new Error(
+                "수취 계좌 조회 권한이 없습니다."
+            );
+        }
+
+        if (response.status === 404) {
+            return null;
+        }
+
+        if (!response.ok) {
+            throw new Error(
+                "수취 계좌 조회에 실패했습니다."
+            );
+        }
+
+        return response.json();
+    }
+    async function requestJson(
+        url,
+        options = {}
+    ) {
+        const response =
+            await fetch(
+                url,
+                {
+                    ...options,
+
+                    headers: {
+                        ...(options.headers || {}),
+
+                        "Authorization":
+                            `Bearer ${token}`
+                    }
+                }
+            );
+
+
+        if (response.status === 401) {
+            sessionStorage.removeItem(
+                "accessToken"
+            );
+
+            redirectToLogin();
+
+            throw new Error(
+                "로그인이 필요합니다."
+            );
+        }
+
+        if (response.status === 403) {
+            throw new Error(
+                "해당 정산을 조회할 권한이 없습니다."
+            );
+        }
+
+        if (response.status === 404) {
+            throw new Error(
+                "정산을 찾을 수 없습니다."
+            );
+        }
+
+        if (!response.ok) {
+            let message =
+                "요청 처리에 실패했습니다.";
+
+            try {
+                const body =
+                    await response.json();
+
+                message =
+                    body.message ||
+                    message;
+
+            } catch (error) {
+                // JSON 응답이 아니면
+                // 기본 메시지 사용
+            }
+
+            throw new Error(message);
+        }
+
+        if (response.status === 204) {
+            return null;
+        }
+
+        return response.json();
+    }
+
+    function renderDetail(detail) {
+        setText(
+            "settlement-title",
+            detail.title ||
+            "이름 없는 정산"
+        );
+
+        setText(
+            "settlement-category",
+            detail.settlementCategory ||
+            "-"
+        );
+
+        setText(
+            "due-date",
+            formatDate(
+                detail.dueDate
+            )
+        );
+
+        setText(
+            "created-at",
+            formatDate(
+                detail.createdAt
+            )
+        );
+
+        setText(
+            "split-type",
+            getSplitTypeText(
+                detail.splitType
+            )
+        );
+
+        setText(
+            "settlement-status-badge",
+            getSettlementStatusText(
+                detail.settlementStatus
+            )
+        );
+
+        setText(
+            "settlement-role-badge",
+            getRoleText(
+                detail.role
+            )
+        );
+
+        if (closeButton) {
+            closeButton.hidden =
+                detail.role !== "OWNER";
+
+            closeButton.disabled =
+                detail.settlementStatus ===
+                "CLOSED";
+        }
+    }
+    function renderPaymentStatus(status) {
+        setText(
+            "total-expected-amount",
+            formatMoney(status.totalExpectedAmount)
+        );
+
+        setText(
+            "total-paid-amount",
+            formatMoney(status.totalPaidAmount)
+        );
+
+        setText(
+            "total-remaining-amount",
+            formatMoney(status.totalRemainingAmount)
+        );
+
+        const progressRate =
+            normalizeRate(status.progressRate);
+
+        setText(
+            "amount-progress-rate",
+            `${progressRate}%`
+        );
+
+        const progressBar =
+            document.getElementById("progress-bar");
+
+        if (progressBar) {
+            progressBar.style.width =
+                `${progressRate}%`;
+        }
+
+        const obligations =
+            Array.isArray(status.obligations)
+                ? status.obligations
+                : [];
+
+        const totalCount =
+            obligations.length;
+
+        const paidCount =
+            obligations.filter(
+                obligation =>
+                    obligation.paymentStatus === "PAID"
+            ).length;
+
+        setText(
+            "completed-target-count",
+            paidCount
+        );
+
+        setText(
+            "total-target-count",
+            totalCount
+        );
+
+        setText(
+            "participant-count",
+            totalCount
+        );
+
+        const participantProgressRate =
+            totalCount === 0
+                ? 0
+                : Math.round(
+                    (paidCount / totalCount) * 100
+                );
+
+        setText(
+            "target-completion-rate",
+            `${participantProgressRate}%`
+        );
+
+
+        setText(
+            "attention-count",
+            "0명"
+        );
+
+        renderParticipants(
+            obligations
+        );
+
+        renderParticipantAvatars(
+            obligations
+        );
+
+        if (closeButton) {
+            closeButton.disabled =
+                !status.closable;
+        }
+    }
+
+    function renderSettlementAccount(account) {
+        if (!account) {
+            setText(
+                "bank-name",
+                "수취 계좌"
+            );
+
+            setText(
+                "masked-account-number",
+                "계좌 정보 없음"
+            );
+
+            setText(
+                "account-holder-name",
+                "-"
+            );
+
+            return;
+        }
+
+        setText(
+            "bank-name",
+            account.bankName || "수취 계좌"
+        );
+
+        setText(
+            "masked-account-number",
+            account.maskedAccountNumber ||
+            "계좌 정보 없음"
+        );
+
+        setText(
+            "account-holder-name",
+            account.accountHolderName || "-"
+        );
+    }
+    function renderParticipants(obligations) {
+        const tableBody =
+            document.getElementById(
+                "payment-table-body"
+            );
+
+        const emptyState =
+            document.getElementById(
+                "empty-participants"
+            );
+
+        if (!tableBody) {
+            return;
+        }
+
+        tableBody.innerHTML = "";
+
+        if (obligations.length === 0) {
+            if (emptyState) {
+                emptyState.hidden = false;
+            }
+
+            return;
+        }
+
+        if (emptyState) {
+            emptyState.hidden = true;
+        }
+
+        obligations.forEach(
+            obligation => {
+
+                const row =
+                    document.createElement("tr");
+
+                row.innerHTML = `
+                <td class="name-cell">
+                    ${escapeHtml(
+                    obligation.participantName ||
+                    `참여자 #${obligation.participantId}`
+                )}
+                </td>
+
+                <td>
+                    ${formatMoney(
+                    obligation.expectedAmount
+                )}원
+                </td>
+
+                <td>
+                    ${formatMoney(
+                    obligation.paidAmount
+                )}원
+                </td>
+
+                <td>
+                    ${formatMoney(
+                    obligation.remainingAmount
+                )}원
+                </td>
+
+                <td>
+                    -
+                </td>
+
+                <td>
+                    ${createPaymentStatusChip(
+                    obligation.paymentStatus
+                )}
+                </td>
+
+                <td>
+                    <button
+                        class="manage-button"
+                        type="button"
+                        disabled
+                    >
+                        -
+                    </button>
+                </td>
+            `;
+
+                tableBody.appendChild(row);
+            }
+        );
+    }
+
+    function renderParticipantAvatars(
+        obligations
+    ) {
+        const container =
+            document.getElementById(
+                "participant-avatar-list"
+            );
+
+        if (!container) {
+            return;
+        }
+
+        container.innerHTML = "";
+
+        if (obligations.length === 0) {
+            container.innerHTML = `
+            <div class="participant-avatar">
+                <small>
+                    참여자가 없습니다.
+                </small>
+            </div>
+        `;
+
+            return;
+        }
+
+        obligations
+            .slice(0, 6)
+            .forEach(
+                obligation => {
+
+                    const item =
+                        document.createElement(
+                            "div"
+                        );
+
+                    item.className =
+                        "participant-avatar";
+
+                    item.innerHTML = `
+                    <div class="avatar-circle">
+                        ◎
+                    </div>
+
+                    <strong>
+                        ${escapeHtml(
+                            obligation.participantName ||
+                            `참여자 #${obligation.participantId}`
+                    )}
+                    </strong>
+
+                    <small>
+                        ${escapeHtml(
+                        getPaymentStatusText(
+                            obligation.paymentStatus
+                        )
+                    )}
+                    </small>
+                `;
+
+                    container.appendChild(
+                        item
+                    );
+                }
+            );
+    }
+
+
+    async function closeSettlement() {
+        if (
+            !window.confirm(
+                "이 정산을 마감하시겠습니까?"
+            )
+        ) {
+            return;
+        }
+
+        try {
+            if (closeButton) {
+                closeButton.disabled =
+                    true;
+            }
+
+            await requestJson(
+                `/api/settlements/${settlementId}/close`,
+                {
+                    method: "POST"
+                }
+            );
+
+            showToast(
+                "정산이 마감되었습니다."
+            );
+
+            await loadPage();
+
+        } catch (error) {
+            console.error(
+                "정산 마감 실패:",
+                error
+            );
+
+            showToast(
+                error.message ||
+                "정산 마감에 실패했습니다.",
+                true
+            );
+
+        } finally {
+            if (closeButton) {
+                closeButton.disabled =
+                    false;
+            }
+        }
+    }
+
+    function createPaymentStatusChip(
+        status
+    ) {
+        if (status === "PAID") {
+            return `
+                <span
+                    class="status-chip status-paid"
+                >
+                    ● 입금 완료
+                </span>
+            `;
+        }
+
+        if (
+            status ===
+            "PARTIALLY_PAID"
+        ) {
+            return `
+                <span
+                    class="status-chip status-partial"
+                >
+                    ● 일부 입금
+                </span>
+            `;
+        }
+
+        return `
+            <span
+                class="status-chip status-unpaid"
+            >
+                ● 미입금
+            </span>
+        `;
+    }
+
+    function getPaymentStatusText(
+        status
+    ) {
+        switch (status) {
+            case "PAID":
+                return "입금 완료";
+
+            case "PARTIALLY_PAID":
+                return "일부 입금";
+
+            case "UNPAID":
+                return "미입금";
+
+            default:
+                return "-";
+        }
+    }
+
+    function getSettlementStatusText(
+        status
+    ) {
+        switch (status) {
+            case "IN_PROGRESS":
+                return "진행중";
+
+            case "CLOSED":
+                return "완료";
+
+            case "CANCELLED":
+                return "취소";
+
+            default:
+                return "-";
+        }
+    }
+
+    function getSplitTypeText(
+        splitType
+    ) {
+        switch (splitType) {
+            case "EQUAL":
+                return "균등";
+
+            case "CUSTOM":
+                return "직접 설정";
+
+            default:
+                return "-";
+        }
+    }
+
+    function getRoleText(role) {
+        switch (role) {
+            case "OWNER":
+                return "정산자";
+
+            case "MEMBER":
+                return "참여자";
+
+            default:
+                return "-";
+        }
+    }
+
+    function getSettlementIdFromPath() {
+        const match =
+            window.location.pathname.match(
+                /^\/settlements\/(\d+)\/?$/
+            );
+
+        return match
+            ? match[1]
+            : null;
+    }
+
+    function normalizeRate(value) {
+        const number =
+            Number(value || 0);
+
+        if (!Number.isFinite(number)) {
+            return 0;
+        }
+
+        return Math.max(
+            0,
+            Math.min(
+                100,
+                Math.round(
+                    number * 100
+                ) / 100
+            )
+        );
+    }
+
+    function formatMoney(value) {
+        const number =
+            Number(value || 0);
+
+        if (!Number.isFinite(number)) {
+            return "0";
+        }
+
+        return new Intl.NumberFormat(
+            "ko-KR"
+        ).format(number);
+    }
+
+    function formatDate(value) {
+        if (!value) {
+            return "-";
+        }
+
+        const parts =
+            String(value)
+                .split("T")[0]
+                .split("-");
+
+        if (parts.length !== 3) {
+            return String(value);
+        }
+
+        return `${parts[0]}.${parts[1]}.${parts[2]}`;
+    }
+
+    function formatDateTime(value) {
+        if (!value) {
+            return "-";
+        }
+
+        const date =
+            value instanceof Date
+                ? value
+                : new Date(value);
+
+        if (
+            Number.isNaN(
+                date.getTime()
+            )
+        ) {
+            return String(value);
+        }
+
+        return new Intl.DateTimeFormat(
+            "ko-KR",
+            {
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                minute: "2-digit"
+            }
+        ).format(date);
+    }
+
+    function setText(
+        id,
+        value
+    ) {
+        const element =
+            document.getElementById(id);
+
+        if (element) {
+            element.textContent =
+                value;
+        }
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replaceAll(
+                "&",
+                "&amp;"
+            )
+            .replaceAll(
+                "<",
+                "&lt;"
+            )
+            .replaceAll(
+                ">",
+                "&gt;"
+            )
+            .replaceAll(
+                '"',
+                "&quot;"
+            )
+            .replaceAll(
+                "'",
+                "&#039;"
+            );
+    }
+
+    function setLoading(loading) {
+        if (!refreshButton) {
+            return;
+        }
+
+        refreshButton.disabled =
+            loading;
+
+        refreshButton.textContent =
+            loading
+                ? "불러오는 중..."
+                : "↻ 새로고침";
+    }
+
+    function redirectToLogin() {
+        window.location.href =
+            "/login?required=true";
+    }
+
+    function showToast(
+        message,
+        isError = false
+    ) {
+        if (!toast) {
+            return;
+        }
+
+        toast.textContent =
+            message;
+
+        toast.classList.toggle(
+            "error",
+            isError
+        );
+
+        toast.classList.add(
+            "visible"
+        );
+
+        window.clearTimeout(
+            showToast.timer
+        );
+
+        showToast.timer =
+            window.setTimeout(
+                () => {
+                    toast.classList.remove(
+                        "visible"
+                    );
+                },
+                3000
+            );
+    }
+});

--- a/src/main/resources/static/js/settlement/settlement-list.js
+++ b/src/main/resources/static/js/settlement/settlement-list.js
@@ -106,9 +106,8 @@ document.addEventListener("DOMContentLoaded", () => {
             <span>${escapeHtml(formatDate(settlement.dueDate))}</span>
             <a
                 class="detail-link"
-                href="/settlements"
-                aria-label="정산 상세 기능 준비 중"
-                title="상세 조회 API 구현 후 연결"
+                href="/settlements/${settlement.settlementId}"
+                aria-label="${escapeHtml(settlement.title || "정산")} 상세 조회"
             >›</a>
         `;
 

--- a/src/main/resources/templates/settlement/settlement-detail.html
+++ b/src/main/resources/templates/settlement/settlement-detail.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>정산 상세 | 사이원장</title>
+  <link rel="stylesheet" href="/css/settlement/settlement-detail.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="header-inner">
+    <a class="brand" href="/">
+      <span class="brand-mark"></span><span>사이원장</span>
+    </a>
+    <nav class="main-nav">
+      <a href="/">서비스소개</a>
+      <a href="/contracts">금전소비대차</a>
+      <a class="active" href="/settlements">정산</a>
+      <a href="/calendar">캘린더</a>
+    </nav>
+    <div class="profile-chip"></div>
+  </div>
+</header>
+
+<main class="page-shell">
+  <section class="detail-heading">
+    <div>
+      <div class="heading-badges">
+        <span id="settlement-status-badge" class="badge badge-progress">진행중</span>
+        <span id="settlement-role-badge" class="badge badge-role">정산자</span>
+      </div>
+      <h1 id="settlement-title">정산 상세</h1>
+    </div>
+    <div class="heading-actions">
+      <a class="button button-secondary" href="/settlements">목록으로</a>
+      <button id="sync-button" class="button button-secondary" type="button">↻ 거래내역 동기화</button>
+      <button id="close-button" class="button button-primary" type="button">정산 마감</button>
+    </div>
+  </section>
+
+  <section class="summary-card">
+    <div class="summary-item">
+      <span>전체 지출 합계</span>
+      <strong><span id="total-expected-amount">0</span>원</strong>
+    </div>
+    <div class="summary-item">
+      <span>입금 완료 금액</span>
+      <strong class="text-success"><span id="total-paid-amount">0</span>원</strong>
+    </div>
+    <div class="summary-item">
+      <span>미정산 금액</span>
+      <strong><span id="total-remaining-amount">0</span>원</strong>
+    </div>
+    <div class="summary-progress">
+      <div class="progress-meta"><span>입금률</span><strong id="amount-progress-rate">0%</strong></div>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <div class="progress-count"><strong id="completed-target-count">0</strong>/<span id="total-target-count">0</span></div>
+    </div>
+  </section>
+
+  <section class="meta-card">
+    <div class="meta-item"><span>생성일</span><strong id="created-at">-</strong></div>
+    <div class="meta-divider"></div>
+    <div class="meta-item"><span>마감일</span><strong id="due-date">-</strong></div>
+    <div class="meta-divider"></div>
+    <div class="meta-item meta-grow"><span>정산 목적</span><strong id="settlement-category">-</strong></div>
+    <div class="meta-divider"></div>
+    <div class="meta-item"><span>참여 인원</span><strong><span id="participant-count">0</span>명</strong></div>
+  </section>
+
+  <div class="detail-grid">
+    <aside class="side-column">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>정산 요청 정보</h2>
+          <button id="change-account-button" class="text-button" type="button">요청 계좌 변경</button>
+        </div>
+        <div class="account-card">
+          <div class="account-icon">₩</div>
+          <div>
+            <span id="bank-name">수취 계좌</span>
+            <strong id="masked-account-number">계좌 정보 없음</strong>
+            <small id="account-holder-name">-</small>
+          </div>
+        </div>
+        <dl class="info-list">
+          <div><dt>분배 방식</dt><dd id="split-type">-</dd></div>
+          <div><dt>최근 동기화</dt><dd id="sync-time">-</dd></div>
+          <div><dt>확인 필요</dt><dd id="attention-count" class="text-danger">0명</dd></div>
+        </dl>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>참여자 정산 현황</h2>
+          <span id="target-completion-rate" class="panel-side-text">0%</span>
+        </div>
+        <div id="participant-avatar-list" class="participant-avatar-list"></div>
+      </section>
+    </aside>
+
+    <section class="panel participant-panel">
+      <div class="panel-header participant-panel-header">
+        <div>
+          <h2>참여자별 입금 현황</h2>
+          <p>정산 생성 시 만들어진 납부의무와 실제 입금 반영 결과입니다.</p>
+        </div>
+        <button id="refresh-button" class="button button-secondary button-small" type="button">↻ 새로고침</button>
+      </div>
+      <div class="table-scroll">
+        <table class="payment-table">
+          <thead>
+          <tr>
+            <th>참여자</th>
+            <th>분담 금액</th>
+            <th>입금 금액</th>
+            <th>잔여 금액</th>
+            <th>최근 입금일</th>
+            <th>입금 상태</th>
+            <th>관리</th>
+          </tr>
+          </thead>
+          <tbody id="payment-table-body"></tbody>
+        </table>
+      </div>
+      <div id="empty-participants" class="empty-state" hidden>등록된 납부 대상이 없습니다.</div>
+    </section>
+  </div>
+</main>
+
+<div id="toast" class="toast"></div>
+<script src="/js/settlement/settlement-detail.js"></script>
+</body>
+</html>

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SharedSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SharedSettlementServiceTest.java
@@ -11,6 +11,7 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementInvitationRequest;
 import org.teamsai.saibackend.domain.settlement.dto.request.CreateSharedSettlementRequest;
 import org.teamsai.saibackend.domain.settlement.dto.response.CreateSharedSettlementResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementDetailResponse;
 import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
@@ -24,7 +25,9 @@ import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -424,6 +427,64 @@ class SharedSettlementServiceTest {
                 .findAllByUserId(userId);
     }
 
+    @Test
+    @DisplayName("정산 생성자는 정산 상세를 조회할 수 있다")
+    void getSettlementDetailByOwner() {
+        SettlementDetailResponse detail = createDetail("OWNER");
+
+        given(settlementMapper.findDetailById(
+                SETTLEMENT_ID,
+                OWNER_ID
+        )).willReturn(Optional.of(detail));
+
+        SettlementDetailResponse result =
+                sharedSettlementService.getSettlementDetail(
+                        SETTLEMENT_ID,
+                        OWNER_ID
+                );
+
+        assertThat(result.settlementId()).isEqualTo(SETTLEMENT_ID);
+        assertThat(result.title()).isEqualTo("테스트 정산");
+        assertThat(result.role()).isEqualTo("OWNER");
+    }
+
+    @Test
+    @DisplayName("정산 참여자는 정산 상세를 조회할 수 있다")
+    void getSettlementDetailByMember() {
+        Long memberId = 2L;
+
+        given(settlementMapper.findDetailById(
+                SETTLEMENT_ID,
+                memberId
+        )).willReturn(Optional.of(createDetail("MEMBER")));
+
+        SettlementDetailResponse result =
+                sharedSettlementService.getSettlementDetail(
+                        SETTLEMENT_ID,
+                        memberId
+                );
+
+        assertThat(result.role()).isEqualTo("MEMBER");
+    }
+
+    @Test
+    @DisplayName("정산과 관계없는 사용자는 상세를 조회할 수 없다")
+    void getSettlementDetailFailsWhenNotParticipant() {
+        Long otherUserId = 3L;
+
+        given(settlementMapper.findDetailById(
+                SETTLEMENT_ID,
+                otherUserId
+        )).willReturn(Optional.of(createDetail("NONE")));
+
+        assertThatThrownBy(() ->
+                sharedSettlementService.getSettlementDetail(
+                        SETTLEMENT_ID,
+                        otherUserId
+                )
+        ).isInstanceOf(DomainException.class);
+    }
+
     private CreateSettlementInvitationRequest invitation(
             String userToken
     ) {
@@ -443,5 +504,19 @@ class SharedSettlementServiceTest {
                                 exception.getErrorCode()
                         ).isEqualTo(errorCode)
                 );
+    }
+
+    private SettlementDetailResponse createDetail(String role) {
+        return new SettlementDetailResponse(
+                SETTLEMENT_ID,
+                "테스트 정산",
+                "모임",
+                "SHARED",
+                "IN_PROGRESS",
+                "EQUAL",
+                LocalDate.now().plusDays(7),
+                LocalDateTime.now(),
+                role
+        );
     }
 }


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #102 

## 🛠 작업 사항

- 정산 상세 조회 기능 구현 추가
- 정산 생성 시 연결했던 수취계좌 및 모든 정산에 대한 납부 현황을 조회하는 api와 연결
- 상세 조회 화면 구현 및 연결

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

-