### PR TITLE
feat(#135): 원 단위 상환 스케줄 생성 및 거래 자동매칭 연동

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/dto/request/LoanContractRequest.java
@@ -27,6 +27,18 @@ public class LoanContractRequest {
     @DecimalMax(value = "20.0", inclusive = true, message = "연이자율은 20%를 초과할 수 없습니다.")
     private BigDecimal interestRate;
 
+    @AssertTrue(message = "대출원금은 원 단위로 입력해주세요.")
+    public boolean isWholeWonPrincipalAmount() {
+        if (principalAmount == null) return true;
+        return principalAmount.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0;
+    }
+
+    @AssertTrue(message = "연이자율은 0.5% 단위로 입력해주세요.")
+    public boolean isValidInterestRateIncrement() {
+        if (interestRate == null) return true;
+        return interestRate.remainder(new BigDecimal("0.5")).compareTo(BigDecimal.ZERO) == 0;
+    }
+
     @NotNull(message = "상환방식을 클릭해주세요.")
     private RepaymentMethod repaymentType;
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/request/ContractChangeRequest.java
@@ -21,8 +21,13 @@ public class ContractChangeRequest {
 
     @DecimalMin(value = "0", inclusive = false, message = "이율은 0보다 커야 합니다.")
     @DecimalMax(value = "20", message = "이율은 20% 이하여야 합니다.")
-    @Digits(integer = 2, fraction = 2, message = "이율은 소수점 둘째 자리까지만 입력 가능합니다.")
     private BigDecimal newInterestRate;
+
+    @AssertTrue(message = "이율은 0.5% 단위로 입력해주세요.")
+    public boolean isValidInterestRateIncrement() {
+        if (newInterestRate == null) return true;
+        return newInterestRate.remainder(new BigDecimal("0.5")).compareTo(BigDecimal.ZERO) == 0;
+    }
 
     @Pattern(
             regexp = "EQUAL_PRINCIPAL_AND_INTEREST|EQUAL_PRINCIPAL|BULLET_REPAYMENT",

--- a/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/exception/RepaymentScheduleErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/exception/RepaymentScheduleErrorCode.java
@@ -14,7 +14,9 @@ public enum RepaymentScheduleErrorCode implements BaseErrorCode<DomainException>
 
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND,"상환 스케줄을 찾을 수 없습니다"),
 
-    SCHEDULE_NOT_PENDING(HttpStatus.CONFLICT, "이미 상환 완료되었거나 처리 불가능한 스케줄입니다.");
+    SCHEDULE_NOT_PENDING(HttpStatus.CONFLICT, "이미 상환 완료되었거나 처리 불가능한 스케줄입니다."),
+
+    SCHEDULE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상환 스케줄 생성 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/util/ScheduleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/util/ScheduleGenerator.java
@@ -1,6 +1,7 @@
 package org.teamsai.saibackend.domain.contractrepaymentschedule.util;
 
 import org.teamsai.saibackend.domain.contractrepaymentschedule.dto.RepaymentScheduleDTO;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.RepaymentScheduleErrorCode;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
 
 import java.math.BigDecimal;
@@ -11,6 +12,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ScheduleGenerator {
+
+    private static final int CALCULATION_SCALE = 20;
+    private static final int WON_SCALE = 0;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+    private static final BigDecimal MONTHS_PER_YEAR = BigDecimal.valueOf(12);
 
     public static List<RepaymentScheduleDTO> generateEqualPrincipalAndInterest(
             Long contractId, BigDecimal principal, BigDecimal annualInterestRate,
@@ -23,17 +29,57 @@ public class ScheduleGenerator {
         }
 
         BigDecimal compoundFactor = BigDecimal.ONE.add(monthlyRate).pow(months);
-        BigDecimal monthlyPayment = principal.multiply(monthlyRate).multiply(compoundFactor)
-                .divide(compoundFactor.subtract(BigDecimal.ONE), 2, RoundingMode.HALF_UP);
+        BigDecimal theoreticalMonthlyPayment = principal.multiply(monthlyRate).multiply(compoundFactor)
+                .divide(compoundFactor.subtract(BigDecimal.ONE), CALCULATION_SCALE, RoundingMode.HALF_UP);
+
+        List<BigDecimal> theoreticalInterests = new ArrayList<>();
+        BigDecimal theoreticalRemainingPrincipal = principal;
+        BigDecimal theoreticalTotalInterest = BigDecimal.ZERO;
+
+        for (int i = 1; i <= months; i++) {
+            BigDecimal theoreticalInterest = theoreticalRemainingPrincipal.multiply(monthlyRate);
+            BigDecimal theoreticalPrincipal = (i == months)
+                    ? theoreticalRemainingPrincipal
+                    : theoreticalMonthlyPayment.subtract(theoreticalInterest);
+
+            theoreticalInterests.add(theoreticalInterest);
+            theoreticalTotalInterest = theoreticalTotalInterest.add(theoreticalInterest);
+            theoreticalRemainingPrincipal = theoreticalRemainingPrincipal.subtract(theoreticalPrincipal);
+        }
+
+        BigDecimal finalizedTotalInterest = floorToWon(theoreticalTotalInterest);
+        BigDecimal finalizedTotalPayment = principal.add(finalizedTotalInterest);
+        BigDecimal regularTotalPayment = finalizedTotalPayment
+                .divide(BigDecimal.valueOf(months), WON_SCALE, RoundingMode.DOWN);
 
         List<RepaymentScheduleDTO> schedules = new ArrayList<>();
         BigDecimal remainingPrincipal = principal;
+        BigDecimal allocatedPrincipal = BigDecimal.ZERO;
+        BigDecimal allocatedInterest = BigDecimal.ZERO;
+
         for (int i = 1; i <= months; i++) {
-            BigDecimal interestDue = remainingPrincipal.multiply(monthlyRate).setScale(2, RoundingMode.HALF_UP);
-            BigDecimal principalDue = (i == months) ? remainingPrincipal : monthlyPayment.subtract(interestDue);
+            BigDecimal principalDue;
+            BigDecimal interestDue;
+
+            if (i == months) {
+                principalDue = principal.subtract(allocatedPrincipal);
+                interestDue = finalizedTotalInterest.subtract(allocatedInterest);
+            } else {
+                interestDue = floorToWon(theoreticalInterests.get(i - 1));
+                principalDue = regularTotalPayment.subtract(interestDue);
+            }
+
             remainingPrincipal = remainingPrincipal.subtract(principalDue);
-            schedules.add(buildScheduleRow(contractId, i, startDate.plusMonths(i), principalDue, interestDue, remainingPrincipal));
+            allocatedPrincipal = allocatedPrincipal.add(principalDue);
+            allocatedInterest = allocatedInterest.add(interestDue);
+
+            schedules.add(buildScheduleRow(
+                    contractId, i, startDate.plusMonths(i),
+                    principalDue, interestDue, remainingPrincipal
+            ));
         }
+
+        validateSchedule(schedules, principal, finalizedTotalInterest);
         return schedules;
     }
 
@@ -42,18 +88,43 @@ public class ScheduleGenerator {
             int months, LocalDate startDate
     ) {
         BigDecimal monthlyRate = calculateMonthlyRate(annualInterestRate);
-        BigDecimal monthlyPrincipal = principal.divide(BigDecimal.valueOf(months), 2, RoundingMode.HALF_UP);
+        BigDecimal monthlyPrincipal = principal
+                .divide(BigDecimal.valueOf(months), WON_SCALE, RoundingMode.DOWN);
 
-        List<RepaymentScheduleDTO> schedules = new ArrayList<>();
-        BigDecimal remainingPrincipal = principal;
+        List<BigDecimal> theoreticalInterests = new ArrayList<>();
+        BigDecimal calculationRemainingPrincipal = principal;
+        BigDecimal theoreticalTotalInterest = BigDecimal.ZERO;
 
         for (int i = 1; i <= months; i++) {
-            BigDecimal interestDue = remainingPrincipal.multiply(monthlyRate).setScale(2, RoundingMode.HALF_UP);
-            BigDecimal principalDue = (i == months) ? remainingPrincipal : monthlyPrincipal;
-            remainingPrincipal = remainingPrincipal.subtract(principalDue);
+            BigDecimal theoreticalInterest = calculationRemainingPrincipal.multiply(monthlyRate);
+            BigDecimal principalDue = (i == months) ? calculationRemainingPrincipal : monthlyPrincipal;
 
-            schedules.add(buildScheduleRow(contractId, i, startDate.plusMonths(i), principalDue, interestDue, remainingPrincipal));
+            theoreticalInterests.add(theoreticalInterest);
+            theoreticalTotalInterest = theoreticalTotalInterest.add(theoreticalInterest);
+            calculationRemainingPrincipal = calculationRemainingPrincipal.subtract(principalDue);
         }
+
+        BigDecimal finalizedTotalInterest = floorToWon(theoreticalTotalInterest);
+        List<RepaymentScheduleDTO> schedules = new ArrayList<>();
+        BigDecimal remainingPrincipal = principal;
+        BigDecimal allocatedInterest = BigDecimal.ZERO;
+
+        for (int i = 1; i <= months; i++) {
+            BigDecimal principalDue = (i == months) ? remainingPrincipal : monthlyPrincipal;
+            BigDecimal interestDue = (i == months)
+                    ? finalizedTotalInterest.subtract(allocatedInterest)
+                    : floorToWon(theoreticalInterests.get(i - 1));
+
+            remainingPrincipal = remainingPrincipal.subtract(principalDue);
+            allocatedInterest = allocatedInterest.add(interestDue);
+
+            schedules.add(buildScheduleRow(
+                    contractId, i, startDate.plusMonths(i),
+                    principalDue, interestDue, remainingPrincipal
+            ));
+        }
+
+        validateSchedule(schedules, principal, finalizedTotalInterest);
         return schedules;
     }
 
@@ -62,36 +133,66 @@ public class ScheduleGenerator {
             int months, LocalDate startDate
     ) {
         BigDecimal monthlyRate = calculateMonthlyRate(annualInterestRate);
-        BigDecimal interestDue = principal.multiply(monthlyRate).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal theoreticalMonthlyInterest = principal.multiply(monthlyRate);
+        BigDecimal finalizedTotalInterest = floorToWon(
+                theoreticalMonthlyInterest.multiply(BigDecimal.valueOf(months))
+        );
+        BigDecimal regularInterest = floorToWon(theoreticalMonthlyInterest);
 
         List<RepaymentScheduleDTO> schedules = new ArrayList<>();
+        BigDecimal allocatedInterest = BigDecimal.ZERO;
 
         for (int i = 1; i <= months; i++) {
             BigDecimal principalDue = (i == months) ? principal : BigDecimal.ZERO;
             BigDecimal remainingPrincipal = (i == months) ? BigDecimal.ZERO : principal;
+            BigDecimal interestDue = (i == months)
+                    ? finalizedTotalInterest.subtract(allocatedInterest)
+                    : regularInterest;
 
-            schedules.add(buildScheduleRow(contractId, i, startDate.plusMonths(i), principalDue, interestDue, remainingPrincipal));
+            allocatedInterest = allocatedInterest.add(interestDue);
+
+            schedules.add(buildScheduleRow(
+                    contractId, i, startDate.plusMonths(i),
+                    principalDue, interestDue, remainingPrincipal
+            ));
         }
+
+        validateSchedule(schedules, principal, finalizedTotalInterest);
         return schedules;
     }
 
     private static BigDecimal calculateMonthlyRate(BigDecimal annualInterestRate) {
         return annualInterestRate
-                .divide(BigDecimal.valueOf(100), 10, RoundingMode.HALF_UP)
-                .divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_UP);
+                .divide(HUNDRED, CALCULATION_SCALE, RoundingMode.HALF_UP)
+                .divide(MONTHS_PER_YEAR, CALCULATION_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private static BigDecimal floorToWon(BigDecimal amount) {
+        return amount.setScale(WON_SCALE, RoundingMode.DOWN);
     }
 
     private static RepaymentScheduleDTO buildScheduleRow(
             Long contractId, int sequence, LocalDate dueDate,
             BigDecimal principalDue, BigDecimal interestDue, BigDecimal remainingPrincipal
     ) {
+        validateWholeWon(principalDue);
+        validateWholeWon(interestDue);
+        validateWholeWon(remainingPrincipal);
+
+        BigDecimal totalPaymentDue = principalDue.add(interestDue);
+        validateWholeWon(totalPaymentDue);
+
+        if (principalDue.signum() < 0 || interestDue.signum() < 0 || remainingPrincipal.signum() < 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_GENERATION_FAILED.toException();
+        }
+
         return RepaymentScheduleDTO.builder()
                 .contractId(contractId)
                 .sequence(sequence)
                 .dueDate(dueDate)
                 .principalDue(principalDue)
                 .interestDue(interestDue)
-                .totalPaymentDue(principalDue.add(interestDue))
+                .totalPaymentDue(totalPaymentDue)
                 .remainingPrincipal(remainingPrincipal)
                 .status(RepaymentScheduleStatus.PENDING)
                 .createdAt(LocalDateTime.now())
@@ -101,14 +202,51 @@ public class ScheduleGenerator {
     private static List<RepaymentScheduleDTO> generateZeroInterestRows(
             Long contractId, BigDecimal principal, int months, LocalDate startDate
     ) {
-        BigDecimal monthlyPrincipal = principal.divide(BigDecimal.valueOf(months), 2, RoundingMode.HALF_UP);
+        BigDecimal monthlyPrincipal = principal
+                .divide(BigDecimal.valueOf(months), WON_SCALE, RoundingMode.DOWN);
         List<RepaymentScheduleDTO> schedules = new ArrayList<>();
         BigDecimal remainingPrincipal = principal;
+
         for (int i = 1; i <= months; i++) {
             BigDecimal principalDue = (i == months) ? remainingPrincipal : monthlyPrincipal;
             remainingPrincipal = remainingPrincipal.subtract(principalDue);
-            schedules.add(buildScheduleRow(contractId, i, startDate.plusMonths(i), principalDue, BigDecimal.ZERO, remainingPrincipal));
+            schedules.add(buildScheduleRow(
+                    contractId, i, startDate.plusMonths(i),
+                    principalDue, BigDecimal.ZERO, remainingPrincipal
+            ));
         }
+
+        validateSchedule(schedules, principal, BigDecimal.ZERO);
         return schedules;
+    }
+
+    private static void validateWholeWon(BigDecimal amount) {
+        if (amount == null || amount.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_GENERATION_FAILED.toException();
+        }
+    }
+
+    private static void validateSchedule(
+            List<RepaymentScheduleDTO> schedules,
+            BigDecimal expectedPrincipal,
+            BigDecimal expectedInterest
+    ) {
+        BigDecimal principalSum = schedules.stream()
+                .map(RepaymentScheduleDTO::getPrincipalDue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal interestSum = schedules.stream()
+                .map(RepaymentScheduleDTO::getInterestDue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (principalSum.compareTo(expectedPrincipal) != 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_GENERATION_FAILED.toException();
+        }
+        if (interestSum.compareTo(expectedInterest) != 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_GENERATION_FAILED.toException();
+        }
+        if (schedules.isEmpty()
+                || schedules.get(schedules.size() - 1).getRemainingPrincipal().compareTo(BigDecimal.ZERO) != 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_GENERATION_FAILED.toException();
+        }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/teamsai/saibackend/global/exception/GlobalExceptionHandler.java
@@ -22,11 +22,20 @@ public class GlobalExceptionHandler {
     ) {
         HttpStatus httpStatus = exception.getHttpStatus();
 
-        log.warn(
-                "도메인 예외 발생: status={}, message={}",
-                httpStatus.value(),
-                exception.getMessage()
-        );
+        if (httpStatus.is5xxServerError()) {
+            log.error(
+                    "도메인 예외 발생: status={}, message={}",
+                    httpStatus.value(),
+                    exception.getMessage(),
+                    exception
+            );
+        } else {
+            log.warn(
+                    "도메인 예외 발생: status={}, message={}",
+                    httpStatus.value(),
+                    exception.getMessage()
+            );
+        }
 
         return ResponseEntity
                 .status(httpStatus)

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -19,7 +19,7 @@
         <constructor>
             <arg column="target_type"
                  javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
-            <arg column="obligation_id"
+            <arg column="target_id"
                  javaType="java.lang.Long"/>
             <arg column="participant_id"
                  javaType="java.lang.Long"/>
@@ -53,22 +53,21 @@
 
     <select id="findMatchCandidatesByLinkedAccountId"
             resultMap="MatchingCandidateResultMap">
+
         SELECT
         'SETTLEMENT' AS target_type,
-        po.payment_obligation_id AS obligation_id,
+        po.payment_obligation_id AS target_id,
         po.participant_id AS participant_id,
         u.name AS participant_name,
-        po.expected_amount - COALESCE(SUM(pr.amount), 0) AS remaining_amount
+        po.expected_amount - COALESCE(SUM(pr.amount), 0)
+        AS remaining_amount
         FROM payment_obligation po
         JOIN settlement_participant sp
         ON sp.participant_id = po.participant_id
-
         JOIN settlement s
         ON s.settlement_id = sp.settlement_id
-
         JOIN settlement_account sa
         ON sa.settlement_id = s.settlement_id
-
         JOIN users u
         ON u.user_id = sp.user_id
         LEFT JOIN payment_record pr
@@ -91,7 +90,55 @@
         po.participant_id,
         u.name,
         po.expected_amount
-        HAVING po.expected_amount - COALESCE(SUM(pr.amount), 0) &gt; 0
+        HAVING
+        po.expected_amount - COALESCE(SUM(pr.amount), 0) &gt; 0
+
+        UNION ALL
+
+        SELECT
+        'LOAN' AS target_type,
+        rs.schedule_id AS target_id,
+        lc.debtor_id AS participant_id,
+        debtor.name AS participant_name,
+        rs.total_payment_due - COALESCE(SUM(pr.amount), 0)
+        AS remaining_amount
+        FROM repayment_schedule rs
+        JOIN loan_contract lc
+        ON lc.contract_id = rs.contract_id
+        JOIN contract_account ca
+        ON ca.contract_id = lc.contract_id
+        JOIN users debtor
+        ON debtor.user_id = lc.debtor_id
+        LEFT JOIN payment_record pr
+        ON pr.payment_target_type = 'LOAN'
+        AND pr.target_id = rs.schedule_id
+        AND pr.record_status = 'CONFIRMED'
+        WHERE ca.linked_account_id = #{linkedAccountId}
+        AND ca.selected_at &lt;= #{transactionAt}
+        AND (
+        ca.ended_at IS NULL
+        OR ca.ended_at &gt; #{transactionAt}
+        )
+        AND ca.account_status = 'ACTIVE'
+        AND lc.status = 'COMPLETED'
+        AND lc.created_at &lt;= #{transactionAt}
+        AND rs.created_at &lt;= #{transactionAt}
+        AND rs.status = 'PENDING'
+        AND NOT EXISTS (
+        SELECT 1
+        FROM repayment_schedule earlier
+        WHERE earlier.contract_id = rs.contract_id
+        AND earlier.status = 'PENDING'
+        AND earlier.sequence &lt; rs.sequence
+        )
+        GROUP BY
+        rs.schedule_id,
+        lc.debtor_id,
+        debtor.name,
+        rs.total_payment_due
+        HAVING
+        rs.total_payment_due - COALESCE(SUM(pr.amount), 0) &gt; 0
+
     </select>
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="paymentObligationId">

--- a/src/main/resources/static/js/contract/contract-form.js
+++ b/src/main/resources/static/js/contract/contract-form.js
@@ -99,8 +99,9 @@
       return false;
     }
 
-    if (!interestRate.value || Number(interestRate.value) <= 0 || Number(interestRate.value) > 20) {
-      showStatus("연이자율은 0보다 크고 20% 이하여야 합니다.", true);
+    const rate = Number(interestRate.value);
+    if (!interestRate.value || !Number.isFinite(rate) || rate < 0.5 || rate > 20 || !Number.isInteger(rate * 2)) {
+      showStatus("연이자율은 0.5% 이상 20% 이하이며, 0.5% 단위여야 합니다.", true);
       interestRate.focus();
       return false;
     }

--- a/src/main/resources/static/js/contractchange/contractchange.js
+++ b/src/main/resources/static/js/contractchange/contractchange.js
@@ -91,12 +91,8 @@ function validate() {
 
     if (newInterestRate !== '') {
         const rate = Number(newInterestRate);
-        if (rate > 20) {
-            alert('이율은 20%를 넘을 수 없습니다.');
-            return false;
-        }
-        if (rate <= 0) {
-            alert('이율은 0%보다 커야 합니다.');
+        if (!Number.isFinite(rate) || rate < 0.5 || rate > 20 || !Number.isInteger(rate * 2)) {
+            alert('이율은 0.5% 이상 20% 이하이며, 0.5% 단위여야 합니다.');
             return false;
         }
     }

--- a/src/main/resources/static/js/contractdashboard/contract-dashboard.js
+++ b/src/main/resources/static/js/contractdashboard/contract-dashboard.js
@@ -132,6 +132,67 @@ document.getElementById('sortSelect').addEventListener('change', (e) => {
     fetchDashboard();
 });
 
+const syncButton = document.getElementById('btnSyncTransactions');
+
+syncButton.addEventListener('click', syncTransactions);
+
+async function syncTransactions() {
+    const originalText = syncButton.textContent;
+
+    try {
+        syncButton.disabled = true;
+        syncButton.textContent = '동기화 중...';
+
+        const response = await fetch('/api/transactions/sync', {
+            method: 'POST',
+            headers: authHeaders()
+        });
+
+        const result = await readJsonSafely(response);
+
+        if (!response.ok) {
+            throw new Error(
+                result?.message || '거래내역 동기화에 실패했습니다.'
+            );
+        }
+
+        alert(
+            `거래내역 동기화가 완료되었습니다.\n` +
+            `자동 반영: ${result.appliedCount}건\n` +
+            `확인 필요: ${result.needsCheckCount}건\n` +
+            `미매칭: ${result.unmatchedCount}건\n` +
+            `중복: ${result.duplicateCount}건\n` +
+            `실패: ${result.failedCount}건`
+        );
+
+        // 상환 금액과 납부 상태를 다시 조회한다.
+        fetchDashboard();
+    } catch (error) {
+        console.error('거래내역 동기화 실패:', error);
+
+        alert(
+            error.message || '거래내역 동기화에 실패했습니다.'
+        );
+    } finally {
+        syncButton.disabled = false;
+        syncButton.textContent = originalText;
+    }
+}
+
+async function readJsonSafely(response) {
+    const text = await response.text();
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
+
 document.getElementById('btnCreateContract').addEventListener('click', () => {
     window.location.href = '/contracts/new';
 })

--- a/src/main/resources/static/js/contractdashboard/contract-dashboard.js
+++ b/src/main/resources/static/js/contractdashboard/contract-dashboard.js
@@ -156,6 +156,10 @@ async function syncTransactions() {
             );
         }
 
+        if (!result) {
+            throw new Error('거래내역 동기화 결과를 확인할 수 없습니다.');
+        }
+
         alert(
             `거래내역 동기화가 완료되었습니다.\n` +
             `자동 반영: ${result.appliedCount}건\n` +

--- a/src/main/resources/templates/contract/contract-form.html
+++ b/src/main/resources/templates/contract/contract-form.html
@@ -116,7 +116,7 @@
             <span class="doc__clause">제3조(이자)</span>
             <span class="doc__text">
         이자는 연
-        <input type="number" step="0.01" min="0" max="20" class="doc__inline-input doc__inline-input--rate" id="interestRate" name="interestRate" placeholder="0.00" />
+        <input type="number" step="0.5" min="0.5" max="20" class="doc__inline-input doc__inline-input--rate" id="interestRate" name="interestRate" placeholder="0.5" />
         %의 비율로 하며, 20%를 초과할 수 없다.
       </span>
         </section>

--- a/src/main/resources/templates/contractchange/request.html
+++ b/src/main/resources/templates/contractchange/request.html
@@ -41,7 +41,7 @@
             <input type="date" id="newMaturityDate">
 
             <label for="newInterestRate">변경 이율</label>
-            <input type="number" step="0.01" id="newInterestRate">
+            <input type="number" step="0.5" min="0.5" max="20" id="newInterestRate">
 
             <label for="newRepaymentType">상환 방식</label>
             <select id="newRepaymentType">

--- a/src/main/resources/templates/contractdashboard/dashboard.html
+++ b/src/main/resources/templates/contractdashboard/dashboard.html
@@ -40,7 +40,7 @@
             </div>
         </div>
         <div class="header-actions">
-            <button type="button" class="btn" disabled>거래내역 동기화</button>
+            <button type="button" class="btn" id="btnSyncTransactions" >거래내역 동기화</button>
             <button type="button" class="btn btn--primary" id="btnCreateContract">+ 계약 생성</button>
         </div>
     </div>

--- a/src/test/java/org/teamsai/saibackend/domain/contractrepaymentschedule/ScheduleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractrepaymentschedule/ScheduleGeneratorTest.java
@@ -36,10 +36,10 @@ class ScheduleGeneratorTest {
                 ScheduleGenerator.generateEqualPrincipalAndInterest(contractId, principal, annualInterestRate, months, startDate);
 
         RepaymentScheduleDTO first = schedules.get(0);
-        assertThat(first.getInterestDue()).isEqualByComparingTo("100000.00");
-        assertThat(first.getPrincipalDue()).isEqualByComparingTo("788487.89");
-        assertThat(first.getTotalPaymentDue()).isEqualByComparingTo("888487.89");
-        assertThat(first.getRemainingPrincipal()).isEqualByComparingTo("9211512.11");
+        assertThat(first.getInterestDue()).isEqualByComparingTo("100000");
+        assertThat(first.getPrincipalDue()).isEqualByComparingTo("788487");
+        assertThat(first.getTotalPaymentDue()).isEqualByComparingTo("888487");
+        assertThat(first.getRemainingPrincipal()).isEqualByComparingTo("9211513");
     }
 
     @Test
@@ -74,10 +74,10 @@ class ScheduleGeneratorTest {
         RepaymentScheduleDTO first = schedules.get(0);
         RepaymentScheduleDTO second = schedules.get(1);
 
-        assertThat(first.getPrincipalDue()).isEqualByComparingTo("833333.33");
-        assertThat(first.getInterestDue()).isEqualByComparingTo("100000.00");
-        assertThat(second.getPrincipalDue()).isEqualByComparingTo("833333.33");
-        assertThat(second.getInterestDue()).isEqualByComparingTo("91666.67");
+        assertThat(first.getPrincipalDue()).isEqualByComparingTo("833333");
+        assertThat(first.getInterestDue()).isEqualByComparingTo("100000");
+        assertThat(second.getPrincipalDue()).isEqualByComparingTo("833333");
+        assertThat(second.getInterestDue()).isEqualByComparingTo("91666");
 
         // 원금은 고정, 이자만 줄어서 → 2회차 총액이 1회차보다 작아야 함
         assertThat(second.getTotalPaymentDue()).isLessThan(first.getTotalPaymentDue());
@@ -120,6 +120,91 @@ class ScheduleGeneratorTest {
     }
 
     @Test
+    @DisplayName("무이자 100만원을 3회 상환하면 마지막 회차가 원금 나머지를 부담한다")
+    void zeroInterest_lastRoundAbsorbsPrincipalRemainder() {
+        List<RepaymentScheduleDTO> schedules =
+                ScheduleGenerator.generateEqualPrincipalAndInterest(
+                        contractId,
+                        new BigDecimal("1000000"),
+                        BigDecimal.ZERO,
+                        3,
+                        startDate
+                );
+
+        assertThat(schedules)
+                .extracting(RepaymentScheduleDTO::getPrincipalDue)
+                .containsExactly(
+                        new BigDecimal("333333"),
+                        new BigDecimal("333333"),
+                        new BigDecimal("333334")
+                );
+        assertThat(schedules)
+                .extracting(RepaymentScheduleDTO::getTotalPaymentDue)
+                .containsExactly(
+                        new BigDecimal("333333"),
+                        new BigDecimal("333333"),
+                        new BigDecimal("333334")
+                );
+    }
+
+    @Test
+    @DisplayName("만기일시 0.5% 이자의 정수 나머지는 마지막 회차에 추가한다")
+    void bulletRepayment_lastRoundAbsorbsInterestRemainder() {
+        List<RepaymentScheduleDTO> schedules =
+                ScheduleGenerator.generateBulletRepayment(
+                        contractId,
+                        new BigDecimal("100000"),
+                        new BigDecimal("0.5"),
+                        12,
+                        startDate
+                );
+
+        assertThat(schedules.subList(0, 11))
+                .extracting(RepaymentScheduleDTO::getInterestDue)
+                .containsOnly(new BigDecimal("41"));
+        assertThat(schedules.get(11).getInterestDue()).isEqualByComparingTo("49");
+        assertThat(schedules.stream()
+                .map(RepaymentScheduleDTO::getInterestDue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add))
+                .isEqualByComparingTo("500");
+    }
+
+    @Test
+    @DisplayName("모든 상환방식의 저장 금액은 원 단위이고 원금 합계가 유지된다")
+    void allMethods_generateWholeWonAmountsAndPreservePrincipal() {
+        BigDecimal testPrincipal = new BigDecimal("1000000");
+        BigDecimal testRate = new BigDecimal("0.5");
+
+        List<List<RepaymentScheduleDTO>> schedulesByMethod = List.of(
+                ScheduleGenerator.generateEqualPrincipalAndInterest(
+                        contractId, testPrincipal, testRate, 12, startDate),
+                ScheduleGenerator.generateEqualPrincipal(
+                        contractId, testPrincipal, testRate, 12, startDate),
+                ScheduleGenerator.generateBulletRepayment(
+                        contractId, testPrincipal, testRate, 12, startDate)
+        );
+
+        for (List<RepaymentScheduleDTO> schedules : schedulesByMethod) {
+            assertThat(schedules.stream()
+                    .map(RepaymentScheduleDTO::getPrincipalDue)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add))
+                    .isEqualByComparingTo(testPrincipal);
+
+            assertThat(schedules).allSatisfy(schedule -> {
+                assertWholeWon(schedule.getPrincipalDue());
+                assertWholeWon(schedule.getInterestDue());
+                assertWholeWon(schedule.getTotalPaymentDue());
+                assertWholeWon(schedule.getRemainingPrincipal());
+                assertThat(schedule.getTotalPaymentDue())
+                        .isEqualByComparingTo(schedule.getPrincipalDue().add(schedule.getInterestDue()));
+            });
+
+            assertThat(schedules.get(schedules.size() - 1).getRemainingPrincipal())
+                    .isEqualByComparingTo(BigDecimal.ZERO);
+        }
+    }
+
+    @Test
     @DisplayName("세 방식 모두 회차별 contractId와 sequence가 정확하다")
     void allMethods_haveCorrectContractIdAndSequence() {
         List<RepaymentScheduleDTO> schedules =
@@ -130,5 +215,10 @@ class ScheduleGeneratorTest {
             assertThat(schedules.get(i).getSequence()).isEqualTo(i + 1);
             assertThat(schedules.get(i).getStatus()).isEqualTo(RepaymentScheduleStatus.PENDING);
         }
+    }
+
+    private void assertWholeWon(BigDecimal amount) {
+        assertThat(amount.remainder(BigDecimal.ONE))
+                .isEqualByComparingTo(BigDecimal.ZERO);
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
@@ -26,6 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Sql(scripts = {
         "/db/user.sql",
         "/db/linked_bank_account.sql",
+        "/db/01_loancontract.sql",
+        "/db/02_repayment_schedule.sql",
+        "/db/04_contractaccount.sql",
         "/db/settlement.sql",
         "/db/settlement_participant.sql",
         "/db/settlement_account.sql",
@@ -113,6 +116,45 @@ class PaymentObligationMapperTest {
                 );
     }
 
+    @Test
+    @Transactional
+    @DisplayName("연결 계좌를 사용하는 완료된 차용증의 가장 빠른 미납 회차를 조회한다")
+    void findMatchCandidatesByLinkedAccountIdReturnsEarliestLoanSchedule() {
+        insertUser(9101L, "Creditor");
+        insertUser(9102L, "Hong Gil Dong");
+        insertLinkedAccount(LINKED_ACCOUNT_ID, 9101L);
+        insertLoanContract(9201L, 9101L, 9102L);
+        insertActiveContractAccount(9301L, 9201L, LINKED_ACCOUNT_ID);
+        insertRepaymentSchedule(9401L, 9201L, 1, "20000.00");
+        insertRepaymentSchedule(9402L, 9201L, 2, "20000.00");
+        insertConfirmedLoanPaymentRecord(9501L, 9401L, "5000.00");
+
+        List<MatchingCandidate> result =
+                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                        LINKED_ACCOUNT_ID,
+                        MATCHING_TRANSACTION_AT
+                );
+
+        assertThat(result)
+                .extracting(
+                        MatchingCandidate::targetType,
+                        MatchingCandidate::targetId,
+                        MatchingCandidate::participantId,
+                        MatchingCandidate::participantName,
+                        candidate -> candidate.remainingAmount()
+                                .stripTrailingZeros()
+                )
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                MatchingTargetType.LOAN,
+                                9401L,
+                                9102L,
+                                "Hong Gil Dong",
+                                new BigDecimal("15000").stripTrailingZeros()
+                        )
+                );
+    }
+
     private void insertUser(Long userId, String name) {
         String unique = UUID.randomUUID().toString();
         jdbcTemplate.update(
@@ -153,6 +195,123 @@ class PaymentObligationMapperTest {
                 userId,
                 "account-" + linkedAccountId,
                 linkedAccountId
+        );
+    }
+
+    private void insertLoanContract(
+            Long contractId,
+            Long creditorId,
+            Long debtorId
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO loan_contract (
+                    contract_id,
+                    creditor_id,
+                    debtor_id,
+                    principal_amount,
+                    interest_rate,
+                    repayment_type,
+                    start_date,
+                    maturity_date,
+                    repayment_day,
+                    status,
+                    creditor_address,
+                    debtor_address,
+                    contract_alias,
+                    created_at,
+                    updated_at
+                )
+                VALUES (
+                    ?, ?, ?, 40000, 0, 'EQUAL_PRINCIPAL',
+                    '2026-01-01', '2026-12-31', 1, 'COMPLETED',
+                    'creditor-address', 'debtor-address', ?, NOW(), NOW()
+                )
+                """,
+                contractId,
+                creditorId,
+                debtorId,
+                "contract-" + contractId
+        );
+    }
+
+    private void insertActiveContractAccount(
+            Long contractAccountId,
+            Long contractId,
+            Long linkedAccountId
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO contract_account (
+                    contract_account_id,
+                    linked_account_id,
+                    account_status,
+                    selected_at,
+                    contract_id
+                )
+                VALUES (?, ?, 'ACTIVE', NOW(), ?)
+                """,
+                contractAccountId,
+                linkedAccountId,
+                contractId
+        );
+    }
+
+    private void insertRepaymentSchedule(
+            Long scheduleId,
+            Long contractId,
+            int sequence,
+            String totalPaymentDue
+    ) {
+        BigDecimal amount = new BigDecimal(totalPaymentDue);
+        jdbcTemplate.update(
+                """
+                INSERT INTO repayment_schedule (
+                    schedule_id,
+                    contract_id,
+                    sequence,
+                    due_date,
+                    principal_due,
+                    interest_due,
+                    total_payment_due,
+                    remaining_principal,
+                    status,
+                    created_at
+                )
+                VALUES (?, ?, ?, '2026-06-01', ?, 0, ?, ?, 'PENDING', NOW())
+                """,
+                scheduleId,
+                contractId,
+                sequence,
+                amount,
+                amount,
+                amount
+        );
+    }
+
+    private void insertConfirmedLoanPaymentRecord(
+            Long paymentRecordId,
+            Long scheduleId,
+            String amount
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO payment_record (
+                    payment_record_id,
+                    bank_transaction_id,
+                    payment_target_type,
+                    target_id,
+                    amount,
+                    source_type,
+                    record_status,
+                    recorded_at
+                )
+                VALUES (?, ?, 'LOAN', ?, ?, 'AUTO_MATCH', 'CONFIRMED', NOW())
+                """,
+                paymentRecordId,
+                paymentRecordId,
+                scheduleId,
+                new BigDecimal(amount)
         );
     }
 


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #135 

## 🛠 작업 사항

  - 차용증 생성 및 변경 시 이율을 0.5% 단위로 입력하도록 제한
  - 이율은 DB에 percent 값으로 저장하고, 이자 계산 시 비율로 변환하도록 유지
  - 상환스케줄의 원금, 이자 및 총상환금액을 은행 이체가 가능한 원 단위로 생성
  - 회차별 금액 계산에서 발생하는 차액을 마지막 회차에 반영하여 전체 상환 합계유지
  - 거래 동기화 시 미납 상환 회차를 조회하고, 은행 거래 금액과 잔여상환금액이 일치하면 자동매칭되도록 연동

  - 스케줄 생성 과정에서 발생하는 서버 내부 오류가 스택 트레이스와 함께 기록되도록 로깅 개선

## ✅ 테스트

  - [x] 로컬 서버에서 차용증 및 상환스케줄 생성 결과 확인
  - [x] 실제 거래 동기화 후 입금내역 자동매칭 및 상환 처리 확인
  - [x] 상환스케줄 생성 및 자동매칭 대상 조회 테스트 실행 완료
  - [ ] 전체 테스트 실행 결과 3건 실패 load/auth/loan

## 📌 주의 사항 및 참고사항

  - 기존 로컬 DB에는 소수점 단위로 생성된 상환스케줄이 남아 있을 수 있어 DB 초기화 후 확인 필요
  - repayment_schedule의 금액 관련 DB 컬럼 타입은 기존 DECIMAL 설정을 유지
  - 자동매칭은 은행 거래 금액과 확정된 원 단위 잔여상환금액을 정확히 비교
  - 상환일 생성 기준에 관한 개선은 이번 작업 범위에서 제외했으며 후속 작업으로진행 예정

