### PR TITLE
refactor(#110): 거래 동기화 연동

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/account/mapper/LinkedBankAccountMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/account/mapper/LinkedBankAccountMapper.java
@@ -17,6 +17,8 @@ public interface LinkedBankAccountMapper {
 
     List<LinkedBankAccountDTO> selectLinkedAccountsByUserId(@Param("userId") Long userId);
 
+    List<LinkedBankAccountDTO> selectAvailableLinkedAccountsByUserId(@Param("userId") Long userId);
+
     Long findLastSyncedTransactionIdById(@Param("linkedAccountId") Long linkedAccountId);
 
     int updateLastSyncedTransactionId(

--- a/src/main/java/org/teamsai/saibackend/domain/account/service/LinkedBankAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/account/service/LinkedBankAccountService.java
@@ -81,7 +81,8 @@ public class LinkedBankAccountService {
             return Collections.emptyList();
         }
 
-        List<LinkedBankAccountDTO> linkedAccounts = linkedBankAccountMapper.selectLinkedAccountsByUserId(userId);
+        List<LinkedBankAccountDTO> linkedAccounts =
+                linkedBankAccountMapper.selectAvailableLinkedAccountsByUserId(userId);
         if (linkedAccounts == null || linkedAccounts.isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/controller/TransactionSyncController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/controller/TransactionSyncController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
 import org.teamsai.saibackend.domain.transaction.service.TransactionSyncFacade;
 import org.teamsai.saibackend.global.security.CustomUserDetails;
 
@@ -27,6 +28,17 @@ public class TransactionSyncController {
     ) {
         return ResponseEntity.ok(
                 transactionSyncFacade.syncAndMatch(userDetails.getUserId(), linkedAccountId)
+        );
+    }
+
+    @Operation(summary = "전체 연동계좌 거래 동기화")
+    @PostMapping("/api/transactions/sync")
+    public ResponseEntity<TransactionSyncAllResponse> syncAll(
+            @AuthenticationPrincipal
+            CustomUserDetails userDetails
+    ){
+        return ResponseEntity.ok(
+                transactionSyncFacade.syncAll(userDetails.getUserId())
         );
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/AccountSyncFailureResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/AccountSyncFailureResponse.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.transaction.dto.response;
+
+public record AccountSyncFailureResponse(
+        Long linkedAccountId,
+        String errorCode
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/TransactionSyncAllResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/TransactionSyncAllResponse.java
@@ -1,7 +1,10 @@
 package org.teamsai.saibackend.domain.transaction.dto.response;
 
+import java.util.List;
+
 public record TransactionSyncAllResponse(
         int syncedAccountCount,
+        List<AccountSyncFailureResponse> failedAccounts,
         int totalTransactionCount,
         int appliedCount,
         int needsCheckCount,

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/TransactionSyncAllResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/dto/response/TransactionSyncAllResponse.java
@@ -1,0 +1,12 @@
+package org.teamsai.saibackend.domain.transaction.dto.response;
+
+public record TransactionSyncAllResponse(
+        int syncedAccountCount,
+        int totalTransactionCount,
+        int appliedCount,
+        int needsCheckCount,
+        int unmatchedCount,
+        int duplicateCount,
+        int failedCount
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
@@ -2,8 +2,13 @@ package org.teamsai.saibackend.domain.transaction.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
+import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
+import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -11,9 +16,44 @@ public class TransactionSyncFacade {
 
     private final TransactionSyncService transactionSyncService;
     private final BankMatchingService bankMatchingService;
+    private final LinkedBankAccountService linkedBankAccountService;
 
     public AutoMatchingExecutionResult syncAndMatch(Long userId, Long linkedAccountId) {
         transactionSyncService.syncTransactions(userId, linkedAccountId);
         return bankMatchingService.execute(linkedAccountId);
+    }
+
+    public TransactionSyncAllResponse syncAll(Long userId){
+        List<LinkedBankAccountResponse> accounts =
+                linkedBankAccountService.getLinkedAccounts(userId);
+
+        int totalTransactionCount = 0;
+        int appliedCount = 0;
+        int needsCheckCount = 0;
+        int unmatchedCount = 0;
+        int duplicateCount = 0;
+        int failedCount = 0;
+
+        for(LinkedBankAccountResponse account : accounts){
+            AutoMatchingExecutionResult result =
+                    syncAndMatch(userId, account.linkedAccountId());
+
+            totalTransactionCount += result.totalTransactionCount();
+            appliedCount += result.appliedCount();
+            needsCheckCount += result.needsCheckCount();
+            unmatchedCount += result.unmatchedCount();
+            duplicateCount += result.duplicateCount();
+            failedCount += result.failedCount();
+        }
+
+        return new TransactionSyncAllResponse(
+                accounts.size(),
+                totalTransactionCount,
+                appliedCount,
+                needsCheckCount,
+                unmatchedCount,
+                duplicateCount,
+                failedCount
+        );
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
@@ -1,15 +1,20 @@
 package org.teamsai.saibackend.domain.transaction.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
 import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
 import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
+import org.teamsai.saibackend.domain.transaction.dto.response.AccountSyncFailureResponse;
+import org.teamsai.saibackend.global.exception.DomainException;
 
+import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TransactionSyncFacade {
@@ -27,27 +32,45 @@ public class TransactionSyncFacade {
         List<LinkedBankAccountResponse> accounts =
                 linkedBankAccountService.getLinkedAccounts(userId);
 
+        int syncedAccountCount = 0;
         int totalTransactionCount = 0;
         int appliedCount = 0;
         int needsCheckCount = 0;
         int unmatchedCount = 0;
         int duplicateCount = 0;
         int failedCount = 0;
+        List<AccountSyncFailureResponse> failedAccounts = new ArrayList<>();
 
         for(LinkedBankAccountResponse account : accounts){
-            AutoMatchingExecutionResult result =
-                    syncAndMatch(userId, account.linkedAccountId());
+            try {
+                AutoMatchingExecutionResult result =
+                        syncAndMatch(userId, account.linkedAccountId());
 
-            totalTransactionCount += result.totalTransactionCount();
-            appliedCount += result.appliedCount();
-            needsCheckCount += result.needsCheckCount();
-            unmatchedCount += result.unmatchedCount();
-            duplicateCount += result.duplicateCount();
-            failedCount += result.failedCount();
+                syncedAccountCount++;
+                totalTransactionCount += result.totalTransactionCount();
+                appliedCount += result.appliedCount();
+                needsCheckCount += result.needsCheckCount();
+                unmatchedCount += result.unmatchedCount();
+                duplicateCount += result.duplicateCount();
+                failedCount += result.failedCount();
+            } catch (DomainException e) {
+                String errorCode = e.getErrorCode().toString();
+                failedAccounts.add(new AccountSyncFailureResponse(
+                        account.linkedAccountId(),
+                        errorCode
+                ));
+                log.warn(
+                        "Account sync failed - linkedAccountId: {}, errorCode: {}",
+                        account.linkedAccountId(),
+                        errorCode,
+                        e
+                );
+            }
         }
 
         return new TransactionSyncAllResponse(
-                accounts.size(),
+                syncedAccountCount,
+                List.copyOf(failedAccounts),
                 totalTransactionCount,
                 appliedCount,
                 needsCheckCount,

--- a/src/main/resources/mapper/link/LinkedBankAccountMapper.xml
+++ b/src/main/resources/mapper/link/LinkedBankAccountMapper.xml
@@ -17,8 +17,24 @@
         created_at AS createdAt
         FROM linked_bank_account
         WHERE user_id = #{userId}
-        AND connection_status = 'AVAILABLE'
         <!-- 현재 활성 상태인 것만 소유권으로 인정할지는 나중에 정함 -->
+    </select>
+
+    <select id="selectAvailableLinkedAccountsByUserId"
+            resultType="org.teamsai.saibackend.domain.account.dto.LinkedBankAccountDTO">
+        SELECT
+        linked_account_id,
+        user_id AS userId,
+        account_id AS accountId,
+        account_number AS accountNumber,
+        bank_code AS bankCode,
+        account_holder_name AS accountHolderName,
+        connection_status AS connectionStatus,
+        balance AS balance,
+        created_at AS createdAt
+        FROM linked_bank_account
+        WHERE user_id = #{userId}
+        AND connection_status = 'AVAILABLE'
     </select>
 
     <insert id="insertOne" useGeneratedKeys="true" keyProperty="linkedAccountId">

--- a/src/main/resources/mapper/link/LinkedBankAccountMapper.xml
+++ b/src/main/resources/mapper/link/LinkedBankAccountMapper.xml
@@ -17,6 +17,7 @@
         created_at AS createdAt
         FROM linked_bank_account
         WHERE user_id = #{userId}
+        AND connection_status = 'AVAILABLE'
         <!-- 현재 활성 상태인 것만 소유권으로 인정할지는 나중에 정함 -->
     </select>
 

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -48,16 +48,42 @@ document.addEventListener("DOMContentLoaded", () => {
         );
     }
 
-
-    if (changeAccountButton) {
-        changeAccountButton.addEventListener(
+    if (syncButton) {
+        syncButton.addEventListener(
             "click",
-            () => {
-                showToast(
-                    "수취 계좌 변경 기능 연결 전입니다."
-                );
-            }
+            syncTransactions
         );
+    }
+
+    async function syncTransactions() {
+        try {
+            syncButton.disabled = true;
+
+            const result = await requestJson(
+                "/api/transactions/sync",
+                {
+                    method: "POST"
+                }
+            );
+
+            showToast(
+                `동기화 완료: 자동반영 ${result.appliedCount}건, 확인필요
+              ${result.needsCheckCount}건, 미매칭 ${result.unmatchedCount}건`
+            );
+
+            await loadPage();
+
+        } catch (error) {
+            console.error("거래내역 동기화 실패:", error);
+
+            showToast(
+                error.message || "거래내역 동기화에 실패했습니다.",
+                true
+            );
+
+        } finally {
+            syncButton.disabled = false;
+        }
     }
 
     async function loadPage() {

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -37,16 +37,6 @@ document.addEventListener("DOMContentLoaded", () => {
             closeSettlement
         );
     }
-    if (syncButton) {
-        syncButton.addEventListener(
-            "click",
-            () => {
-                showToast(
-                    "거래내역 동기화 API 연결 전입니다."
-                );
-            }
-        );
-    }
 
     if (syncButton) {
         syncButton.addEventListener(

--- a/src/main/resources/static/js/settlement/settlement-list.js
+++ b/src/main/resources/static/js/settlement/settlement-list.js
@@ -21,9 +21,53 @@ document.addEventListener("DOMContentLoaded", () => {
     showCreatedToast();
     bindFilters();
 
-    syncButton.addEventListener("click", () => {
-        showToast("거래내역 동기화 API가 연결되면 이 버튼에서 호출합니다.");
-    });
+    syncButton.addEventListener("click", syncTransactions);
+
+    async function syncTransactions() {
+        try {
+            syncButton.disabled = true;
+
+            const token = sessionStorage.getItem("accessToken");
+
+            if (!token) {
+                window.location.href = "/login?required=true";
+                return;
+            }
+
+            const response = await fetch("/api/transactions/sync", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`
+                }
+            });
+
+            if (!response.ok) {
+                if (response.status === 401) {
+                    sessionStorage.removeItem("accessToken");
+                    window.location.href = "/login?required=true";
+                    return;
+                }
+
+                throw new Error("거래내역 동기화에 실패했습니다.");
+            }
+
+            const result = await response.json();
+
+            showToast(
+                `동기화 완료: 자동반영 ${result.appliedCount}건, 확인필요
+              ${result.needsCheckCount}건, 미매칭 ${result.unmatchedCount}건`
+            );
+
+            await loadSettlements();
+
+        } catch (error) {
+            console.error(error);
+            showToast(error.message || "거래내역 동기화에 실패했습니다.", true);
+
+        } finally {
+            syncButton.disabled = false;
+        }
+    }
 
     function bindFilters() {
         [searchInput, typeFilter, splitFilter, statusFilter].forEach((element) => {

--- a/src/test/java/org/teamsai/saibackend/domain/account/LinkedBankAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/account/LinkedBankAccountServiceTest.java
@@ -242,7 +242,7 @@ public class LinkedBankAccountServiceTest {
                     .updatedAt(LocalDateTime.now())
                     .build();
 
-            given(linkedBankAccountMapper.selectLinkedAccountsByUserId(USER_ID))
+            given(linkedBankAccountMapper.selectAvailableLinkedAccountsByUserId(USER_ID))
                     .willReturn(List.of(linked));
 
             List<LinkedBankAccountResponse> result =
@@ -251,7 +251,7 @@ public class LinkedBankAccountServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).linkedAccountId()).isEqualTo(100L);
             assertThat(result.get(0).connectionStatus()).isEqualTo("AVAILABLE");
-            verify(linkedBankAccountMapper).selectLinkedAccountsByUserId(USER_ID);
+            verify(linkedBankAccountMapper).selectAvailableLinkedAccountsByUserId(USER_ID);
         }
 
         @Test
@@ -261,13 +261,13 @@ public class LinkedBankAccountServiceTest {
                     linkedBankAccountService.getLinkedAccounts(null);
 
             assertThat(result).isEmpty();
-            verify(linkedBankAccountMapper, never()).selectLinkedAccountsByUserId(any());
+            verify(linkedBankAccountMapper, never()).selectAvailableLinkedAccountsByUserId(any());
         }
 
         @Test
         @DisplayName("매퍼가 null을 반환하면 빈 목록을 반환한다")
         void returnsEmptyListWhenMapperReturnsNull() {
-            given(linkedBankAccountMapper.selectLinkedAccountsByUserId(USER_ID)).willReturn(null);
+            given(linkedBankAccountMapper.selectAvailableLinkedAccountsByUserId(USER_ID)).willReturn(null);
 
             List<LinkedBankAccountResponse> result =
                     linkedBankAccountService.getLinkedAccounts(USER_ID);
@@ -278,7 +278,7 @@ public class LinkedBankAccountServiceTest {
         @Test
         @DisplayName("연동된 계좌가 없으면 빈 목록을 반환한다")
         void returnsEmptyListWhenNoLinkedAccounts() {
-            given(linkedBankAccountMapper.selectLinkedAccountsByUserId(USER_ID))
+            given(linkedBankAccountMapper.selectAvailableLinkedAccountsByUserId(USER_ID))
                     .willReturn(List.of());
 
             List<LinkedBankAccountResponse> result =

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
@@ -7,14 +7,18 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
+import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
 import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
 import org.teamsai.saibackend.domain.transaction.service.TransactionSyncFacade;
 import org.teamsai.saibackend.domain.transaction.service.TransactionSyncService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,11 +37,15 @@ class TransactionSyncFacadeTest {
     @Mock
     private BankMatchingService bankMatchingService;
 
+    @Mock
+    private LinkedBankAccountService linkedBankAccountService;
+
     @InjectMocks
     private TransactionSyncFacade transactionSyncFacade;
 
     private static final Long USER_ID = 10L;
     private static final Long LINKED_ACCOUNT_ID = 1L;
+    private static final Long SECOND_LINKED_ACCOUNT_ID = 2L;
 
     @Test
     @DisplayName("동기화를 먼저 실행한 뒤 매칭을 실행하고, 매칭 결과를 그대로 반환한다")
@@ -104,5 +112,126 @@ class TransactionSyncFacadeTest {
                 .isSameAs(matchingFailure);
         
         verify(transactionSyncService).syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
+    }
+
+    @Test
+    @DisplayName("전체 동기화는 사용자의 모든 연동계좌를 계좌별로 동기화하고 매칭 결과를 합산한다")
+    void syncAllSyncsEveryLinkedAccountAndAggregatesMatchingResults() {
+        given(linkedBankAccountService.getLinkedAccounts(USER_ID))
+                .willReturn(List.of(
+                        linkedAccount(LINKED_ACCOUNT_ID),
+                        linkedAccount(SECOND_LINKED_ACCOUNT_ID)
+                ));
+
+        AutoMatchingExecutionResult firstResult =
+                new AutoMatchingExecutionResult(
+                        2,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        List.of(
+                                new AutoMatchingTransactionResult(
+                                        100L,
+                                        AutoMatchingProcessStatus.APPLIED
+                                ),
+                                new AutoMatchingTransactionResult(
+                                        101L,
+                                        AutoMatchingProcessStatus.NEEDS_CHECK
+                                )
+                        )
+                );
+
+        AutoMatchingExecutionResult secondResult =
+                new AutoMatchingExecutionResult(
+                        3,
+                        1,
+                        0,
+                        1,
+                        1,
+                        0,
+                        List.of(
+                                new AutoMatchingTransactionResult(
+                                        200L,
+                                        AutoMatchingProcessStatus.APPLIED
+                                ),
+                                new AutoMatchingTransactionResult(
+                                        201L,
+                                        AutoMatchingProcessStatus.UNMATCHED
+                                ),
+                                new AutoMatchingTransactionResult(
+                                        202L,
+                                        AutoMatchingProcessStatus.DUPLICATE
+                                )
+                        )
+                );
+
+        given(transactionSyncService.syncTransactions(USER_ID, LINKED_ACCOUNT_ID))
+                .willReturn(2);
+        given(transactionSyncService.syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID))
+                .willReturn(3);
+        given(bankMatchingService.execute(LINKED_ACCOUNT_ID))
+                .willReturn(firstResult);
+        given(bankMatchingService.execute(SECOND_LINKED_ACCOUNT_ID))
+                .willReturn(secondResult);
+
+        TransactionSyncAllResponse result =
+                transactionSyncFacade.syncAll(USER_ID);
+
+        assertThat(result.syncedAccountCount()).isEqualTo(2);
+        assertThat(result.totalTransactionCount()).isEqualTo(5);
+        assertThat(result.appliedCount()).isEqualTo(2);
+        assertThat(result.needsCheckCount()).isEqualTo(1);
+        assertThat(result.unmatchedCount()).isEqualTo(1);
+        assertThat(result.duplicateCount()).isEqualTo(1);
+        assertThat(result.failedCount()).isZero();
+
+        InOrder inOrder = inOrder(
+                linkedBankAccountService,
+                transactionSyncService,
+                bankMatchingService
+        );
+        inOrder.verify(linkedBankAccountService).getLinkedAccounts(USER_ID);
+        inOrder.verify(transactionSyncService)
+                .syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
+        inOrder.verify(bankMatchingService).execute(LINKED_ACCOUNT_ID);
+        inOrder.verify(transactionSyncService)
+                .syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID);
+        inOrder.verify(bankMatchingService).execute(SECOND_LINKED_ACCOUNT_ID);
+    }
+
+    @Test
+    @DisplayName("전체 동기화는 연동계좌가 없으면 동기화와 매칭을 실행하지 않고 빈 결과를 반환한다")
+    void syncAllReturnsEmptyResultWhenUserHasNoLinkedAccounts() {
+        given(linkedBankAccountService.getLinkedAccounts(USER_ID))
+                .willReturn(List.of());
+
+        TransactionSyncAllResponse result =
+                transactionSyncFacade.syncAll(USER_ID);
+
+        assertThat(result.syncedAccountCount()).isZero();
+        assertThat(result.totalTransactionCount()).isZero();
+        assertThat(result.appliedCount()).isZero();
+        assertThat(result.needsCheckCount()).isZero();
+        assertThat(result.unmatchedCount()).isZero();
+        assertThat(result.duplicateCount()).isZero();
+        assertThat(result.failedCount()).isZero();
+
+        verify(transactionSyncService, never()).syncTransactions(any(), any());
+        verify(bankMatchingService, never()).execute(any());
+    }
+
+    private LinkedBankAccountResponse linkedAccount(Long linkedAccountId) {
+        return new LinkedBankAccountResponse(
+                linkedAccountId,
+                "088",
+                "신한은행",
+                "110-***-123456",
+                "정산 계좌",
+                "홍길동",
+                BigDecimal.ZERO,
+                "AVAILABLE"
+        );
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
+import org.teamsai.saibackend.domain.account.exception.AccountErrorCode;
 import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
@@ -199,6 +200,46 @@ class TransactionSyncFacadeTest {
         inOrder.verify(transactionSyncService)
                 .syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID);
         inOrder.verify(bankMatchingService).execute(SECOND_LINKED_ACCOUNT_ID);
+    }
+
+    @Test
+    @DisplayName("계좌 하나의 동기화가 실패해도 나머지 계좌를 계속 처리한다")
+    void syncAllContinuesWhenOneAccountFails() {
+        given(linkedBankAccountService.getLinkedAccounts(USER_ID))
+                .willReturn(List.of(
+                        linkedAccount(LINKED_ACCOUNT_ID),
+                        linkedAccount(SECOND_LINKED_ACCOUNT_ID)
+                ));
+
+        DomainException syncFailure =
+                AccountErrorCode.BANK_SERVER_UNAVAILABLE.toException();
+        AutoMatchingExecutionResult successResult =
+                new AutoMatchingExecutionResult(
+                        1, 1, 0, 0, 0, 0,
+                        List.of(new AutoMatchingTransactionResult(
+                                200L,
+                                AutoMatchingProcessStatus.APPLIED
+                        ))
+                );
+
+        willThrow(syncFailure)
+                .given(transactionSyncService)
+                .syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
+        given(transactionSyncService.syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID))
+                .willReturn(1);
+        given(bankMatchingService.execute(SECOND_LINKED_ACCOUNT_ID))
+                .willReturn(successResult);
+
+        TransactionSyncAllResponse result = transactionSyncFacade.syncAll(USER_ID);
+
+        assertThat(result.syncedAccountCount()).isEqualTo(1);
+        assertThat(result.failedAccounts()).hasSize(1);
+        assertThat(result.failedAccounts().get(0).linkedAccountId())
+                .isEqualTo(LINKED_ACCOUNT_ID);
+        assertThat(result.failedAccounts().get(0).errorCode())
+                .isEqualTo("BANK_SERVER_UNAVAILABLE");
+        assertThat(result.totalTransactionCount()).isEqualTo(1);
+        assertThat(result.appliedCount()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #110 

## 작업 사항

  - Mock Bank 거래 동기화 기능과 자동매칭 기능 연동
  - 동기화된 입금 거래가 자동매칭 대상으로 전달되도록
  수정
  - 자동매칭 처리 결과가 동기화 응답에 포함되도록 일부
  로직 수정
  - 연동 과정에서 필요한 거래 및 계좌 조회 로직 보완

## ✅ 테스트

  - [x] 로컬 서버 테스트 완료
  - [x] 핵심 기능 테스트 코드 작성 및 실행 완료
  - [x] 기존 기능에 영향이 없는지 확인

 ### 확인한 시나리오

  - 입금자명과 납부금액이 일치하는 거래의 정상 반영 확인
  - 납부금액이 일치하지 않는 거래의 미매칭 처리 확인
  - 일부 참여자만 입금한 경우의 납부 상태 확인
  - 마감된 정산에 입금된 거래가 자동 반영되지 않는지
  확인
  - 남은 참여자 입금 완료 후 정산 마감 가능 여부 확인

## 주의 사항 및 참고사항

  - 자동매칭은 정산에 등록된 연결계좌의 입금 거래를 대상으로 합니다.
  - 입금자명과 남은 납부금액이 모두 일치해야 정상 매칭됩니다.
  - 금액이 다르거나 마감된 정산의 거래는 자동매칭되지않습니다.
  - 연동 확인을 위해 Mock Bank에 테스트 계좌와 입금 거래를 등록하여 테스트했습니다.
