### PR TITLE
feat(#121): 통합테스트 화면 연동

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contractdashboard/dto/response/DashboardContractRowResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdashboard/dto/response/DashboardContractRowResponse.java
@@ -10,6 +10,7 @@ import org.teamsai.saibackend.domain.contractdashboard.type.TransactionCategory;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -29,4 +30,7 @@ public class DashboardContractRowResponse {
 
     @JsonIgnore
     private LocalDate nearestScheduleDueDate;
+
+    @JsonIgnore
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractdashboard/service/DashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdashboard/service/DashboardService.java
@@ -95,8 +95,12 @@ public class DashboardService {
                 : TransactionCategory.PAY;
     }
 
-    private DashboardContractRowResponse toRow(LoanContractResponse contract, Long userId) {
-        List<RepaymentScheduleDTO> schedules = repaymentScheduleService.getSchedule(contract.getContractId());
+    private DashboardContractRowResponse toRow(
+            ContractScheduleContext context,
+            Long userId
+    ) {
+        LoanContractResponse contract = context.contract();
+        List<RepaymentScheduleDTO> schedules = context.schedules();
 
         BigDecimal totalRemaining = calculateTotalRemaining(schedules);
         BigDecimal thisMonthDue = calculateThisMonthDue(schedules);
@@ -124,6 +128,7 @@ public class DashboardService {
                 .paymentStatus(paymentStatus)
                 .maturityDate(contract.getMaturityDate())
                 .nearestScheduleDueDate(nearestDueDate)
+                .createdAt(contract.getCreatedAt())
                 .build();
     }
 
@@ -220,6 +225,10 @@ public class DashboardService {
             case "AMOUNT_ASC" -> sorted.sort(Comparator.comparing(DashboardContractRowResponse::getTotalRemainingAmount));
             case "STATUS" -> sorted.sort(Comparator.comparing(DashboardContractRowResponse::getContractStatus));
             case "DEADLINE" -> sorted.sort(Comparator.comparing(DashboardContractRowResponse::getMaturityDate));
+            case "CREATED_DESC" -> sorted.sort(Comparator.comparing(
+                    DashboardContractRowResponse::getCreatedAt,
+                    Comparator.nullsLast(Comparator.reverseOrder())
+            ));
             default -> throw DashboardErrorCode.INVALID_SORT_TYPE.toException();
         }
         return sorted;
@@ -239,11 +248,25 @@ public class DashboardService {
         return rows.subList(startIndex, endIndex);
     }
 
-    public DashboardResponse getDashboard(Long userId, String keyword, String roleFilter, String sortType, int page) {
-        List<LoanContractResponse> contracts = getVisibleContracts(userId);
+    private List<ContractScheduleContext> getContractScheduleContexts(Long userId) {
+        return getVisibleContracts(userId).stream()
+                .map(contract -> new ContractScheduleContext(
+                        contract,
+                        repaymentScheduleService.getSchedule(contract.getContractId())
+                ))
+                .toList();
+    }
 
-        List<DashboardContractRowResponse> allRows = contracts.stream()
-                .map(contract -> toRow(contract, userId)).toList();
+    private DashboardResponse buildDashboard(
+            List<ContractScheduleContext> contexts,
+            Long userId,
+            String keyword,
+            String roleFilter,
+            String sortType,
+            int page
+    ) {
+        List<DashboardContractRowResponse> allRows = contexts.stream()
+                .map(context -> toRow(context, userId)).toList();
 
         DashboardSummaryResponse summary = buildSummary(allRows);
         List<DashboardContractRowResponse> filtered = filterByKeyword(allRows, keyword);
@@ -262,6 +285,52 @@ public class DashboardService {
                 .pageSize(5)
                 .build();
 
+    }
+
+    public DashboardResponse getDashboard(Long userId, String keyword, String roleFilter, String sortType, int page) {
+        return buildDashboard(
+                getContractScheduleContexts(userId),
+                userId,
+                keyword,
+                roleFilter,
+                sortType,
+                page
+        );
+    }
+
+    public IntegrationDashboardData getIntegrationDashboardData(Long userId) {
+        List<ContractScheduleContext> contexts = getContractScheduleContexts(userId);
+        DashboardResponse dashboard = buildDashboard(
+                contexts,
+                userId,
+                null,
+                "ALL",
+                "CREATED_DESC",
+                1
+        );
+        List<LoanScheduleContext> loanSchedules = contexts.stream()
+                .flatMap(context -> context.schedules().stream()
+                        .map(schedule -> new LoanScheduleContext(context.contract(), schedule)))
+                .toList();
+        return new IntegrationDashboardData(dashboard, loanSchedules);
+    }
+
+    private record ContractScheduleContext(
+            LoanContractResponse contract,
+            List<RepaymentScheduleDTO> schedules
+    ) {
+    }
+
+    public record LoanScheduleContext(
+            LoanContractResponse contract,
+            RepaymentScheduleDTO schedule
+    ) {
+    }
+
+    public record IntegrationDashboardData(
+            DashboardResponse dashboard,
+            List<LoanScheduleContext> loanSchedules
+    ) {
     }
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/integration/controller/IntegrationDashboardController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/controller/IntegrationDashboardController.java
@@ -1,0 +1,46 @@
+package org.teamsai.saibackend.domain.integration.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.teamsai.saibackend.domain.integration.dto.response.IntegrationDashboardResponse;
+import org.teamsai.saibackend.domain.integration.service.IntegrationDashboardService;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
+
+import java.time.YearMonth;
+
+@Controller
+@RequiredArgsConstructor
+public class IntegrationDashboardController {
+
+    private final IntegrationDashboardService integrationDashboardService;
+
+    @GetMapping("/integration/dashboard")
+    public String dashboardPage() {
+        return "integration/dashboard";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/integration/dashboard")
+    public ResponseEntity<IntegrationDashboardResponse> getDashboard(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
+    ) {
+        YearMonth requestedMonth = yearMonth == null
+                ? YearMonth.now()
+                : yearMonth;
+
+        IntegrationDashboardResponse response =
+                integrationDashboardService.getDashboard(
+                        userDetails.getUserId(),
+                        requestedMonth
+                );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/controller/IntegrationDashboardController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/controller/IntegrationDashboardController.java
@@ -1,5 +1,10 @@
 package org.teamsai.saibackend.domain.integration.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -14,21 +19,35 @@ import org.teamsai.saibackend.global.security.CustomUserDetails;
 
 import java.time.YearMonth;
 
+@Tag(
+        name = "통합 대시보드 API",
+        description = "월별 통합 대시보드 조회 API"
+)
 @Controller
 @RequiredArgsConstructor
 public class IntegrationDashboardController {
 
     private final IntegrationDashboardService integrationDashboardService;
 
-    @GetMapping("/integration/dashboard")
-    public String dashboardPage() {
-        return "integration/dashboard";
-    }
-
+    @Operation(
+            summary = "통합 대시보드 조회",
+            description = "현재 로그인한 사용자의 지정 월 통합 대시보드 정보를 조회합니다. 조회 월을 생략하면 현재 월을 기준으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "통합 대시보드 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            )
+    })
     @ResponseBody
     @GetMapping("/api/integration/dashboard")
     public ResponseEntity<IntegrationDashboardResponse> getDashboard(
             @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "조회 월 (yyyy-MM)", example = "2026-08")
             @RequestParam(required = false)
             @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
     ) {
@@ -42,5 +61,11 @@ public class IntegrationDashboardController {
                         requestedMonth
                 );
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(hidden = true)
+    @GetMapping("/integration/dashboard")
+    public String dashboardPage() {
+        return "integration/dashboard";
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardAmountSummaryResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardAmountSummaryResponse.java
@@ -1,0 +1,12 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DashboardAmountSummaryResponse {
+
+    private DashboardMoneyBreakdownResponse receivable;
+    private DashboardMoneyBreakdownResponse payable;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardAttentionItemResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardAttentionItemResponse.java
@@ -1,0 +1,15 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.integration.type.DashboardAttentionType;
+
+@Getter
+@Builder
+public class DashboardAttentionItemResponse {
+
+    private Long id;
+    private DashboardAttentionType type;
+    private Long remainingDays;
+    private String actionUrl;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardCalendarDayResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardCalendarDayResponse.java
@@ -1,0 +1,15 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DashboardCalendarDayResponse {
+
+    private LocalDate date;
+    private boolean hasInbound;
+    private boolean hasOutbound;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardMoneyBreakdownResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardMoneyBreakdownResponse.java
@@ -1,0 +1,17 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class DashboardMoneyBreakdownResponse {
+
+    private BigDecimal totalAmount;
+
+    private BigDecimal settlementAmount;
+
+    private BigDecimal loanAmount;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardMonthlySummaryResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardMonthlySummaryResponse.java
@@ -1,0 +1,19 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class DashboardMonthlySummaryResponse {
+
+    private int completedTransactionCount;
+
+    private int inProgressSettlementCount;
+
+    private int inProgressLoanRepaymentCount;
+
+    private BigDecimal transactionCompletionRate;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardRecentTransactionResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/DashboardRecentTransactionResponse.java
@@ -1,0 +1,30 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.integration.type.DashboardTransactionStatus;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DashboardRecentTransactionResponse {
+
+    private Long targetId;
+
+    private PaymentTargetType type;
+
+    private String title;
+
+    private DashboardTransactionStatus status;
+
+    private BigDecimal amount;
+
+    private String detailUrl;
+
+    @JsonIgnore
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/IntegrationDashboardResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/dto/response/IntegrationDashboardResponse.java
@@ -1,0 +1,24 @@
+package org.teamsai.saibackend.domain.integration.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Getter
+@Builder
+public class IntegrationDashboardResponse {
+
+    private YearMonth yearMonth;
+
+    private DashboardAmountSummaryResponse amountSummary;
+
+    private DashboardMonthlySummaryResponse monthlySummary;
+
+    private List<DashboardAttentionItemResponse> attentionItems;
+
+    private List<DashboardRecentTransactionResponse> recentTransactions;
+
+    private List<DashboardCalendarDayResponse> calendarDays;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -1,0 +1,399 @@
+package org.teamsai.saibackend.domain.integration.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardContractRowResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
+import org.teamsai.saibackend.domain.contractdashboard.service.DashboardService;
+import org.teamsai.saibackend.domain.contractdashboard.type.DashboardContractStatus;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
+import org.teamsai.saibackend.domain.integration.dto.response.*;
+import org.teamsai.saibackend.domain.integration.type.DashboardAttentionType;
+import org.teamsai.saibackend.domain.integration.type.DashboardTransactionStatus;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentObligationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentStatusResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementPaymentStatusService;
+import org.teamsai.saibackend.domain.settlement.service.SettlementQueryService;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IntegrationDashboardService {
+
+    private final DashboardService contractDashboardService;
+    private final SettlementQueryService settlementQueryService;
+    private final SettlementPaymentStatusService settlementPaymentStatusService;
+
+    public IntegrationDashboardResponse getDashboard(
+            Long userId,
+            YearMonth yearMonth
+    ) {
+        DashboardService.IntegrationDashboardData loanData =
+                contractDashboardService.getIntegrationDashboardData(userId);
+        DashboardResponse contractDashboard = loanData.dashboard();
+        List<DashboardService.LoanScheduleContext> loanSchedules = loanData.loanSchedules();
+        List<SettlementContext> settlements = getSettlements(userId);
+
+        return IntegrationDashboardResponse.builder()
+                .yearMonth(yearMonth)
+                .amountSummary(getAmountSummary(contractDashboard, settlements))
+                .monthlySummary(getMonthlySummary(loanSchedules, settlements, yearMonth))
+                .attentionItems(getAttentionItems(loanSchedules, settlements))
+                .recentTransactions(getRecentTransactions(contractDashboard, settlements))
+                .calendarDays(getCalendarDays(loanSchedules, settlements, yearMonth, userId))
+                .build();
+    }
+
+    private DashboardAmountSummaryResponse getAmountSummary(
+            DashboardResponse contractDashboard,
+            List<SettlementContext> settlements
+    ) {
+        DashboardSummaryResponse contractSummary = contractDashboard.getSummary();
+        BigDecimal settlementReceivable = settlements.stream()
+                .filter(SettlementContext::isOwner)
+                .map(SettlementContext::roleRemainingAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal settlementPayable = settlements.stream()
+                .filter(context -> !context.isOwner())
+                .map(SettlementContext::roleRemainingAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal loanReceivable = zeroIfNull(contractSummary.getTotalLentAmount());
+        BigDecimal loanPayable = zeroIfNull(contractSummary.getTotalBorrowedAmount());
+
+        return DashboardAmountSummaryResponse.builder()
+                .receivable(DashboardMoneyBreakdownResponse.builder()
+                        .totalAmount(settlementReceivable.add(loanReceivable))
+                        .settlementAmount(settlementReceivable)
+                        .loanAmount(loanReceivable)
+                        .build())
+                .payable(DashboardMoneyBreakdownResponse.builder()
+                        .totalAmount(settlementPayable.add(loanPayable))
+                        .settlementAmount(settlementPayable)
+                        .loanAmount(loanPayable)
+                        .build())
+                .build();
+    }
+
+    private List<DashboardRecentTransactionResponse> getRecentLoanTransactions(
+            DashboardResponse contractDashboard
+    ) {
+        List<DashboardContractRowResponse> contracts = contractDashboard.getContracts();
+
+        if (contracts == null) {
+            return List.of();
+        }
+
+        return contracts.stream()
+                .map(this::toRecentLoanTransaction)
+                .toList();
+    }
+
+    private DashboardRecentTransactionResponse toRecentLoanTransaction(
+            DashboardContractRowResponse contract
+    ) {
+        DashboardTransactionStatus status =
+                contract.getContractStatus() == DashboardContractStatus.COMPLETED
+                        ? DashboardTransactionStatus.COMPLETED
+                        : DashboardTransactionStatus.IN_PROGRESS;
+
+        return DashboardRecentTransactionResponse.builder()
+                .targetId(contract.getContractId())
+                .type(PaymentTargetType.LOAN)
+                .title(contract.getContractAlias())
+                .status(status)
+                .amount(zeroIfNull(contract.getPrincipalAmount()))
+                .detailUrl("/contracts/" + contract.getContractId() + "/contract-detail")
+                .createdAt(contract.getCreatedAt())
+                .build();
+    }
+
+    private List<DashboardRecentTransactionResponse> getRecentTransactions(
+            DashboardResponse contractDashboard,
+            List<SettlementContext> settlements
+    ) {
+        Comparator<DashboardRecentTransactionResponse> newestFirst = Comparator.comparing(
+                DashboardRecentTransactionResponse::getCreatedAt,
+                Comparator.nullsLast(Comparator.reverseOrder())
+        );
+        List<DashboardRecentTransactionResponse> transactions = new ArrayList<>();
+        getRecentLoanTransactions(contractDashboard).stream()
+                .sorted(newestFirst)
+                .limit(5)
+                .forEach(transactions::add);
+        settlements.stream()
+                .map(this::toRecentSettlementTransaction)
+                .sorted(newestFirst)
+                .limit(5)
+                .forEach(transactions::add);
+        return transactions.stream()
+                .sorted(newestFirst)
+                .toList();
+    }
+
+    private DashboardRecentTransactionResponse toRecentSettlementTransaction(SettlementContext context) {
+        SettlementListResponse settlement = context.settlement();
+        return DashboardRecentTransactionResponse.builder()
+                .targetId(settlement.settlementId())
+                .type(PaymentTargetType.SETTLEMENT)
+                .title(settlement.title())
+                .status(isClosed(settlement)
+                        ? DashboardTransactionStatus.COMPLETED
+                        : DashboardTransactionStatus.IN_PROGRESS)
+                .amount(context.originalRoleAmount())
+                .detailUrl("/settlements/" + settlement.settlementId())
+                .createdAt(settlement.createdAt())
+                .build();
+    }
+
+    private List<SettlementContext> getSettlements(Long userId) {
+        List<SettlementListResponse> settlements = settlementQueryService.getSettlementList(userId);
+        if (settlements == null) {
+            return List.of();
+        }
+        return settlements.stream()
+                .map(settlement -> {
+                    SettlementPaymentStatusResponse paymentStatus = settlementPaymentStatusService
+                            .getPaymentStatus(settlement.settlementId(), userId);
+                    BigDecimal roleRemaining = "OWNER".equals(settlement.role())
+                            ? zeroIfNull(paymentStatus.getTotalRemainingAmount())
+                            : ownRemainingAmount(paymentStatus, userId);
+                    BigDecimal originalRoleAmount = "OWNER".equals(settlement.role())
+                            ? zeroIfNull(paymentStatus.getTotalExpectedAmount())
+                            : ownExpectedAmount(paymentStatus, userId);
+                    return new SettlementContext(
+                            settlement,
+                            roleRemaining,
+                            originalRoleAmount
+                    );
+                })
+                .toList();
+    }
+
+    private BigDecimal ownRemainingAmount(SettlementPaymentStatusResponse status, Long userId) {
+        if (status.getObligations() == null) {
+            return BigDecimal.ZERO;
+        }
+        return status.getObligations().stream()
+                .filter(obligation -> userId.equals(obligation.getUserId()))
+                .map(SettlementPaymentObligationResponse::getRemainingAmount)
+                .map(this::zeroIfNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal ownExpectedAmount(SettlementPaymentStatusResponse status, Long userId) {
+        if (status.getObligations() == null) {
+            return BigDecimal.ZERO;
+        }
+        return status.getObligations().stream()
+                .filter(obligation -> userId.equals(obligation.getUserId()))
+                .map(SettlementPaymentObligationResponse::getExpectedAmount)
+                .map(this::zeroIfNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal zeroIfNull(BigDecimal amount) {
+        return amount == null ? BigDecimal.ZERO : amount;
+    }
+
+    private List<DashboardCalendarDayResponse> getLoanCalendarDays(
+            List<DashboardService.LoanScheduleContext> loanSchedules,
+            YearMonth yearMonth,
+            Long userId
+    ) {
+        Map<LocalDate, CalendarDirection> directionsByDate = new TreeMap<>();
+
+        loanSchedules.stream()
+                .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
+                .filter(context -> YearMonth.from(context.schedule().getDueDate()).equals(yearMonth))
+                .forEach(context -> {
+                    CalendarDirection direction = directionsByDate.computeIfAbsent(
+                            context.schedule().getDueDate(),
+                            ignored -> new CalendarDirection()
+                    );
+                    if (userId.equals(context.contract().getCreditorId())) {
+                        direction.inbound = true;
+                    }
+                    if (userId.equals(context.contract().getDebtorId())) {
+                        direction.outbound = true;
+                    }
+                });
+
+        return directionsByDate.entrySet().stream()
+                .map(entry -> DashboardCalendarDayResponse.builder()
+                        .date(entry.getKey())
+                        .hasInbound(entry.getValue().inbound)
+                        .hasOutbound(entry.getValue().outbound)
+                        .build())
+                .toList();
+    }
+
+    private List<DashboardCalendarDayResponse> getCalendarDays(
+            List<DashboardService.LoanScheduleContext> loanSchedules,
+            List<SettlementContext> settlements,
+            YearMonth yearMonth,
+            Long userId
+    ) {
+        Map<LocalDate, CalendarDirection> directionsByDate = new TreeMap<>();
+        getLoanCalendarDays(loanSchedules, yearMonth, userId).forEach(day -> {
+            CalendarDirection direction = directionsByDate.computeIfAbsent(
+                    day.getDate(), ignored -> new CalendarDirection()
+            );
+            direction.inbound |= day.isHasInbound();
+            direction.outbound |= day.isHasOutbound();
+        });
+        settlements.stream()
+                .filter(context -> !isClosed(context.settlement()))
+                .filter(context -> context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
+                .filter(context -> context.settlement().dueDate() != null)
+                .filter(context -> YearMonth.from(context.settlement().dueDate()).equals(yearMonth))
+                .forEach(context -> {
+                    CalendarDirection direction = directionsByDate.computeIfAbsent(
+                            context.settlement().dueDate(), ignored -> new CalendarDirection()
+                    );
+                    direction.inbound |= context.isOwner();
+                    direction.outbound |= !context.isOwner();
+                });
+        return directionsByDate.entrySet().stream()
+                .map(entry -> DashboardCalendarDayResponse.builder()
+                        .date(entry.getKey())
+                        .hasInbound(entry.getValue().inbound)
+                        .hasOutbound(entry.getValue().outbound)
+                        .build())
+                .toList();
+    }
+
+    private List<DashboardAttentionItemResponse> getUpcomingLoanAttentionItems(
+            List<DashboardService.LoanScheduleContext> loanSchedules
+    ) {
+        LocalDate today = LocalDate.now();
+        LocalDate attentionLimit = today.plusDays(3);
+
+        return loanSchedules.stream()
+                .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
+                .filter(context -> !context.schedule().getDueDate().isBefore(today))
+                .filter(context -> !context.schedule().getDueDate().isAfter(attentionLimit))
+                .sorted(Comparator.comparing(context -> context.schedule().getDueDate()))
+                .map(context -> {
+                    long remainingDays = ChronoUnit.DAYS.between(
+                            today,
+                            context.schedule().getDueDate()
+                    );
+
+                    return DashboardAttentionItemResponse.builder()
+                            .id(context.schedule().getScheduleId())
+                            .type(DashboardAttentionType.LOAN_DUE_SOON)
+                            .remainingDays(remainingDays)
+                            .actionUrl("/contracts/"
+                                    + context.contract().getContractId()
+                                    + "/schedule")
+                            .build();
+                })
+                .toList();
+    }
+
+    private List<DashboardAttentionItemResponse> getAttentionItems(
+            List<DashboardService.LoanScheduleContext> loanSchedules,
+            List<SettlementContext> settlements
+    ) {
+        LocalDate today = LocalDate.now();
+        LocalDate attentionLimit = today.plusDays(3);
+        List<DashboardAttentionItemResponse> items = new ArrayList<>(
+                getUpcomingLoanAttentionItems(loanSchedules)
+        );
+        settlements.stream()
+                .filter(context -> !isClosed(context.settlement()))
+                .filter(context -> context.isOwner()
+                        || context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
+                .filter(context -> context.settlement().dueDate() != null)
+                .filter(context -> !context.settlement().dueDate().isBefore(today))
+                .filter(context -> !context.settlement().dueDate().isAfter(attentionLimit))
+                .map(context -> DashboardAttentionItemResponse.builder()
+                        .id(context.settlement().settlementId())
+                        .type(DashboardAttentionType.SETTLEMENT_DUE_SOON)
+                        .remainingDays(ChronoUnit.DAYS.between(today, context.settlement().dueDate()))
+                        .actionUrl("/settlements/" + context.settlement().settlementId())
+                        .build())
+                .forEach(items::add);
+        return items.stream()
+                .sorted(Comparator.comparing(DashboardAttentionItemResponse::getRemainingDays))
+                .toList();
+    }
+
+    private DashboardMonthlySummaryResponse getMonthlySummary(
+            List<DashboardService.LoanScheduleContext> loanSchedules,
+            List<SettlementContext> settlements,
+            YearMonth yearMonth
+    ) {
+        List<DashboardService.LoanScheduleContext> monthlySchedules = loanSchedules.stream()
+                .filter(context -> YearMonth.from(context.schedule().getDueDate()).equals(yearMonth))
+                .toList();
+
+        int completedLoanRepaymentCount = (int) monthlySchedules.stream()
+                .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PAID)
+                .count();
+
+        int inProgressLoanRepaymentCount = (int) monthlySchedules.stream()
+                .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
+                .count();
+
+        List<SettlementContext> monthlySettlements = settlements.stream()
+                .filter(context -> context.settlement().dueDate() != null)
+                .filter(context -> YearMonth.from(context.settlement().dueDate()).equals(yearMonth))
+                .toList();
+        int completedSettlementCount = (int) monthlySettlements.stream()
+                .filter(context -> isClosed(context.settlement()))
+                .count();
+        int inProgressSettlementCount = (int) monthlySettlements.stream()
+                .filter(context -> !isClosed(context.settlement()))
+                .count();
+        int totalTransactionCount = monthlySchedules.size() + monthlySettlements.size();
+        int completedTransactionCount = completedLoanRepaymentCount + completedSettlementCount;
+
+        BigDecimal completionRate = totalTransactionCount == 0
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(completedTransactionCount)
+                        .multiply(BigDecimal.valueOf(100))
+                        .divide(
+                                BigDecimal.valueOf(totalTransactionCount),
+                                2,
+                                RoundingMode.HALF_UP
+                        );
+
+        return DashboardMonthlySummaryResponse.builder()
+                .completedTransactionCount(completedTransactionCount)
+                .inProgressSettlementCount(inProgressSettlementCount)
+                .inProgressLoanRepaymentCount(inProgressLoanRepaymentCount)
+                .transactionCompletionRate(completionRate)
+                .build();
+    }
+
+    private boolean isClosed(SettlementListResponse settlement) {
+        return "CLOSED".equals(settlement.settlementStatus());
+    }
+
+    private record SettlementContext(
+            SettlementListResponse settlement,
+            BigDecimal roleRemainingAmount,
+            BigDecimal originalRoleAmount
+    ) {
+        private boolean isOwner() {
+            return "OWNER".equals(settlement.role());
+        }
+    }
+
+    private static class CalendarDirection {
+        private boolean inbound;
+        private boolean outbound;
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/type/DashboardAttentionType.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/type/DashboardAttentionType.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.integration.type;
+
+public enum DashboardAttentionType {
+    LOAN_DUE_SOON,
+    SETTLEMENT_DUE_SOON
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/type/DashboardTransactionStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/type/DashboardTransactionStatus.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.integration.type;
+
+public enum DashboardTransactionStatus {
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
@@ -1,6 +1,8 @@
 package org.teamsai.saibackend.domain.settlement.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record SettlementListResponse(
         Long settlementId,
@@ -10,6 +12,7 @@ public record SettlementListResponse(
         String settlementType,
         String splitType,
         String settlementStatus,
-        LocalDate dueDate
+        LocalDate dueDate,
+        @JsonIgnore LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementPaymentObligationResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementPaymentObligationResponse.java
@@ -1,5 +1,6 @@
 package org.teamsai.saibackend.domain.settlement.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,8 @@ public class SettlementPaymentObligationResponse {
 
     private Long paymentObligationId;
     private Long participantId;
+    @JsonIgnore
+    private Long userId;
     private String participantName;
     private BigDecimal expectedAmount;
     private BigDecimal paidAmount;

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAccountService.java
@@ -155,12 +155,12 @@ public class SettlementAccountService {
     public SettlementAccountResponse findCurrentAccount(Long userId, Long settlementId){
         SettlementDTO settlement = findSettlement(settlementId);
 
-        settlementValidator.validateOwner(settlement,userId);
+        settlementValidator.validateAccessibleUser(settlement,userId);
 
         SettlementAccountDTO account = settlementAccountMapper.findActiveBySettlementId(settlementId)
                 .orElseThrow(SettlementErrorCode.SETTLEMENT_ACCOUNT_NOT_FOUND::toException);
 
-        return toResponse(userId, account);
+        return toResponse(settlement.getOwnerId(), account);
     }
 
 

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -74,7 +74,9 @@ public class SecurityConfig {
                                         "/settlements",
                                         "/settlements/**",
                                         "/contracts/**",
-                                        "/notifications"
+                                        "/notifications",
+
+                                        "/integration/dashboard"
 
                                 )
                                 .permitAll()

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -125,7 +125,8 @@
         s.settlement_type AS settlementType,
         s.split_type AS splitType,
         s.settlement_status AS settlementStatus,
-        s.due_date AS dueDate
+        s.due_date AS dueDate,
+        s.created_at AS createdAt
 
         FROM settlement s
 

--- a/src/main/resources/mapper/settlement/SettlementPaymentStatusMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementPaymentStatusMapper.xml
@@ -12,6 +12,7 @@
         SELECT
         po.payment_obligation_id AS paymentObligationId,
         po.participant_id AS participantId,
+        sp.user_id AS userId,
         u.name AS participantName,
         po.expected_amount AS expectedAmount,
 
@@ -50,6 +51,7 @@
         GROUP BY
         po.payment_obligation_id,
         po.participant_id,
+        sp.user_id,
         u.name,
         po.expected_amount
 

--- a/src/main/resources/static/css/integration/dashboard.css
+++ b/src/main/resources/static/css/integration/dashboard.css
@@ -1,0 +1,693 @@
+﻿:root {
+    --page: #f5f7fb;
+    --surface: #ffffff;
+    --surface-soft: #f9fafc;
+    --text: #151922;
+    --muted: #667085;
+    --line: #d9dee8;
+    --green: #0f8a5f;
+    --green-soft: #e9f7f0;
+    --red: #d94c4c;
+    --red-soft: #fff0ef;
+    --blue: #275dc7;
+    --blue-soft: #eef4ff;
+    --amber: #b46a00;
+    --amber-soft: #fff4df;
+    --shadow: 0 10px 30px rgba(28, 39, 60, 0.08);
+    --font-ui: "Noto Sans KR", "Apple SD Gothic Neo", Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+    background: var(--page);
+    color: var(--text);
+    font-family: var(--font-ui);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+button {
+    font: inherit;
+}
+
+.dashboard-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.site-header {
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 0 48px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--line);
+}
+
+.brand,
+.site-nav,
+.header-actions,
+.site-footer nav {
+    display: flex;
+    align-items: center;
+}
+
+.brand {
+    gap: 10px;
+    min-width: 160px;
+    font-weight: 800;
+}
+
+.brand__mark {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: var(--green);
+    color: #fff;
+}
+
+.brand__name {
+    font-size: 18px;
+}
+
+.site-nav {
+    gap: 30px;
+    color: var(--muted);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.site-nav__link {
+    padding: 29px 0;
+    border-bottom: 2px solid transparent;
+}
+
+.site-nav__link.is-active {
+    color: var(--green);
+    border-bottom-color: var(--green);
+}
+
+.header-actions {
+    gap: 10px;
+}
+
+.icon-button,
+.profile-button,
+.calendar-button,
+.text-button,
+.filter-tab {
+    border: 0;
+    cursor: pointer;
+}
+
+.icon-button {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: var(--amber-soft);
+    color: var(--amber);
+    font-weight: 900;
+}
+
+.profile-button {
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 14px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--text);
+    font-weight: 800;
+}
+
+.dashboard-main {
+    width: min(1344px, calc(100% - 96px));
+    margin: 37px auto 80px;
+    flex: 1;
+}
+
+.page-title {
+    margin: 0 0 20px;
+    font-size: 20px;
+    line-height: 1;
+    font-weight: 800;
+}
+
+.hero-summary,
+.panel {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+}
+
+.hero-summary {
+    min-height: 256px;
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: center;
+    gap: 24px;
+    padding: 34px 56px;
+    margin-bottom: 8px;
+}
+
+.section-kicker,
+.panel h2 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 800;
+}
+
+.summary-sentence {
+    max-width: 640px;
+    margin: 22px 0 20px;
+    font-size: 32px;
+    line-height: 1.5;
+    font-weight: 700;
+}
+
+.summary-sentence span {
+    display: block;
+}
+
+.summary-sentence strong {
+    color: var(--green);
+}
+
+.summary-detail {
+    margin: 0;
+    color: var(--muted);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 760px) minmax(360px, 1fr);
+    gap: 8px;
+    align-items: start;
+    margin-top: 8px;
+}
+
+.panel {
+    overflow: hidden;
+}
+
+.calendar-panel {
+    min-height: 573px;
+    padding: 32px 31px;
+}
+
+.panel-header,
+.transaction-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.text-button {
+    min-width: 60px;
+    height: 24px;
+    padding: 0 10px;
+    border-radius: 999px;
+    background: var(--surface-soft);
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.calendar-card {
+    margin-top: 18px;
+    padding: 25px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+}
+
+.calendar-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.calendar-toolbar strong {
+    font-size: 20px;
+}
+
+.calendar-actions {
+    display: flex;
+    gap: 16px;
+}
+
+.calendar-button {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: var(--surface-soft);
+    color: var(--text);
+    font-size: 23px;
+    line-height: 1;
+}
+
+.calendar-weekdays,
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.calendar-weekdays {
+    margin-bottom: 12px;
+    color: var(--muted);
+    font-size: 13px;
+    font-weight: 800;
+    text-align: center;
+}
+
+.calendar-weekdays span:first-child,
+.calendar-day.is-sunday .calendar-day__number {
+    color: var(--red);
+}
+
+.calendar-weekdays span:last-child,
+.calendar-day.is-saturday .calendar-day__number {
+    color: var(--blue);
+}
+
+.calendar-grid {
+    row-gap: 8px;
+    column-gap: 8px;
+}
+
+.calendar-day {
+    position: relative;
+    height: 44px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+}
+
+.calendar-day:hover {
+    background: var(--surface-soft);
+}
+
+.calendar-day.is-today {
+    background: var(--blue-soft);
+    font-weight: 900;
+}
+
+.calendar-day.is-outside {
+    opacity: 0.34;
+}
+
+.calendar-day__number {
+    display: block;
+    line-height: 20px;
+}
+
+.calendar-day__dots {
+    position: absolute;
+    left: 50%;
+    bottom: 5px;
+    display: flex;
+    gap: 4px;
+    transform: translateX(-50%);
+}
+
+.dot {
+    width: 7px;
+    height: 7px;
+    display: inline-block;
+    border-radius: 50%;
+}
+
+.dot--inbound {
+    background: var(--green);
+}
+
+.dot--outbound {
+    background: var(--red);
+}
+
+.calendar-legend {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+    margin-top: 18px;
+    color: var(--muted);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.calendar-legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.side-stack {
+    display: grid;
+    gap: 8px;
+}
+
+.attention-panel {
+    min-height: 330px;
+    padding: 28px 29px;
+}
+
+.attention-list {
+    display: grid;
+    gap: 17px;
+    margin-top: 16px;
+}
+
+.attention-item {
+    min-height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 0 28px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    background: var(--surface-soft);
+}
+
+.attention-item span {
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.attention-item button {
+    min-width: 60px;
+    height: 24px;
+    border: 0;
+    border-radius: 999px;
+    background: var(--green-soft);
+    color: var(--green);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.month-panel {
+    min-height: 240px;
+    padding: 20px 27px 25px;
+}
+
+.month-stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    margin-top: 19px;
+}
+
+.month-stats div {
+    min-width: 0;
+}
+
+.month-stats span,
+.completion-row span {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.month-stats strong {
+    font-size: 36px;
+    line-height: 1;
+}
+
+.month-stats em {
+    margin-left: 4px;
+    font-style: normal;
+    font-weight: 700;
+}
+
+.completion-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 17px;
+}
+
+.completion-row strong {
+    font-size: 20px;
+}
+
+.progress-track {
+    height: 8px;
+    margin-top: 14px;
+    border-radius: 999px;
+    background: #edf0f5;
+    overflow: hidden;
+}
+
+.progress-track span {
+    display: block;
+    height: 100%;
+    width: 0;
+    border-radius: inherit;
+    background: var(--green);
+}
+
+.transaction-panel {
+    margin-top: 8px;
+}
+
+.transaction-header {
+    height: 41px;
+    padding: 0 32px;
+}
+
+.filter-tabs {
+    display: inline-flex;
+    padding: 2px 4px;
+    border-radius: 999px;
+    background: var(--surface-soft);
+}
+
+.filter-tab {
+    width: 53px;
+    height: 26px;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.filter-tab.is-active {
+    background: var(--surface);
+    color: var(--green);
+    box-shadow: 0 1px 3px rgba(16, 24, 40, 0.12);
+}
+
+.transaction-table {
+    border-top: 1px solid var(--line);
+}
+
+.transaction-row {
+    min-height: 45px;
+    display: grid;
+    grid-template-columns: 1.3fr 1.2fr 1.2fr 110px;
+    align-items: center;
+    gap: 24px;
+    padding: 0 32px;
+    border-bottom: 1px solid var(--line);
+}
+
+.transaction-row:last-child {
+    border-bottom: 0;
+}
+
+.transaction-row--head {
+    background: var(--surface-soft);
+    color: var(--muted);
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.status-chip {
+    width: fit-content;
+    min-width: 48px;
+    display: inline-flex;
+    justify-content: center;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.status-chip--done {
+    background: var(--green-soft);
+    color: var(--green);
+}
+
+.status-chip--waiting {
+    background: var(--blue-soft);
+    color: var(--blue);
+}
+
+.detail-arrow {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    color: var(--muted);
+    font-size: 22px;
+}
+
+.empty-state {
+    padding: 34px 32px;
+    color: var(--muted);
+    text-align: center;
+}
+
+.site-footer {
+    min-height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 24px 48px;
+    background: #1f2937;
+    color: #fff;
+}
+
+.site-footer p {
+    margin: 8px 0 0;
+    color: #cfd6e3;
+    font-size: 13px;
+}
+
+.site-footer nav {
+    gap: 18px;
+    color: #dce3ef;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+@media (max-width: 1180px) {
+    .site-header,
+    .site-footer {
+        padding-left: 28px;
+        padding-right: 28px;
+    }
+
+    .dashboard-main {
+        width: min(100% - 40px, 960px);
+    }
+
+    .hero-summary,
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+
+}
+
+@media (max-width: 760px) {
+    .site-header {
+        height: auto;
+        flex-wrap: wrap;
+        padding-top: 16px;
+        padding-bottom: 16px;
+    }
+
+    .site-nav {
+        order: 3;
+        width: 100%;
+        justify-content: space-between;
+        gap: 12px;
+        overflow-x: auto;
+    }
+
+    .site-nav__link {
+        padding: 12px 0;
+        white-space: nowrap;
+    }
+
+    .dashboard-main {
+        width: min(100% - 28px, 680px);
+        margin-top: 24px;
+    }
+
+    .hero-summary {
+        grid-template-columns: 1fr;
+        padding: 28px 22px;
+    }
+
+    .summary-sentence {
+        font-size: 24px;
+    }
+
+    .calendar-panel,
+    .attention-panel,
+    .month-panel {
+        padding: 22px 18px;
+    }
+
+    .calendar-card {
+        padding: 18px 12px;
+    }
+
+    .calendar-grid {
+        column-gap: 3px;
+    }
+
+    .calendar-day {
+        height: 42px;
+    }
+
+    .month-stats {
+        grid-template-columns: 1fr;
+        gap: 14px;
+    }
+
+    .transaction-header {
+        height: auto;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 18px;
+    }
+
+    .transaction-row {
+        grid-template-columns: 1fr;
+        gap: 6px;
+        padding: 14px 18px;
+    }
+
+    .transaction-row--head {
+        display: none;
+    }
+
+    .site-footer {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}

--- a/src/main/resources/static/js/integration/dashboard.js
+++ b/src/main/resources/static/js/integration/dashboard.js
@@ -1,0 +1,310 @@
+const dashboardState = {
+    amountSummary: null,
+    attentionItems: [],
+    monthlySummary: null,
+    recentTransactions: [],
+    calendarDays: []
+};
+
+let calendarCursor = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+let currentTransactionFilter = "ALL";
+
+const currencyFormatter = new Intl.NumberFormat("ko-KR");
+const transactionStatusLabels = {
+    COMPLETED: "완료",
+    IN_PROGRESS: "진행중"
+};
+const transactionStatusClasses = {
+    COMPLETED: "done",
+    IN_PROGRESS: "waiting"
+};
+
+function authHeaders() {
+    const token = sessionStorage.getItem("accessToken");
+    return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function toAmount(value) {
+    const amount = Number(value);
+    return Number.isFinite(amount) ? amount : 0;
+}
+
+function formatWon(amount) {
+    return `${currencyFormatter.format(toAmount(amount))}원`;
+}
+
+function toDateKey(date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
+function toYearMonth(date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    return `${year}-${month}`;
+}
+
+async function loadDashboard(calendarOnly = false) {
+    const token = sessionStorage.getItem("accessToken");
+
+    if (!token) {
+        window.location.href = "/login?required=true";
+        return;
+    }
+
+    if (!calendarOnly) {
+        setLoadingState();
+    }
+
+    try {
+        const params = new URLSearchParams({
+            yearMonth: toYearMonth(calendarCursor)
+        });
+        const response = await fetch(`/api/integration/dashboard?${params}`, {
+            headers: authHeaders()
+        });
+
+        if (response.status === 401) {
+            sessionStorage.removeItem("accessToken");
+            window.location.href = "/login?required=true";
+            return;
+        }
+
+        if (!response.ok) {
+            throw new Error(`통합 대시보드 조회 실패: ${response.status}`);
+        }
+
+        const data = await response.json();
+        dashboardState.calendarDays = data.calendarDays || [];
+
+        if (calendarOnly) {
+            renderCalendar();
+            return;
+        }
+
+        dashboardState.monthlySummary = data.monthlySummary || null;
+        dashboardState.amountSummary = data.amountSummary || null;
+        dashboardState.attentionItems = data.attentionItems || [];
+        dashboardState.recentTransactions = data.recentTransactions || [];
+        renderDashboard();
+    } catch (error) {
+        console.error(error);
+        if (!calendarOnly) {
+            renderLoadError();
+        }
+    }
+}
+
+function setLoadingState() {
+    document.getElementById("receiveTotalText").textContent = "불러오는 중";
+    document.getElementById("sendTotalText").textContent = "불러오는 중";
+    document.getElementById("receiveBreakdownText").textContent = "-";
+    document.getElementById("attentionList").innerHTML =
+        '<div class="empty-state">내역을 불러오는 중입니다.</div>';
+    document.getElementById("transactionList").innerHTML =
+        '<div class="empty-state">거래를 불러오는 중입니다.</div>';
+}
+
+function renderDashboard() {
+    renderAmountSummary();
+    renderAttentionItems();
+    renderMonthlySummary();
+    renderCalendar();
+    renderTransactions();
+}
+
+function renderAmountSummary() {
+    const receivable = dashboardState.amountSummary?.receivable || {};
+    const payable = dashboardState.amountSummary?.payable || {};
+
+    document.getElementById("receiveTotalText").textContent = formatWon(receivable.totalAmount);
+    document.getElementById("sendTotalText").textContent = formatWon(payable.totalAmount);
+    document.getElementById("receiveBreakdownText").textContent =
+        `정산 ${formatWon(receivable.settlementAmount)} 차용증 ${formatWon(receivable.loanAmount)} 입니다`;
+}
+
+function renderAttentionItems() {
+    const list = document.getElementById("attentionList");
+    list.innerHTML = "";
+
+    if (dashboardState.attentionItems.length === 0) {
+        list.innerHTML = '<div class="empty-state">확인이 필요한 내역이 없습니다.</div>';
+        return;
+    }
+
+    dashboardState.attentionItems.forEach((item) => {
+        const row = document.createElement("div");
+        const button = document.createElement("button");
+        row.className = "attention-item";
+        row.innerHTML = `<span>${escapeHtml(getAttentionMessage(item))}</span>`;
+        button.type = "button";
+        button.textContent = "확인";
+        button.addEventListener("click", () => {
+            if (item.actionUrl) window.location.href = item.actionUrl;
+        });
+        row.appendChild(button);
+        list.appendChild(row);
+    });
+}
+
+function getAttentionMessage(item) {
+    if (item.type === "LOAN_DUE_SOON") {
+        return item.remainingDays === 0
+            ? "차용증 상환일이 오늘이에요"
+            : `차용증 상환일이 ${item.remainingDays}일 남았어요`;
+    }
+
+    if (item.type === "SETTLEMENT_DUE_SOON") {
+        return item.remainingDays === 0
+            ? "정산 마감일이 오늘이에요"
+            : `정산 마감일이 ${item.remainingDays}일 남았어요`;
+    }
+
+    return "확인이 필요한 내역이 있어요";
+}
+
+function renderMonthlySummary() {
+    const summary = dashboardState.monthlySummary || {};
+    const completionRate = Math.min(100, Math.max(0, toAmount(summary.transactionCompletionRate)));
+
+    document.getElementById("completedCount").textContent = summary.completedTransactionCount || 0;
+    document.getElementById("activeSettlementCount").textContent = summary.inProgressSettlementCount || 0;
+    document.getElementById("loanRepaymentCount").textContent = summary.inProgressLoanRepaymentCount || 0;
+    document.getElementById("completionRateText").textContent = `${completionRate}%`;
+    document.getElementById("completionRateBar").style.width = `${completionRate}%`;
+}
+
+function getCalendarDates(cursor) {
+    const year = cursor.getFullYear();
+    const month = cursor.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const startDate = new Date(year, month, 1 - firstDay.getDay());
+
+    return Array.from({ length: 42 }, (_, index) => {
+        const date = new Date(startDate);
+        date.setDate(startDate.getDate() + index);
+        return date;
+    });
+}
+
+function getCalendarDaysByDate() {
+    return dashboardState.calendarDays.reduce((acc, calendarDay) => {
+        acc[calendarDay.date] = calendarDay;
+        return acc;
+    }, {});
+}
+
+function renderCalendar() {
+    const label = document.getElementById("calendarMonthLabel");
+    const grid = document.getElementById("calendarGrid");
+    const calendarDaysByDate = getCalendarDaysByDate();
+    const todayKey = toDateKey(new Date());
+    const cursorMonth = calendarCursor.getMonth();
+
+    label.textContent = `${calendarCursor.getFullYear()}년 ${calendarCursor.getMonth() + 1}월`;
+    grid.innerHTML = "";
+
+    getCalendarDates(calendarCursor).forEach((date) => {
+        const dateKey = toDateKey(date);
+        const calendarDay = calendarDaysByDate[dateKey] || {};
+        const dayButton = document.createElement("button");
+        dayButton.type = "button";
+        dayButton.className = "calendar-day";
+        dayButton.setAttribute("aria-label", `${date.getMonth() + 1}월 ${date.getDate()}일`);
+
+        if (date.getMonth() !== cursorMonth) dayButton.classList.add("is-outside");
+        if (date.getDay() === 0) dayButton.classList.add("is-sunday");
+        if (date.getDay() === 6) dayButton.classList.add("is-saturday");
+        if (dateKey === todayKey) dayButton.classList.add("is-today");
+
+        dayButton.innerHTML = `
+            <span class="calendar-day__number">${date.getDate()}</span>
+            <span class="calendar-day__dots" aria-hidden="true">
+                ${calendarDay.hasInbound ? '<i class="dot dot--inbound"></i>' : ""}
+                ${calendarDay.hasOutbound ? '<i class="dot dot--outbound"></i>' : ""}
+            </span>
+        `;
+        grid.appendChild(dayButton);
+    });
+}
+
+function renderTransactions() {
+    const list = document.getElementById("transactionList");
+    const filteredTransactions = (currentTransactionFilter === "ALL"
+        ? dashboardState.recentTransactions
+        : dashboardState.recentTransactions.filter(
+            (transaction) => transaction.type === currentTransactionFilter
+        )).slice(0, 5);
+
+    list.innerHTML = "";
+
+    if (filteredTransactions.length === 0) {
+        list.innerHTML = '<div class="empty-state">표시할 거래 내역이 없습니다.</div>';
+        return;
+    }
+
+    filteredTransactions.forEach((transaction) => {
+        const row = document.createElement("div");
+        const statusLabel = transactionStatusLabels[transaction.status] || transaction.status || "-";
+        const statusClass = transactionStatusClasses[transaction.status] || "waiting";
+        const detailUrl = transaction.detailUrl || "#";
+        row.className = "transaction-row";
+        row.setAttribute("role", "row");
+        row.innerHTML = `
+            <span>${escapeHtml(transaction.title)}</span>
+            <span><i class="status-chip status-chip--${statusClass}">${escapeHtml(statusLabel)}</i></span>
+            <span>${formatWon(transaction.amount)}</span>
+            <span><a class="detail-arrow" href="${escapeHtml(detailUrl)}" aria-label="${escapeHtml(transaction.title)} 상세보기">›</a></span>
+        `;
+        list.appendChild(row);
+    });
+}
+
+function renderLoadError() {
+    document.getElementById("receiveTotalText").textContent = "-";
+    document.getElementById("sendTotalText").textContent = "-";
+    document.getElementById("receiveBreakdownText").textContent = "금액을 불러오지 못했습니다.";
+    document.getElementById("attentionList").innerHTML =
+        '<div class="empty-state">내역을 불러오지 못했습니다.</div>';
+    document.getElementById("transactionList").innerHTML =
+        '<div class="empty-state">거래를 불러오지 못했습니다.</div>';
+    dashboardState.calendarDays = [];
+    dashboardState.monthlySummary = null;
+    renderMonthlySummary();
+    renderCalendar();
+}
+
+function bindEvents() {
+    document.getElementById("prevMonthButton").addEventListener("click", async () => {
+        calendarCursor = new Date(calendarCursor.getFullYear(), calendarCursor.getMonth() - 1, 1);
+        await loadDashboard(true);
+    });
+
+    document.getElementById("nextMonthButton").addEventListener("click", async () => {
+        calendarCursor = new Date(calendarCursor.getFullYear(), calendarCursor.getMonth() + 1, 1);
+        await loadDashboard(true);
+    });
+
+    document.querySelectorAll(".filter-tab").forEach((button) => {
+        button.addEventListener("click", () => {
+            document.querySelectorAll(".filter-tab").forEach((tab) => tab.classList.remove("is-active"));
+            button.classList.add("is-active");
+            currentTransactionFilter = button.dataset.filter;
+            renderTransactions();
+        });
+    });
+}
+
+function escapeHtml(value) {
+    return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+bindEvents();
+loadDashboard();

--- a/src/main/resources/static/js/user/login.js
+++ b/src/main/resources/static/js/user/login.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const ROUTES = {
         main: FILE_PREVIEW ? "../login/login.html" : "/",
         signup: FILE_PREVIEW ? "../signup/signup.html" : "/signup",
-        mypage: FILE_PREVIEW ? "../mypage/mypage.html" : "/mypage"
+        dashboard: FILE_PREVIEW ? "../integration/dashboard.html" : "/integration/dashboard"
     };
 
     const API = {
@@ -135,7 +135,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 await loginWithApi();
             }
 
-            window.location.replace(ROUTES.mypage);
+            window.location.replace(ROUTES.dashboard);
 
         } catch (error) {
             console.error(error);

--- a/src/main/resources/templates/integration/dashboard.html
+++ b/src/main/resources/templates/integration/dashboard.html
@@ -1,0 +1,127 @@
+﻿<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>사이원장 통합 대시보드</title>
+    <link rel="stylesheet" th:href="@{/css/integration/dashboard.css}" href="/css/integration/dashboard.css">
+</head>
+<body>
+<div class="dashboard-shell">
+    <header class="site-header">
+        <a class="brand" href="/integration/dashboard" aria-label="사이원장 홈">
+            <span class="brand__mark">S</span>
+            <span class="brand__name">사이원장</span>
+        </a>
+        <nav class="site-nav" aria-label="주요 메뉴">
+            <a class="site-nav__link is-active" href="/integration/dashboard">대시보드</a>
+            <a class="site-nav__link" href="/settlements">정산</a>
+            <a class="site-nav__link" href="/dashboard">금전소비대차</a>
+            <a class="site-nav__link" href="#">캘린더</a>
+        </nav>
+        <div class="header-actions" aria-label="사용자 메뉴">
+            <a class="icon-button" href="/notifications" aria-label="알림">!</a>
+            <a class="profile-button" href="/mypage">마이페이지</a>
+        </div>
+    </header>
+
+    <main class="dashboard-main">
+        <h1 class="page-title">통합 대시보드</h1>
+
+        <section class="hero-summary" aria-labelledby="summaryTitle">
+            <div class="hero-summary__copy">
+                <p id="summaryTitle" class="section-kicker">요약 현황</p>
+                <p class="summary-sentence">
+                    현재 받을 돈은 <strong id="receiveTotalText">-</strong>이고
+                    <span>현재 보낼 돈은 <strong id="sendTotalText">-</strong>이에요.</span>
+                </p>
+                <p class="summary-detail" id="receiveBreakdownText">-</p>
+            </div>
+        </section>
+
+        <section class="dashboard-grid" aria-label="월별 현황과 확인 필요 내역">
+            <article class="panel calendar-panel">
+                <div class="panel-header">
+                    <h2>월별 현황</h2>
+                    <button class="text-button" type="button">전체보기</button>
+                </div>
+                <div class="calendar-card">
+                    <div class="calendar-toolbar">
+                        <strong id="calendarMonthLabel">-</strong>
+                        <div class="calendar-actions">
+                            <button id="prevMonthButton" class="calendar-button" type="button" aria-label="이전 달">‹</button>
+                            <button id="nextMonthButton" class="calendar-button" type="button" aria-label="다음 달">›</button>
+                        </div>
+                    </div>
+                    <div class="calendar-weekdays" aria-hidden="true">
+                        <span>일</span><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span>
+                    </div>
+                    <div id="calendarGrid" class="calendar-grid" aria-label="월별 일정 달력"></div>
+                    <div class="calendar-legend" aria-label="입출금 범례">
+                        <span><i class="dot dot--inbound"></i>입금</span>
+                        <span><i class="dot dot--outbound"></i>출금</span>
+                    </div>
+                </div>
+            </article>
+
+            <div class="side-stack">
+                <article class="panel attention-panel">
+                    <h2>확인이 필요한 내역</h2>
+                    <div id="attentionList" class="attention-list"></div>
+                </article>
+
+                <article class="panel month-panel">
+                    <h2>이번달 요약</h2>
+                    <div class="month-stats">
+                        <div><span>완료한 거래</span><strong id="completedCount">-</strong><em>건</em></div>
+                        <div><span>진행 중인 정산</span><strong id="activeSettlementCount">-</strong><em>건</em></div>
+                        <div><span>차용증 상환</span><strong id="loanRepaymentCount">-</strong><em>건</em></div>
+                    </div>
+                    <div class="completion-row">
+                        <span>거래 완료율</span>
+                        <strong id="completionRateText">-</strong>
+                    </div>
+                    <div class="progress-track" aria-hidden="true">
+                        <span id="completionRateBar"></span>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="panel transaction-panel" aria-labelledby="recentTransactionTitle">
+            <div class="panel-header transaction-header">
+                <h2 id="recentTransactionTitle">최근 거래 내역</h2>
+                <div class="filter-tabs" role="tablist" aria-label="거래 유형 필터">
+                    <button class="filter-tab is-active" type="button" data-filter="ALL">전체</button>
+                    <button class="filter-tab" type="button" data-filter="LOAN">대출</button>
+                    <button class="filter-tab" type="button" data-filter="SETTLEMENT">정산</button>
+                </div>
+            </div>
+            <div class="transaction-table" role="table" aria-label="최근 거래 내역">
+                <div class="transaction-row transaction-row--head" role="row">
+                    <span role="columnheader">제목</span>
+                    <span role="columnheader">상태</span>
+                    <span role="columnheader">금액</span>
+                    <span role="columnheader">상세보기</span>
+                </div>
+                <div id="transactionList"></div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div>
+            <strong>사이원장</strong>
+            <p>정산과 차용증 거래를 한 곳에서 확인하세요.</p>
+        </div>
+        <nav aria-label="푸터 메뉴">
+            <a href="#">이용약관</a>
+            <a href="#">개인정보처리방침</a>
+            <a href="#">고객센터</a>
+        </nav>
+    </footer>
+</div>
+
+<script th:src="@{/js/integration/dashboard.js}" src="/js/integration/dashboard.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/settlement/settlement-list.html
+++ b/src/main/resources/templates/settlement/settlement-list.html
@@ -11,11 +11,11 @@
 <body>
 <header class="site-header">
     <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
+        <a class="brand" href="/integration/dashboard">사이원장</a>
 
         <nav class="main-nav" aria-label="주요 메뉴">
             <a href="/">서비스 소개</a>
-            <a href="/contracts">금전거래대차</a>
+            <a href="/dashboard">금전거래대차</a>
             <a class="active" href="/settlements">정산</a>
             <a href="/schedule">거래 일정</a>
         </nav>

--- a/src/test/java/org/teamsai/saibackend/domain/contractdashboard/DashboardServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractdashboard/DashboardServiceTest.java
@@ -20,10 +20,13 @@ import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentSch
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class DashboardServiceTest {
@@ -149,6 +152,52 @@ class DashboardServiceTest {
 
         assertThat(response.getContracts().get(0).getContractId()).isEqualTo(61L);
         assertThat(response.getContracts().get(1).getContractId()).isEqualTo(60L);
+    }
+
+    @Test
+    void getDashboard_sortsByCreatedAtOnlyWhenIntegrationSortIsRequested() {
+        LoanContractResponse newerLowerId = buildContract(60L, null, ContractStatus.COMPLETED, "new", 1L, 2L)
+                .toBuilder().createdAt(LocalDateTime.of(2026, 8, 2, 10, 0)).build();
+        LoanContractResponse olderHigherId = buildContract(61L, null, ContractStatus.COMPLETED, "old", 1L, 3L)
+                .toBuilder().createdAt(LocalDateTime.of(2026, 8, 1, 10, 0)).build();
+        when(loanContractService.findContractsByUser(USER_ID))
+                .thenReturn(List.of(newerLowerId, olderHigherId));
+        when(repaymentScheduleService.getSchedule(60L)).thenReturn(List.of());
+        when(repaymentScheduleService.getSchedule(61L)).thenReturn(List.of());
+
+        DashboardResponse integration = dashboardService.getDashboard(
+                USER_ID, null, "ALL", "CREATED_DESC", 1
+        );
+        DashboardResponse existingDefault = dashboardService.getDashboard(
+                USER_ID, null, "ALL", null, 1
+        );
+
+        assertThat(integration.getContracts()).extracting(DashboardContractRowResponse::getContractId)
+                .containsExactly(60L, 61L);
+        assertThat(existingDefault.getContracts()).extracting(DashboardContractRowResponse::getContractId)
+                .containsExactly(61L, 60L);
+    }
+
+    @Test
+    void getIntegrationDashboardDataReusesEachContractsSchedules() {
+        LoanContractResponse contract = buildContract(
+                62L, null, ContractStatus.COMPLETED, "통합 대시보드 계약", 1L, 2L
+        );
+        RepaymentScheduleDTO schedule = buildSchedule(
+                RepaymentScheduleStatus.PENDING, 500_000, LocalDate.now()
+        );
+        when(loanContractService.findContractsByUser(USER_ID)).thenReturn(List.of(contract));
+        when(repaymentScheduleService.getSchedule(62L)).thenReturn(List.of(schedule));
+
+        DashboardService.IntegrationDashboardData result =
+                dashboardService.getIntegrationDashboardData(USER_ID);
+
+        assertThat(result.dashboard().getContracts()).hasSize(1);
+        assertThat(result.loanSchedules()).singleElement().satisfies(context -> {
+            assertThat(context.contract().getContractId()).isEqualTo(62L);
+            assertThat(context.schedule()).isSameAs(schedule);
+        });
+        verify(repaymentScheduleService, times(1)).getSchedule(62L);
     }
 
     @Test

--- a/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
@@ -1,0 +1,454 @@
+package org.teamsai.saibackend.domain.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.dto.RepaymentScheduleDTO;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardContractRowResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
+import org.teamsai.saibackend.domain.contractdashboard.service.DashboardService;
+import org.teamsai.saibackend.domain.contractdashboard.type.DashboardContractStatus;
+import org.teamsai.saibackend.domain.integration.dto.response.IntegrationDashboardResponse;
+import org.teamsai.saibackend.domain.integration.service.IntegrationDashboardService;
+import org.teamsai.saibackend.domain.integration.type.DashboardAttentionType;
+import org.teamsai.saibackend.domain.integration.type.DashboardTransactionStatus;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentObligationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentStatusResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementPaymentStatusService;
+import org.teamsai.saibackend.domain.settlement.service.SettlementQueryService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationDashboardServiceTest {
+
+    @Mock
+    private DashboardService contractDashboardService;
+
+    @Mock
+    private SettlementQueryService settlementQueryService;
+
+    @Mock
+    private SettlementPaymentStatusService settlementPaymentStatusService;
+
+    @InjectMocks
+    private IntegrationDashboardService integrationDashboardService;
+
+    @Test
+    void includesLoanReceivableAndPayableAmounts() {
+        Long userId = 1L;
+        DashboardSummaryResponse loanSummary = DashboardSummaryResponse.builder()
+                .totalLentAmount(BigDecimal.valueOf(12_000_000))
+                .totalBorrowedAmount(BigDecimal.valueOf(1_000_000))
+                .build();
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(
+                        DashboardResponse.builder().summary(loanSummary).build(),
+                        null,
+                        List.of()
+                ));
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId,
+                YearMonth.of(2026, 8)
+        );
+
+        assertThat(response.getAmountSummary().getReceivable().getLoanAmount())
+                .isEqualByComparingTo("12000000");
+        assertThat(response.getAmountSummary().getReceivable().getTotalAmount())
+                .isEqualByComparingTo("12000000");
+        assertThat(response.getAmountSummary().getPayable().getLoanAmount())
+                .isEqualByComparingTo("1000000");
+        assertThat(response.getAmountSummary().getPayable().getTotalAmount())
+                .isEqualByComparingTo("1000000");
+        assertThat(response.getAmountSummary().getReceivable().getSettlementAmount())
+                .isEqualByComparingTo("0");
+        assertThat(response.getAmountSummary().getPayable().getSettlementAmount())
+                .isEqualByComparingTo("0");
+    }
+
+    @Test
+    void includesLoanContractsInRecentTransactions() {
+        Long userId = 1L;
+        DashboardContractRowResponse contract = DashboardContractRowResponse.builder()
+                .contractId(15L)
+                .contractAlias("생활비 차용증")
+                .principalAmount(BigDecimal.valueOf(3_000_000))
+                .totalRemainingAmount(BigDecimal.valueOf(1_250_000))
+                .contractStatus(DashboardContractStatus.ONGOING)
+                .build();
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(DashboardResponse.builder()
+                        .summary(DashboardSummaryResponse.builder()
+                                .totalLentAmount(BigDecimal.ZERO)
+                                .totalBorrowedAmount(BigDecimal.ZERO)
+                                .build())
+                        .contracts(List.of(contract))
+                        .build(), null, List.of()));
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId,
+                YearMonth.of(2026, 8)
+        );
+
+        assertThat(response.getRecentTransactions()).hasSize(1);
+        assertThat(response.getRecentTransactions().get(0).getTargetId()).isEqualTo(15L);
+        assertThat(response.getRecentTransactions().get(0).getType())
+                .isEqualTo(PaymentTargetType.LOAN);
+        assertThat(response.getRecentTransactions().get(0).getTitle())
+                .isEqualTo("생활비 차용증");
+        assertThat(response.getRecentTransactions().get(0).getStatus())
+                .isEqualTo(DashboardTransactionStatus.IN_PROGRESS);
+        assertThat(response.getRecentTransactions().get(0).getAmount())
+                .isEqualByComparingTo("3000000");
+        assertThat(response.getRecentTransactions().get(0).getDetailUrl())
+                .isEqualTo("/contracts/15/contract-detail");
+    }
+
+    @Test
+    void includesLoanSchedulesInCalendarAttentionAndMonthlySummary() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        LocalDate upcomingDueDate = today.plusDays(2);
+        YearMonth requestedMonth = YearMonth.from(upcomingDueDate);
+
+        LoanContractResponse contract = LoanContractResponse.builder()
+                .contractId(20L)
+                .creditorId(2L)
+                .debtorId(userId)
+                .contractAlias("생활비 차용증")
+                .status(ContractStatus.COMPLETED)
+                .build();
+
+        RepaymentScheduleDTO paidSchedule = RepaymentScheduleDTO.builder()
+                .scheduleId(100L)
+                .contractId(20L)
+                .dueDate(requestedMonth.atDay(1))
+                .status(RepaymentScheduleStatus.PAID)
+                .paidAt(LocalDateTime.of(requestedMonth.atDay(1), java.time.LocalTime.NOON))
+                .build();
+
+        RepaymentScheduleDTO pendingSchedule = RepaymentScheduleDTO.builder()
+                .scheduleId(101L)
+                .contractId(20L)
+                .dueDate(upcomingDueDate)
+                .status(RepaymentScheduleStatus.PENDING)
+                .build();
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(
+                        emptyContractDashboard(), contract, List.of(paidSchedule, pendingSchedule)
+                ));
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId,
+                requestedMonth
+        );
+
+        assertThat(response.getCalendarDays()).hasSize(1);
+        assertThat(response.getCalendarDays().get(0).getDate()).isEqualTo(upcomingDueDate);
+        assertThat(response.getCalendarDays().get(0).isHasInbound()).isFalse();
+        assertThat(response.getCalendarDays().get(0).isHasOutbound()).isTrue();
+
+        assertThat(response.getAttentionItems()).hasSize(1);
+        assertThat(response.getAttentionItems().get(0).getId()).isEqualTo(101L);
+        assertThat(response.getAttentionItems().get(0).getType())
+                .isEqualTo(DashboardAttentionType.LOAN_DUE_SOON);
+        assertThat(response.getAttentionItems().get(0).getRemainingDays()).isEqualTo(2L);
+        assertThat(response.getAttentionItems().get(0).getActionUrl())
+                .isEqualTo("/contracts/20/schedule");
+
+        assertThat(response.getMonthlySummary().getInProgressLoanRepaymentCount()).isEqualTo(1);
+        assertThat(response.getMonthlySummary().getCompletedTransactionCount()).isEqualTo(1);
+        assertThat(response.getMonthlySummary().getTransactionCompletionRate())
+                .isEqualByComparingTo("50.00");
+    }
+
+    @Test
+    void filtersAndSortsUpcomingLoanAttentionItems() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        LoanContractResponse contract = LoanContractResponse.builder()
+                .contractId(20L)
+                .creditorId(2L)
+                .debtorId(userId)
+                .status(ContractStatus.COMPLETED)
+                .build();
+
+        RepaymentScheduleDTO dueInFourDays = schedule(104L, today.plusDays(4), RepaymentScheduleStatus.PENDING);
+        RepaymentScheduleDTO paidToday = schedule(105L, today, RepaymentScheduleStatus.PAID);
+        RepaymentScheduleDTO dueInThreeDays = schedule(103L, today.plusDays(3), RepaymentScheduleStatus.PENDING);
+        RepaymentScheduleDTO dueToday = schedule(100L, today, RepaymentScheduleStatus.PENDING);
+        RepaymentScheduleDTO overdue = schedule(99L, today.minusDays(1), RepaymentScheduleStatus.PENDING);
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(emptyContractDashboard(), contract, List.of(
+                        dueInFourDays,
+                        paidToday,
+                        dueInThreeDays,
+                        dueToday,
+                        overdue
+                )));
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId,
+                YearMonth.from(today)
+        );
+
+        assertThat(response.getAttentionItems())
+                .extracting(
+                        item -> item.getId(),
+                        item -> item.getType(),
+                        item -> item.getRemainingDays(),
+                        item -> item.getActionUrl()
+                )
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                100L,
+                                DashboardAttentionType.LOAN_DUE_SOON,
+                                0L,
+                                "/contracts/20/schedule"
+                        ),
+                        org.assertj.core.groups.Tuple.tuple(
+                                103L,
+                                DashboardAttentionType.LOAN_DUE_SOON,
+                                3L,
+                                "/contracts/20/schedule"
+                        )
+                );
+    }
+
+    @Test
+    void integratesOwnerSettlementAcrossDashboardSections() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        LocalDate dueDate = today.plusDays(3);
+        LocalDateTime createdAt = LocalDateTime.now().plusDays(1);
+        SettlementListResponse settlement = settlement(
+                30L, "여행 정산", "OWNER", "IN_PROGRESS", dueDate, createdAt
+        );
+        SettlementPaymentStatusResponse paymentStatus = paymentStatus(
+                30L,
+                BigDecimal.valueOf(10_000),
+                BigDecimal.valueOf(7000),
+                obligation(11L, 2L, BigDecimal.valueOf(7000))
+        );
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(emptyContractDashboard(), null, List.of()));
+        when(settlementQueryService.getSettlementList(userId)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(30L, userId)).thenReturn(paymentStatus);
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId, YearMonth.from(dueDate)
+        );
+
+        assertThat(response.getAmountSummary().getReceivable().getSettlementAmount())
+                .isEqualByComparingTo("7000");
+        assertThat(response.getMonthlySummary().getInProgressSettlementCount()).isEqualTo(1);
+        assertThat(response.getMonthlySummary().getTransactionCompletionRate())
+                .isEqualByComparingTo("0.00");
+        assertThat(response.getCalendarDays())
+                .singleElement()
+                .satisfies(day -> {
+                    assertThat(day.getDate()).isEqualTo(dueDate);
+                    assertThat(day.isHasInbound()).isTrue();
+                    assertThat(day.isHasOutbound()).isFalse();
+                });
+        assertThat(response.getAttentionItems())
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.getId()).isEqualTo(30L);
+                    assertThat(item.getType()).isEqualTo(DashboardAttentionType.SETTLEMENT_DUE_SOON);
+                    assertThat(item.getRemainingDays()).isEqualTo(3L);
+                    assertThat(item.getActionUrl()).isEqualTo("/settlements/30");
+                });
+        assertThat(response.getRecentTransactions())
+                .singleElement()
+                .satisfies(transaction -> {
+                    assertThat(transaction.getType()).isEqualTo(PaymentTargetType.SETTLEMENT);
+                    assertThat(transaction.getAmount()).isEqualByComparingTo("10000");
+                    assertThat(transaction.getDetailUrl()).isEqualTo("/settlements/30");
+                });
+    }
+
+    @Test
+    void participantUsesOnlyOwnUnpaidSettlementBalance() {
+        Long userId = 1L;
+        LocalDate dueDate = LocalDate.now().plusDays(2);
+        SettlementListResponse settlement = settlement(
+                31L, "회식 정산", "MEMBER", "IN_PROGRESS", dueDate, LocalDateTime.now()
+        );
+        SettlementPaymentStatusResponse paymentStatus = paymentStatus(
+                31L,
+                BigDecimal.valueOf(11_000),
+                BigDecimal.valueOf(9000),
+                obligation(12L, userId, BigDecimal.valueOf(6000), BigDecimal.valueOf(4000)),
+                obligation(13L, 2L, BigDecimal.valueOf(5000))
+        );
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(emptyContractDashboard(), null, List.of()));
+        when(settlementQueryService.getSettlementList(userId)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(31L, userId)).thenReturn(paymentStatus);
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId, YearMonth.from(dueDate)
+        );
+
+        assertThat(response.getAmountSummary().getPayable().getSettlementAmount())
+                .isEqualByComparingTo("4000");
+        assertThat(response.getCalendarDays().get(0).isHasOutbound()).isTrue();
+        assertThat(response.getRecentTransactions().get(0).getAmount())
+                .isEqualByComparingTo("6000");
+    }
+
+    @Test
+    void keepsFiveRecentTransactionsForEachType() {
+        Long userId = 1L;
+        LocalDateTime baseCreatedAt = LocalDateTime.of(2026, 8, 1, 10, 0);
+        List<DashboardContractRowResponse> loans = IntStream.rangeClosed(1, 5)
+                .mapToObj(index -> DashboardContractRowResponse.builder()
+                        .contractId((long) index)
+                        .contractAlias("차용증 " + index)
+                        .principalAmount(BigDecimal.valueOf(index * 1000L))
+                        .totalRemainingAmount(BigDecimal.valueOf(index * 100L))
+                        .contractStatus(DashboardContractStatus.ONGOING)
+                        .createdAt(baseCreatedAt.plusDays(index))
+                        .build())
+                .toList();
+        List<SettlementListResponse> settlements = IntStream.rangeClosed(1, 6)
+                .mapToObj(index -> settlement(
+                        100L + index,
+                        "정산 " + index,
+                        "OWNER",
+                        "IN_PROGRESS",
+                        LocalDate.of(2026, 8, 20),
+                        baseCreatedAt.plusDays(10 + index)
+                ))
+                .toList();
+
+        when(contractDashboardService.getIntegrationDashboardData(userId))
+                .thenReturn(loanData(DashboardResponse.builder()
+                        .summary(DashboardSummaryResponse.builder()
+                                .totalLentAmount(BigDecimal.ZERO)
+                                .totalBorrowedAmount(BigDecimal.ZERO)
+                                .build())
+                        .contracts(loans)
+                        .build(), null, List.of()));
+        when(settlementQueryService.getSettlementList(userId)).thenReturn(settlements);
+        settlements.forEach(settlement -> when(settlementPaymentStatusService.getPaymentStatus(
+                settlement.settlementId(), userId
+        )).thenReturn(paymentStatus(
+                settlement.settlementId(),
+                BigDecimal.valueOf(10_000),
+                BigDecimal.valueOf(10_000),
+                obligation(settlement.settlementId(), 2L, BigDecimal.valueOf(10_000))
+        )));
+
+        IntegrationDashboardResponse response = integrationDashboardService.getDashboard(
+                userId, YearMonth.of(2026, 8)
+        );
+
+        assertThat(response.getRecentTransactions()).hasSize(10);
+        assertThat(response.getRecentTransactions())
+                .filteredOn(transaction -> transaction.getType() == PaymentTargetType.LOAN)
+                .hasSize(5);
+        assertThat(response.getRecentTransactions())
+                .filteredOn(transaction -> transaction.getType() == PaymentTargetType.SETTLEMENT)
+                .extracting(transaction -> transaction.getTargetId())
+                .containsExactly(106L, 105L, 104L, 103L, 102L);
+    }
+
+    private SettlementListResponse settlement(
+            Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
+    ) {
+        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, createdAt);
+    }
+
+    private SettlementPaymentStatusResponse paymentStatus(
+            Long settlementId,
+            BigDecimal totalExpected,
+            BigDecimal totalRemaining,
+            SettlementPaymentObligationResponse... obligations
+    ) {
+        return SettlementPaymentStatusResponse.builder()
+                .settlementId(settlementId)
+                .obligations(List.of(obligations))
+                .totalExpectedAmount(totalExpected)
+                .totalRemainingAmount(totalRemaining)
+                .build();
+    }
+
+    private SettlementPaymentObligationResponse obligation(Long id, Long userId, BigDecimal remaining) {
+        return obligation(id, userId, remaining, remaining);
+    }
+
+    private SettlementPaymentObligationResponse obligation(
+            Long id, Long userId, BigDecimal expected, BigDecimal remaining
+    ) {
+        return SettlementPaymentObligationResponse.builder()
+                .paymentObligationId(id)
+                .userId(userId)
+                .expectedAmount(expected)
+                .paidAmount(BigDecimal.ZERO)
+                .remainingAmount(remaining)
+                .paymentStatus(PaymentStatus.UNPAID)
+                .build();
+    }
+
+    private RepaymentScheduleDTO schedule(
+            Long scheduleId,
+            LocalDate dueDate,
+            RepaymentScheduleStatus status
+    ) {
+        return RepaymentScheduleDTO.builder()
+                .scheduleId(scheduleId)
+                .contractId(20L)
+                .dueDate(dueDate)
+                .status(status)
+                .build();
+    }
+
+    private DashboardResponse emptyContractDashboard() {
+        return DashboardResponse.builder()
+                .summary(DashboardSummaryResponse.builder()
+                        .totalLentAmount(BigDecimal.ZERO)
+                        .totalBorrowedAmount(BigDecimal.ZERO)
+                        .build())
+                .contracts(List.of())
+                .build();
+    }
+
+    private DashboardService.IntegrationDashboardData loanData(
+            DashboardResponse dashboard,
+            LoanContractResponse contract,
+            List<RepaymentScheduleDTO> schedules
+    ) {
+        List<DashboardService.LoanScheduleContext> contexts = contract == null
+                ? List.of()
+                : schedules.stream()
+                        .map(schedule -> new DashboardService.LoanScheduleContext(contract, schedule))
+                        .toList();
+        return new DashboardService.IntegrationDashboardData(dashboard, contexts);
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "/db/user.sql",
         "/db/linked_bank_account.sql",
         "/db/settlement.sql",
-        "/db/settlement_invitation.sql",
         "/db/settlement_participant.sql",
         "/db/settlement_account.sql",
         "/db/payment.sql"
@@ -65,11 +64,11 @@ class PaymentObligationMapperTest {
         insertActiveSettlementAccount(9203L, OTHER_LINKED_ACCOUNT_ID);
         insertActiveSettlementAccount(9204L, LINKED_ACCOUNT_ID);
 
-        insertAcceptedParticipant(9301L, 9201L, 9102L, 9401L, "ACTIVE");
-        insertAcceptedParticipant(9302L, 9202L, 9103L, 9402L, "ACTIVE");
-        insertAcceptedParticipant(9303L, 9203L, 9103L, 9403L, "ACTIVE");
-        insertAcceptedParticipant(9304L, 9204L, 9103L, 9404L, "ACTIVE");
-        insertAcceptedParticipant(9305L, 9201L, 9103L, 9405L, "REMOVED");
+        insertParticipant(9201L, 9102L, 9401L, "ACTIVE");
+        insertParticipant(9202L, 9103L, 9402L, "ACTIVE");
+        insertParticipant(9203L, 9103L, 9403L, "ACTIVE");
+        insertParticipant(9204L, 9103L, 9404L, "ACTIVE");
+        insertParticipant(9201L, 9103L, 9405L, "REMOVED");
 
         insertPaymentObligation(9501L, 9401L, "10000.00", "UNPAID", "ACTIVE");
         insertPaymentObligation(9502L, 9402L, "20000.00", "PARTIALLY_PAID", "ACTIVE");
@@ -202,8 +201,7 @@ class PaymentObligationMapperTest {
         );
     }
 
-    private void insertAcceptedParticipant(
-            Long invitationId,
+    private void insertParticipant(
             Long settlementId,
             Long userId,
             Long participantId,
@@ -211,33 +209,19 @@ class PaymentObligationMapperTest {
     ) {
         jdbcTemplate.update(
                 """
-                INSERT INTO settlement_invitation (
-                    invitation_id,
-                    settlement_id,
-                    user_id,
-                    invitation_status,
-                    invited_at,
-                    accepted_at
-                )
-                VALUES (?, ?, ?, 'ACCEPTED', NOW(), NOW())
-                """,
-                invitationId,
-                settlementId,
-                userId
-        );
-        jdbcTemplate.update(
-                """
                 INSERT INTO settlement_participant (
                     participant_id,
-                    invitation_id,
+                    settlement_id,
+                    user_id,
                     participant_role,
                     participant_status,
                     joined_at
                 )
-                VALUES (?, ?, 'MEMBER', ?, NOW())
+                VALUES (?, ?, ?, 'MEMBER', ?, NOW())
                 """,
                 participantId,
-                invitationId,
+                settlementId,
+                userId,
                 participantStatus
         );
     }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAccountServiceTest.java
@@ -764,10 +764,35 @@ class SettlementAccountServiceTest {
                     );
 
             verify(settlementValidator)
-                    .validateOwner(
+                    .validateAccessibleUser(
                             settlement,
                             OWNER_ID
                     );
+        }
+
+        @Test
+        @DisplayName("참여자는 정산 소유자의 현재 수취 계좌를 조회한다")
+        void participantFindsOwnersCurrentAccount() {
+            SettlementDTO settlement = createSettlement(OWNER_ID);
+            SettlementAccountDTO account = createActiveSettlementAccount(
+                    SECOND_SETTLEMENT_ACCOUNT_ID,
+                    SECOND_LINKED_ACCOUNT_ID
+            );
+            LinkedBankAccountResponse linkedAccount = linkedAccount(SECOND_LINKED_ACCOUNT_ID);
+            when(settlementMapper.findById(SETTLEMENT_ID)).thenReturn(Optional.of(settlement));
+            when(settlementAccountMapper.findActiveBySettlementId(SETTLEMENT_ID))
+                    .thenReturn(Optional.of(account));
+            when(linkedBankAccountService.getLinkedAccounts(OWNER_ID))
+                    .thenReturn(List.of(linkedAccount));
+
+            SettlementAccountResponse response = settlementAccountService.findCurrentAccount(
+                    OTHER_USER_ID,
+                    SETTLEMENT_ID
+            );
+
+            assertThat(response.getLinkedAccountId()).isEqualTo(SECOND_LINKED_ACCOUNT_ID);
+            verify(settlementValidator).validateAccessibleUser(settlement, OTHER_USER_ID);
+            verify(linkedBankAccountService).getLinkedAccounts(OWNER_ID);
         }
 
 
@@ -806,7 +831,7 @@ class SettlementAccountServiceTest {
 
 
             verify(settlementValidator)
-                    .validateOwner(
+                    .validateAccessibleUser(
                             settlement,
                             OWNER_ID
                     );
@@ -830,7 +855,7 @@ class SettlementAccountServiceTest {
                             .SETTLEMENT_ACCESS_DENIED
                             .toException()
             ).when(settlementValidator)
-                    .validateOwner(
+                    .validateAccessibleUser(
                             settlement,
                             OTHER_USER_ID
                     );
@@ -849,7 +874,7 @@ class SettlementAccountServiceTest {
 
 
             verify(settlementValidator)
-                    .validateOwner(
+                    .validateAccessibleUser(
                             settlement,
                             OTHER_USER_ID
                     );


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #121 

## 🛠 작업 사항

  - 차용증·정산 데이터를 통합한 대시보드 구현
  - 금액 요약, 알림, 캘린더, 최근 거래 기능 개선
  - 대시보드 UI와 로그인·페이지 이동 경로 정리
  - 정산 상세 수취 계좌 노출 및 관련 테스트 수정

  ### 코드 변경 규모

  - Java: 17개 파일 (+682 / -12)
  - 테스트 코드: 4개 파일 (+545 / -33)
  - HTML/CSS/JavaScript: 5개 파일 (+1,135 / -5)
  - Mapper XML: 2개 파일 (+6 / -3)
  
## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
  - 정산 지급 현황 조회의 N+1 문제는 후속 리팩터링에서 개선할 예정입니다.
  - DB 스키마 변경은 없습니다.
  - 기존 테스트코드 2개 제외 다 성공
