### PR TITLE
feat(#140): 거래 자동매칭 판정 확장 및 확인 필요 후보 처리 기능 추가

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/matching/controller/BankTransactionMatchingReviewController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/controller/BankTransactionMatchingReviewController.java
@@ -1,0 +1,97 @@
+package org.teamsai.saibackend.domain.matching.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewApplyRequest;
+import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewService;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
+
+@Tag(
+        name = "은행 거래 매칭 검토 API",
+        description = "확인이 필요한 은행 거래의 납부 대상을 선택하거나 미매칭으로 처리하는 API"
+)
+@RestController
+@RequiredArgsConstructor
+public class BankTransactionMatchingReviewController {
+
+    private final BankTransactionMatchingReviewService matchingReviewService;
+
+    @Operation(
+            summary = "은행 거래 매칭 후보 선택 반영",
+            description = "확인이 필요한 은행 거래의 후보 하나를 선택하여 "
+                    + "정산 납부 또는 차용증 상환으로 반영합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "매칭 검토 처리 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 후보 선택 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "연결 계좌에 대한 접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "은행 거래 또는 매칭 후보를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "확인 필요 상태가 아니거나 이미 처리된 거래")
+    })
+    @PostMapping(
+            "/api/linked-accounts/{linkedAccountId}"
+                    + "/transactions/{bankTransactionId}"
+                    + "/matching-review/apply"
+    )
+    public ResponseEntity<MatchingReviewProcessResponse> applyCandidate(
+            @PathVariable Long linkedAccountId,
+            @PathVariable Long bankTransactionId,
+            @Valid @RequestBody MatchingReviewApplyRequest request,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                matchingReviewService.applyCandidate(
+                        userDetails.getUserId(),
+                        linkedAccountId,
+                        bankTransactionId,
+                        request.matchCandidateId()
+                )
+        );
+    }
+
+    @Operation(
+            summary = "은행 거래 미매칭 처리",
+            description = "확인이 필요한 은행 거래에서 어느 후보도 선택하지 않고 "
+                    + "미매칭 거래로 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "미매칭 처리 완료"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "연결 계좌에 대한 접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "은행 거래를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "확인 필요 상태가 아니거나 이미 처리된 거래")
+    })
+    @PostMapping(
+            "/api/linked-accounts/{linkedAccountId}"
+                    + "/transactions/{bankTransactionId}"
+                    + "/matching-review/reject"
+    )
+    public ResponseEntity<MatchingReviewProcessResponse> rejectCandidates(
+            @PathVariable Long linkedAccountId,
+            @PathVariable Long bankTransactionId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                matchingReviewService.rejectCandidates(
+                        userDetails.getUserId(),
+                        linkedAccountId,
+                        bankTransactionId
+                )
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateDTO.java
@@ -1,0 +1,33 @@
+package org.teamsai.saibackend.domain.matching.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BankTransactionMatchCandidateDTO {
+
+    private Long matchCandidateId;
+
+    private Long bankTransactionId;
+
+    private MatchingTargetType targetType;
+
+    private Long targetId;
+
+    private BigDecimal expectedRemainingAmount;
+
+    private MatchingAmountType amountMatchType;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 
 import java.math.BigDecimal;
@@ -29,5 +31,12 @@ public class BankTransactionMatchCandidateDTO {
 
     private MatchingAmountType amountMatchType;
 
+    private MatchingCandidateStatus candidateStatus;
+
+    private LocalDateTime invalidatedAt;
+
+    private MatchingCandidateInvalidationReason invalidationReason;
+
     private LocalDateTime createdAt;
+
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
@@ -1,0 +1,27 @@
+package org.teamsai.saibackend.domain.matching.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BankTransactionMatchCandidateQueryDTO {
+
+    private Long matchCandidateId;
+    private Long bankTransactionId;
+    private MatchingTargetType targetType;
+    private Long targetId;
+    private String participantName;
+    private BigDecimal expectedRemainingAmount;
+    private MatchingAmountType amountMatchType;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewApplyRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewApplyRequest.java
@@ -1,0 +1,11 @@
+package org.teamsai.saibackend.domain.matching.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record MatchingReviewApplyRequest(
+        @NotNull
+        @Positive
+        Long matchCandidateId
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
@@ -1,0 +1,30 @@
+package org.teamsai.saibackend.domain.matching.dto.response;
+
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+
+import java.math.BigDecimal;
+
+public record BankTransactionMatchCandidateResponse(
+        Long matchCandidateId,
+        MatchingTargetType targetType,
+        Long targetId,
+        String participantName,
+        BigDecimal expectedRemainingAmount,
+        MatchingAmountType amountMatchType
+) {
+
+    public static BankTransactionMatchCandidateResponse from(
+            BankTransactionMatchCandidateQueryDTO candidate
+    ) {
+        return new BankTransactionMatchCandidateResponse(
+                candidate.getMatchCandidateId(),
+                candidate.getTargetType(),
+                candidate.getTargetId(),
+                candidate.getParticipantName(),
+                candidate.getExpectedRemainingAmount(),
+                candidate.getAmountMatchType()
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchingReviewResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchingReviewResponse.java
@@ -1,0 +1,13 @@
+package org.teamsai.saibackend.domain.matching.dto.response;
+
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+
+import java.util.List;
+
+public record BankTransactionMatchingReviewResponse(
+        BankTransactionDetailResponse transaction,
+        MatchingReviewChannel reviewChannel,
+        List<BankTransactionMatchCandidateResponse> candidates
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/MatchingReviewProcessResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/MatchingReviewProcessResponse.java
@@ -1,0 +1,9 @@
+package org.teamsai.saibackend.domain.matching.dto.response;
+
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+
+public record MatchingReviewProcessResponse(
+        Long bankTransactionId,
+        BankTransactionProcessingStatus processingStatus
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/MatchingReviewProcessResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/MatchingReviewProcessResponse.java
@@ -1,9 +1,11 @@
 package org.teamsai.saibackend.domain.matching.dto.response;
 
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewResult;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
 
 public record MatchingReviewProcessResponse(
         Long bankTransactionId,
-        BankTransactionProcessingStatus processingStatus
+        BankTransactionProcessingStatus processingStatus,
+        MatchingReviewResult reviewResult
 ) {
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/exception/MatchingErrorCode.java
@@ -26,6 +26,16 @@ public enum MatchingErrorCode
             "매칭 후보를 찾을 수 없습니다."
     ),
 
+    MATCHING_CANDIDATE_SAVE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "매칭 후보 저장에 실패했습니다."
+    ),
+
+    MATCHING_REVIEW_NOT_REQUIRED(
+            HttpStatus.CONFLICT,
+            "확인이 필요한 은행 거래가 아닙니다."
+    ),
+
     ALREADY_MATCHED(
             HttpStatus.CONFLICT,
             "이미 매칭된 항목입니다."

--- a/src/main/java/org/teamsai/saibackend/domain/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/exception/MatchingErrorCode.java
@@ -31,6 +31,11 @@ public enum MatchingErrorCode
             "매칭 후보 저장에 실패했습니다."
     ),
 
+    MATCHING_CANDIDATE_INVALIDATION_FAILED(
+            HttpStatus.CONFLICT,
+            "매칭 후보를 무효화할 수 없습니다."
+    ),
+
     MATCHING_REVIEW_NOT_REQUIRED(
             HttpStatus.CONFLICT,
             "확인이 필요한 은행 거래가 아닙니다."

--- a/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
@@ -4,7 +4,9 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +30,18 @@ public interface BankTransactionMatchCandidateMapper {
     Optional<BankTransactionMatchCandidateDTO>
     findByIdAndBankTransactionId(
             @Param("matchCandidateId") Long matchCandidateId,
+            @Param("bankTransactionId") Long bankTransactionId
+    );
+
+    int invalidate(
+            @Param("matchCandidateId") Long matchCandidateId,
+            @Param("bankTransactionId") Long bankTransactionId,
+            @Param("invalidationReason")
+            MatchingCandidateInvalidationReason invalidationReason,
+            @Param("invalidatedAt") LocalDateTime invalidatedAt
+    );
+
+    int countAvailableByBankTransactionId(
             @Param("bankTransactionId") Long bankTransactionId
     );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
@@ -1,0 +1,33 @@
+package org.teamsai.saibackend.domain.matching.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface BankTransactionMatchCandidateMapper {
+
+    int insertAll(
+            @Param("candidates")
+            List<BankTransactionMatchCandidateDTO> candidates
+    );
+
+    List<BankTransactionMatchCandidateDTO> findAllByBankTransactionId(
+            @Param("bankTransactionId") Long bankTransactionId
+    );
+
+    List<BankTransactionMatchCandidateQueryDTO>
+    findAllForReviewByBankTransactionId(
+            @Param("bankTransactionId") Long bankTransactionId
+    );
+
+    Optional<BankTransactionMatchCandidateDTO>
+    findByIdAndBankTransactionId(
+            @Param("matchCandidateId") Long matchCandidateId,
+            @Param("bankTransactionId") Long bankTransactionId
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/model/AutoMatchingResult.java
@@ -2,37 +2,42 @@ package org.teamsai.saibackend.domain.matching.model;
 
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingDecisionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 
 import java.util.List;
 
 public class AutoMatchingResult {
 
     private final AutoMatchingDecisionType decisionType;
-    private final List<MatchingCandidate> matchedCandidates;
+    private final List<EvaluatedMatchingCandidate> evaluatedCandidates;
 
-    public AutoMatchingResult(List<MatchingCandidate> matchedCandidates) {
-        if (matchedCandidates == null) {
+    public AutoMatchingResult(
+            List<EvaluatedMatchingCandidate> evaluatedCandidates
+    ) {
+        if (evaluatedCandidates == null
+                || evaluatedCandidates.stream()
+                .anyMatch(candidate -> candidate == null)) {
             throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
         }
 
-        this.matchedCandidates = List.copyOf(matchedCandidates);
-        this.decisionType = determineDecisionType(this.matchedCandidates);
+        this.evaluatedCandidates = List.copyOf(evaluatedCandidates);
+        this.decisionType = determineDecisionType(this.evaluatedCandidates);
     }
 
     public AutoMatchingDecisionType decisionType() {
         return decisionType;
     }
 
-    public List<MatchingCandidate> matchedCandidates() {
-        return matchedCandidates;
+    public List<EvaluatedMatchingCandidate> evaluatedCandidates() {
+        return evaluatedCandidates;
     }
 
-    public MatchingCandidate matchedCandidate() {
+    public EvaluatedMatchingCandidate matchedCandidate() {
         if (!isMatchable()) {
             throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
         }
 
-        return matchedCandidates.get(0);
+        return evaluatedCandidates.get(0);
     }
 
     public boolean isMatchable() {
@@ -48,15 +53,15 @@ public class AutoMatchingResult {
     }
 
     private AutoMatchingDecisionType determineDecisionType(
-            List<MatchingCandidate> matchedCandidates
+            List<EvaluatedMatchingCandidate> evaluatedCandidates
     ) {
-        int matchedCandidateCount = matchedCandidates.size();
-
-        if (matchedCandidateCount == 0) {
+        if (evaluatedCandidates.isEmpty()) {
             return AutoMatchingDecisionType.UNMATCHED;
         }
 
-        if (matchedCandidateCount == 1) {
+        if (evaluatedCandidates.size() == 1
+                && evaluatedCandidates.get(0).amountMatchType()
+                == MatchingAmountType.EXACT) {
             return AutoMatchingDecisionType.MATCHABLE;
         }
 

--- a/src/main/java/org/teamsai/saibackend/domain/matching/model/EvaluatedMatchingCandidate.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/model/EvaluatedMatchingCandidate.java
@@ -1,0 +1,16 @@
+package org.teamsai.saibackend.domain.matching.model;
+
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+
+public record EvaluatedMatchingCandidate(
+        MatchingCandidate candidate,
+        MatchingAmountType amountMatchType
+) {
+
+    public EvaluatedMatchingCandidate {
+        if (candidate == null || amountMatchType == null) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/policy/AutoMatchingJudge.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/policy/AutoMatchingJudge.java
@@ -3,14 +3,23 @@ package org.teamsai.saibackend.domain.matching.policy;
 import org.springframework.stereotype.Component;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingResult;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class AutoMatchingJudge {
+
+    private static final BigDecimal MINIMUM_MATCH_RATIO =
+            new BigDecimal("0.10");
+    private static final BigDecimal MAXIMUM_MATCH_RATIO =
+            new BigDecimal("1.10");
 
     public AutoMatchingResult judge(
             MatchingTransaction transaction,
@@ -18,39 +27,77 @@ public class AutoMatchingJudge {
     ) {
         validateInput(transaction, candidates);
 
-        if (transaction.transactionType() != AutoMatchingTransactionType.DEPOSIT) {
+        if (transaction.transactionType()
+                != AutoMatchingTransactionType.DEPOSIT) {
             return new AutoMatchingResult(List.of());
         }
 
-        List<MatchingCandidate> matchedCandidates = candidates.stream()
-                .filter(candidate -> isMatched(transaction, candidate))
-                .toList();
+        List<EvaluatedMatchingCandidate> evaluatedCandidates =
+                candidates.stream()
+                        .filter(candidate ->
+                                isParticipantNameMatched(
+                                        transaction,
+                                        candidate
+                                ))
+                        .map(candidate ->
+                                evaluateCandidate(transaction, candidate))
+                        .flatMap(Optional::stream)
+                        .toList();
 
-        return new AutoMatchingResult(matchedCandidates);
+        return new AutoMatchingResult(evaluatedCandidates);
     }
 
-    private boolean isMatched(
+    private Optional<EvaluatedMatchingCandidate> evaluateCandidate(
             MatchingTransaction transaction,
             MatchingCandidate candidate
     ) {
-        return isAmountMatched(transaction, candidate)
-                && isParticipantNameMatched(transaction, candidate);
+        BigDecimal transactionAmount = transaction.amount();
+        BigDecimal expectedAmount = candidate.remainingAmount();
+        BigDecimal minimumAmount = expectedAmount
+                .multiply(MINIMUM_MATCH_RATIO);
+        BigDecimal maximumAmount = expectedAmount
+                .multiply(MAXIMUM_MATCH_RATIO);
+
+        if (transactionAmount.compareTo(minimumAmount) < 0
+                || transactionAmount.compareTo(maximumAmount) > 0) {
+            return Optional.empty();
+        }
+
+        MatchingAmountType amountMatchType =
+                determineAmountMatchType(
+                        transactionAmount,
+                        expectedAmount
+                );
+
+        return Optional.of(
+                new EvaluatedMatchingCandidate(
+                        candidate,
+                        amountMatchType
+                )
+        );
     }
 
-    private boolean isAmountMatched(
-            MatchingTransaction transaction,
-            MatchingCandidate candidate
+    private MatchingAmountType determineAmountMatchType(
+            BigDecimal transactionAmount,
+            BigDecimal expectedAmount
     ) {
-        // MVP 자동매칭은 입금액과 남은 납부금액이 정확히 같은 경우만 허용한다.
-        return transaction.amount()
-                .compareTo(candidate.remainingAmount()) == 0;
+        int comparison = transactionAmount.compareTo(expectedAmount);
+
+        if (comparison < 0) {
+            return MatchingAmountType.PARTIAL;
+        }
+
+        if (comparison > 0) {
+            return MatchingAmountType.EXCESS;
+        }
+
+        return MatchingAmountType.EXACT;
     }
 
     private boolean isParticipantNameMatched(
             MatchingTransaction transaction,
             MatchingCandidate candidate
     ) {
-        // MVP 이후 실제 은행 연동 시 계좌 ID나 연결 키 기반 식별로 리팩터링한다.
         return normalizeName(transaction.counterpartyName())
                 .equals(normalizeName(candidate.participantName()));
     }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/policy/MatchingReviewValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/policy/MatchingReviewValidator.java
@@ -1,0 +1,22 @@
+package org.teamsai.saibackend.domain.matching.policy;
+
+import org.springframework.stereotype.Component;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+@Component
+public class MatchingReviewValidator {
+
+    public void validate(BankTransactionDetailResponse transaction) {
+        if (transaction.processingStatus()
+                != BankTransactionProcessingStatus.NEEDS_CHECK
+                || transaction.transactionType()
+                != BankTransactionType.DEPOSIT) {
+            throw MatchingErrorCode
+                    .MATCHING_REVIEW_NOT_REQUIRED
+                    .toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/AutoMatchingService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/AutoMatchingService.java
@@ -7,12 +7,14 @@ import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.policy.AutoMatchingJudge;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
 import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -29,6 +31,7 @@ public class AutoMatchingService {
     private final AutoMatchingJudge autoMatchingJudge;
     private final SettlementPaymentService settlementPaymentService;
     private final LoanPaymentService loanPaymentService;
+    private final BankTransactionMatchCandidateService candidateService;
 
     public AutoMatchingExecutionResult execute(
             List<MatchingTransaction> transactions,
@@ -170,10 +173,41 @@ public class AutoMatchingService {
         }
 
         if (result.needsCheck()) {
+            candidateService.saveAll(
+                    transaction.transactionId(),
+                    result.evaluatedCandidates()
+            );
+
             return AutoMatchingProcessResult.needsCheck();
         }
 
-        MatchingCandidate candidate = result.matchedCandidate();
+        EvaluatedMatchingCandidate evaluatedCandidate =
+                result.matchedCandidate();
+
+        try {
+            return applyPayment(transaction, evaluatedCandidate);
+        } catch (DomainException exception) {
+            AutoMatchingProcessResult processResult =
+                    classifyPaymentException(transaction, exception);
+
+            if (processResult.status()
+                    == AutoMatchingProcessStatus.NEEDS_CHECK) {
+                candidateService.saveAll(
+                        transaction.transactionId(),
+                        List.of(evaluatedCandidate)
+                );
+            }
+
+            return processResult;
+        }
+    }
+
+    private AutoMatchingProcessResult applyPayment(
+            MatchingTransaction transaction,
+            EvaluatedMatchingCandidate evaluatedCandidate
+    ) {
+
+        MatchingCandidate candidate = evaluatedCandidate.candidate();
 
         // 1. SETTLEMENT(정산) 타입 처리
         if (candidate.targetType() == MatchingTargetType.SETTLEMENT) {
@@ -182,7 +216,9 @@ public class AutoMatchingService {
                     transaction.transactionId(),
                     transaction.amount()
             );
-            return AutoMatchingProcessResult.applied(AppliedCandidateKey.from(candidate));
+            return AutoMatchingProcessResult.applied(
+                    AppliedCandidateKey.from(candidate)
+            );
         }
 
         // 2. LOAN(차용증) 타입 처리
@@ -192,7 +228,9 @@ public class AutoMatchingService {
                     transaction.transactionId(),
                     transaction.amount()
             );
-            return AutoMatchingProcessResult.applied(AppliedCandidateKey.from(candidate));
+            return AutoMatchingProcessResult.applied(
+                    AppliedCandidateKey.from(candidate)
+            );
         }
 
         return AutoMatchingProcessResult.needsCheck();

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
@@ -5,15 +5,9 @@ import org.springframework.stereotype.Service;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
-import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
-import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
-import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
-import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
-import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
-import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
 
 import java.util.List;
 
@@ -22,10 +16,12 @@ import java.util.List;
 public class BankMatchingService {
 
     private final BankTransactionService bankTransactionService;
-    private final PaymentObligationMapper paymentObligationMapper;
-    private final AutoMatchingService autoMatchingService;
+    private final BankMatchingTransactionService transactionService;
 
-    public AutoMatchingExecutionResult execute(Long linkedAccountId) {
+    public AutoMatchingExecutionResult execute(
+            Long userId,
+            Long linkedAccountId
+    ) {
         validateLinkedAccountId(linkedAccountId);
 
         List<BankTransactionDTO> bankTransactions =
@@ -37,27 +33,13 @@ public class BankMatchingService {
             return emptyResult();
         }
 
-        if (bankTransactions.stream()
-                .noneMatch(this::hasMatchableCounterpartyName)) {
-            AutoMatchingExecutionResult executionResult =
-                    toExecutionResult(
-                            toNeedsCheckResults(bankTransactions)
-                    );
-            updateBankTransactionStatuses(executionResult);
-
-            return executionResult;
-        }
-
-        AutoMatchingExecutionResult executionResult =
-                toExecutionResult(
-                        processTransactions(
-                                linkedAccountId,
-                                bankTransactions
-                        )
-                );
-        updateBankTransactionStatuses(executionResult);
-
-        return executionResult;
+        return toExecutionResult(
+                processTransactions(
+                        userId,
+                        linkedAccountId,
+                        bankTransactions
+                )
+        );
     }
 
     private void validateLinkedAccountId(Long linkedAccountId) {
@@ -79,89 +61,16 @@ public class BankMatchingService {
     }
 
     private List<AutoMatchingTransactionResult> processTransactions(
+            Long userId,
             Long linkedAccountId,
             List<BankTransactionDTO> bankTransactions
     ) {
         return bankTransactions.stream()
-                .map(bankTransaction -> processTransaction(
+                .map(bankTransaction -> transactionService.process(
+                        userId,
                         linkedAccountId,
                         bankTransaction
                 ))
-                .toList();
-    }
-
-    private AutoMatchingTransactionResult processTransaction(
-            Long linkedAccountId,
-            BankTransactionDTO bankTransaction
-    ) {
-        if (!hasMatchableCounterpartyName(bankTransaction)) {
-            return new AutoMatchingTransactionResult(
-                    bankTransaction.getBankTransactionId(),
-                    AutoMatchingProcessStatus.NEEDS_CHECK
-            );
-        }
-
-        MatchingTransaction matchingTransaction =
-                toMatchingTransaction(bankTransaction);
-
-        List<MatchingCandidate> candidates =
-                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
-                        linkedAccountId,
-                        matchingTransaction.transactionAt()
-                );
-
-        AutoMatchingExecutionResult matchingResult =
-                autoMatchingService.execute(
-                        List.of(matchingTransaction),
-                        candidates
-                );
-
-        if (matchingResult.transactionResults().size() != 1) {
-            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
-        }
-
-        return matchingResult.transactionResults().get(0);
-    }
-
-    private boolean hasMatchableCounterpartyName(
-            BankTransactionDTO bankTransaction
-    ) {
-        String counterpartyName = bankTransaction.getCounterpartyName();
-
-        return counterpartyName != null && !counterpartyName.isBlank();
-    }
-
-    private MatchingTransaction toMatchingTransaction(
-            BankTransactionDTO bankTransaction
-    ) {
-        return new MatchingTransaction(
-                bankTransaction.getBankTransactionId(),
-                toMatchingTransactionType(bankTransaction.getTransactionType()),
-                bankTransaction.getAmount(),
-                bankTransaction.getCounterpartyName(),
-                bankTransaction.getTransactionAt()
-        );
-    }
-
-    private AutoMatchingTransactionType toMatchingTransactionType(
-            BankTransactionType transactionType
-    ) {
-        return switch (transactionType) {
-            case DEPOSIT -> AutoMatchingTransactionType.DEPOSIT;
-            case WITHDRAWAL -> AutoMatchingTransactionType.WITHDRAWAL;
-        };
-    }
-
-    private List<AutoMatchingTransactionResult> toNeedsCheckResults(
-            List<BankTransactionDTO> bankTransactions
-    ) {
-        return bankTransactions.stream()
-                .map(transaction ->
-                        new AutoMatchingTransactionResult(
-                                transaction.getBankTransactionId(),
-                                AutoMatchingProcessStatus.NEEDS_CHECK
-                        )
-                )
                 .toList();
     }
 
@@ -193,35 +102,5 @@ public class BankMatchingService {
                 failedCount,
                 transactionResults
         );
-    }
-
-    private void updateBankTransactionStatuses(
-            AutoMatchingExecutionResult executionResult
-    ) {
-        for (AutoMatchingTransactionResult transactionResult
-                : executionResult.transactionResults()) {
-            bankTransactionService.updateStatus(
-                    transactionResult.transactionId(),
-                    BankTransactionProcessingStatus.PENDING,
-                    toBankTransactionProcessingStatus(
-                            transactionResult.processStatus()
-                    )
-            );
-        }
-    }
-
-    private BankTransactionProcessingStatus toBankTransactionProcessingStatus(
-            AutoMatchingProcessStatus processStatus
-    ) {
-        return switch (processStatus) {
-            case APPLIED, DUPLICATE ->
-                    BankTransactionProcessingStatus.APPLIED;
-            case NEEDS_CHECK ->
-                    BankTransactionProcessingStatus.NEEDS_CHECK;
-            case UNMATCHED ->
-                    BankTransactionProcessingStatus.UNMATCHED;
-            case FAILED ->
-                    BankTransactionProcessingStatus.FAILED;
-        };
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
@@ -1,0 +1,188 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.notification.service.NotificationService;
+import org.teamsai.saibackend.domain.notification.type.NotificationType;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BankMatchingTransactionService {
+
+    private final PaymentObligationMapper paymentObligationMapper;
+    private final AutoMatchingService autoMatchingService;
+    private final BankTransactionService bankTransactionService;
+    private final BankTransactionMatchCandidateService candidateService;
+    private final NotificationService notificationService;
+
+    @Transactional
+    public AutoMatchingTransactionResult process(
+            Long userId,
+            Long linkedAccountId,
+            BankTransactionDTO bankTransaction
+    ) {
+        AutoMatchingTransactionResult result =
+                processMatching(linkedAccountId, bankTransaction);
+
+        createMatchingReviewNotificationIfRequired(
+                userId,
+                linkedAccountId,
+                bankTransaction,
+                result
+        );
+
+        bankTransactionService.updateStatus(
+                bankTransaction.getBankTransactionId(),
+                BankTransactionProcessingStatus.PENDING,
+                toBankTransactionProcessingStatus(result.processStatus())
+        );
+
+        return result;
+    }
+
+    private void createMatchingReviewNotificationIfRequired(
+            Long userId,
+            Long linkedAccountId,
+            BankTransactionDTO bankTransaction,
+            AutoMatchingTransactionResult result
+    ) {
+        if (result.processStatus()
+                != AutoMatchingProcessStatus.NEEDS_CHECK) {
+            return;
+        }
+
+        List<BankTransactionMatchCandidateDTO> candidates =
+                candidateService.findAllByBankTransactionId(
+                        bankTransaction.getBankTransactionId()
+                );
+
+        boolean hasSettlement = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.SETTLEMENT);
+        boolean hasLoan = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.LOAN);
+
+        if (!hasSettlement || !hasLoan) {
+            return;
+        }
+
+        notificationService.createIfAbsent(
+                userId,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                "입금 거래 확인이 필요합니다.",
+                createNotificationContent(bankTransaction),
+                bankTransaction.getBankTransactionId(),
+                linkedAccountId
+        );
+    }
+
+    private String createNotificationContent(
+            BankTransactionDTO bankTransaction
+    ) {
+        String counterpartyName = bankTransaction.getCounterpartyName();
+
+        if (counterpartyName == null || counterpartyName.isBlank()) {
+            counterpartyName = "입금자 미상";
+        }
+
+        return counterpartyName
+                + "님의 "
+                + bankTransaction.getAmount().toPlainString()
+                + "원 입금에 정산과 차용증 후보가 모두 발견되었습니다.";
+    }
+
+    private AutoMatchingTransactionResult processMatching(
+            Long linkedAccountId,
+            BankTransactionDTO bankTransaction
+    ) {
+        if (!hasMatchableCounterpartyName(bankTransaction)) {
+            return new AutoMatchingTransactionResult(
+                    bankTransaction.getBankTransactionId(),
+                    AutoMatchingProcessStatus.UNMATCHED
+            );
+        }
+
+        MatchingTransaction matchingTransaction =
+                toMatchingTransaction(bankTransaction);
+
+        List<MatchingCandidate> candidates =
+                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                        linkedAccountId,
+                        matchingTransaction.transactionAt()
+                );
+
+        AutoMatchingExecutionResult matchingResult =
+                autoMatchingService.execute(
+                        List.of(matchingTransaction),
+                        candidates
+                );
+
+        if (matchingResult.transactionResults().size() != 1) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        return matchingResult.transactionResults().get(0);
+    }
+
+    private boolean hasMatchableCounterpartyName(
+            BankTransactionDTO bankTransaction
+    ) {
+        String counterpartyName = bankTransaction.getCounterpartyName();
+
+        return counterpartyName != null && !counterpartyName.isBlank();
+    }
+
+    private MatchingTransaction toMatchingTransaction(
+            BankTransactionDTO bankTransaction
+    ) {
+        return new MatchingTransaction(
+                bankTransaction.getBankTransactionId(),
+                toMatchingTransactionType(bankTransaction.getTransactionType()),
+                bankTransaction.getAmount(),
+                bankTransaction.getCounterpartyName(),
+                bankTransaction.getTransactionAt()
+        );
+    }
+
+    private AutoMatchingTransactionType toMatchingTransactionType(
+            BankTransactionType transactionType
+    ) {
+        return switch (transactionType) {
+            case DEPOSIT -> AutoMatchingTransactionType.DEPOSIT;
+            case WITHDRAWAL -> AutoMatchingTransactionType.WITHDRAWAL;
+        };
+    }
+
+    private BankTransactionProcessingStatus toBankTransactionProcessingStatus(
+            AutoMatchingProcessStatus processStatus
+    ) {
+        return switch (processStatus) {
+            case APPLIED, DUPLICATE ->
+                    BankTransactionProcessingStatus.APPLIED;
+            case NEEDS_CHECK ->
+                    BankTransactionProcessingStatus.NEEDS_CHECK;
+            case UNMATCHED ->
+                    BankTransactionProcessingStatus.UNMATCHED;
+            case FAILED ->
+                    BankTransactionProcessingStatus.FAILED;
+        };
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
@@ -38,18 +38,33 @@ public class BankMatchingTransactionService {
             Long linkedAccountId,
             BankTransactionDTO bankTransaction
     ) {
+        BankTransactionDTO lockedTransaction =
+                bankTransactionService
+                        .findByIdAndLinkedAccountIdForUpdate(
+                                bankTransaction.getBankTransactionId(),
+                                linkedAccountId
+                        );
+
+        if (lockedTransaction.getProcessingStatus()
+                != BankTransactionProcessingStatus.PENDING) {
+            return new AutoMatchingTransactionResult(
+                    lockedTransaction.getBankTransactionId(),
+                    AutoMatchingProcessStatus.DUPLICATE
+            );
+        }
+
         AutoMatchingTransactionResult result =
-                processMatching(linkedAccountId, bankTransaction);
+                processMatching(linkedAccountId, lockedTransaction);
 
         createMatchingReviewNotificationIfRequired(
                 userId,
                 linkedAccountId,
-                bankTransaction,
+                lockedTransaction,
                 result
         );
 
         bankTransactionService.updateStatus(
-                bankTransaction.getBankTransactionId(),
+                lockedTransaction.getBankTransactionId(),
                 BankTransactionProcessingStatus.PENDING,
                 toBankTransactionProcessingStatus(result.processStatus())
         );

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
@@ -1,0 +1,140 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchCandidateMapper;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BankTransactionMatchCandidateService {
+
+    private final BankTransactionMatchCandidateMapper candidateMapper;
+
+    @Transactional
+    public void saveAll(
+            Long bankTransactionId,
+            List<EvaluatedMatchingCandidate> evaluatedCandidates
+    ) {
+        validateSaveRequest(bankTransactionId, evaluatedCandidates);
+
+        if (evaluatedCandidates.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        List<BankTransactionMatchCandidateDTO> candidates =
+                evaluatedCandidates.stream()
+                        .map(candidate -> toDto(
+                                bankTransactionId,
+                                candidate,
+                                createdAt
+                        ))
+                        .toList();
+
+        int insertedCount = candidateMapper.insertAll(candidates);
+
+        if (insertedCount != candidates.size()) {
+            throw MatchingErrorCode
+                    .MATCHING_CANDIDATE_SAVE_FAILED
+                    .toException();
+        }
+    }
+
+    public List<BankTransactionMatchCandidateDTO>
+    findAllByBankTransactionId(Long bankTransactionId) {
+        validateBankTransactionId(bankTransactionId);
+
+        return candidateMapper.findAllByBankTransactionId(
+                bankTransactionId
+        );
+    }
+
+    public List<BankTransactionMatchCandidateQueryDTO>
+    findAllForReviewByBankTransactionId(Long bankTransactionId) {
+        validateBankTransactionId(bankTransactionId);
+
+        return candidateMapper.findAllForReviewByBankTransactionId(
+                bankTransactionId
+        );
+    }
+
+    public BankTransactionMatchCandidateDTO
+    findByIdAndBankTransactionId(
+            Long matchCandidateId,
+            Long bankTransactionId
+    ) {
+        if (matchCandidateId == null || matchCandidateId <= 0) {
+            throw MatchingErrorCode
+                    .INVALID_MATCHING_REQUEST
+                    .toException();
+        }
+
+        validateBankTransactionId(bankTransactionId);
+
+        return candidateMapper.findByIdAndBankTransactionId(
+                        matchCandidateId,
+                        bankTransactionId
+                )
+                .orElseThrow(
+                        MatchingErrorCode
+                                .MATCHING_CANDIDATE_NOT_FOUND
+                                ::toException
+                );
+    }
+
+    private BankTransactionMatchCandidateDTO toDto(
+            Long bankTransactionId,
+            EvaluatedMatchingCandidate evaluatedCandidate,
+            LocalDateTime createdAt
+    ) {
+        return BankTransactionMatchCandidateDTO.builder()
+                .bankTransactionId(bankTransactionId)
+                .targetType(
+                        evaluatedCandidate.candidate().targetType()
+                )
+                .targetId(
+                        evaluatedCandidate.candidate().targetId()
+                )
+                .expectedRemainingAmount(
+                        evaluatedCandidate.candidate().remainingAmount()
+                )
+                .amountMatchType(
+                        evaluatedCandidate.amountMatchType()
+                )
+                .createdAt(createdAt)
+                .build();
+    }
+
+    private void validateSaveRequest(
+            Long bankTransactionId,
+            List<EvaluatedMatchingCandidate> evaluatedCandidates
+    ) {
+        validateBankTransactionId(bankTransactionId);
+
+        if (evaluatedCandidates == null
+                || evaluatedCandidates.stream()
+                .anyMatch(candidate -> candidate == null)) {
+            throw MatchingErrorCode
+                    .INVALID_MATCHING_REQUEST
+                    .toException();
+        }
+    }
+
+    private void validateBankTransactionId(Long bankTransactionId) {
+        if (bankTransactionId == null || bankTransactionId <= 0) {
+            throw MatchingErrorCode
+                    .INVALID_MATCHING_REQUEST
+                    .toException();
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
@@ -8,6 +8,8 @@ import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQ
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchCandidateMapper;
 import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -73,12 +75,7 @@ public class BankTransactionMatchCandidateService {
             Long matchCandidateId,
             Long bankTransactionId
     ) {
-        if (matchCandidateId == null || matchCandidateId <= 0) {
-            throw MatchingErrorCode
-                    .INVALID_MATCHING_REQUEST
-                    .toException();
-        }
-
+        validateMatchCandidateId(matchCandidateId);
         validateBankTransactionId(bankTransactionId);
 
         return candidateMapper.findByIdAndBankTransactionId(
@@ -90,6 +87,43 @@ public class BankTransactionMatchCandidateService {
                                 .MATCHING_CANDIDATE_NOT_FOUND
                                 ::toException
                 );
+    }
+
+    @Transactional
+    public void invalidateCandidate(
+            Long matchCandidateId,
+            Long bankTransactionId,
+            MatchingCandidateInvalidationReason invalidationReason
+    ) {
+        validateMatchCandidateId(matchCandidateId);
+        validateBankTransactionId(bankTransactionId);
+
+        if (invalidationReason == null) {
+            throw MatchingErrorCode
+                    .INVALID_MATCHING_REQUEST
+                    .toException();
+        }
+
+        int updatedCount = candidateMapper.invalidate(
+                matchCandidateId,
+                bankTransactionId,
+                invalidationReason,
+                LocalDateTime.now()
+        );
+
+        if (updatedCount != 1) {
+            throw MatchingErrorCode
+                    .MATCHING_CANDIDATE_INVALIDATION_FAILED
+                    .toException();
+        }
+    }
+
+    public int countAvailableCandidates(Long bankTransactionId) {
+        validateBankTransactionId(bankTransactionId);
+
+        return candidateMapper.countAvailableByBankTransactionId(
+                bankTransactionId
+        );
     }
 
     private BankTransactionMatchCandidateDTO toDto(
@@ -111,6 +145,7 @@ public class BankTransactionMatchCandidateService {
                 .amountMatchType(
                         evaluatedCandidate.amountMatchType()
                 )
+                .candidateStatus(MatchingCandidateStatus.AVAILABLE)
                 .createdAt(createdAt)
                 .build();
     }
@@ -132,6 +167,14 @@ public class BankTransactionMatchCandidateService {
 
     private void validateBankTransactionId(Long bankTransactionId) {
         if (bankTransactionId == null || bankTransactionId <= 0) {
+            throw MatchingErrorCode
+                    .INVALID_MATCHING_REQUEST
+                    .toException();
+        }
+    }
+
+    private void validateMatchCandidateId(Long matchCandidateId) {
+        if (matchCandidateId == null || matchCandidateId <= 0) {
             throw MatchingErrorCode
                     .INVALID_MATCHING_REQUEST
                     .toException();

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
 import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchCandidateResponse;
 import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.policy.MatchingReviewValidator;
 import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
@@ -20,6 +21,7 @@ public class BankTransactionMatchingReviewQueryService {
 
     private final BankTransactionQueryService bankTransactionQueryService;
     private final BankTransactionMatchCandidateService candidateService;
+    private final MatchingReviewValidator matchingReviewValidator;
 
     public BankTransactionMatchingReviewResponse getReview(
             Long userId,
@@ -32,6 +34,8 @@ public class BankTransactionMatchingReviewQueryService {
                         linkedAccountId,
                         bankTransactionId
                 );
+
+        matchingReviewValidator.validate(transaction);
 
         List<BankTransactionMatchCandidateQueryDTO> candidates =
                 candidateService.findAllForReviewByBankTransactionId(

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
@@ -1,0 +1,67 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchCandidateResponse;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BankTransactionMatchingReviewQueryService {
+
+    private final BankTransactionQueryService bankTransactionQueryService;
+    private final BankTransactionMatchCandidateService candidateService;
+
+    public BankTransactionMatchingReviewResponse getReview(
+            Long userId,
+            Long linkedAccountId,
+            Long bankTransactionId
+    ) {
+        BankTransactionDetailResponse transaction =
+                bankTransactionQueryService.getTransactionDetail(
+                        userId,
+                        linkedAccountId,
+                        bankTransactionId
+                );
+
+        List<BankTransactionMatchCandidateQueryDTO> candidates =
+                candidateService.findAllForReviewByBankTransactionId(
+                        bankTransactionId
+                );
+
+        return new BankTransactionMatchingReviewResponse(
+                transaction,
+                determineReviewChannel(candidates),
+                candidates.stream()
+                        .map(BankTransactionMatchCandidateResponse::from)
+                        .toList()
+        );
+    }
+
+    private MatchingReviewChannel determineReviewChannel(
+            List<BankTransactionMatchCandidateQueryDTO> candidates
+    ) {
+        boolean hasSettlement = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.SETTLEMENT);
+
+        boolean hasLoan = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.LOAN);
+
+        if (hasSettlement && hasLoan) {
+            return MatchingReviewChannel.NOTIFICATION;
+        }
+
+        return MatchingReviewChannel.TRANSACTION_HISTORY;
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
@@ -7,6 +7,8 @@ import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.Repayme
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewResult;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
 import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
@@ -55,14 +57,19 @@ public class BankTransactionMatchingReviewService {
                     == PaymentErrorCode.DUPLICATE_PAYMENT_RECORD) {
                 return updateStatus(
                         bankTransactionId,
-                        BankTransactionProcessingStatus.APPLIED
+                        BankTransactionProcessingStatus.APPLIED,
+                        MatchingReviewResult.APPLIED
                 );
             }
 
-            if (isIrrecoverableTargetError(exception)) {
-                return updateStatus(
+            MatchingCandidateInvalidationReason invalidationReason =
+                    toInvalidationReason(exception);
+
+            if (invalidationReason != null) {
+                return invalidateCandidate(
                         bankTransactionId,
-                        BankTransactionProcessingStatus.FAILED
+                        candidate.getMatchCandidateId(),
+                        invalidationReason
                 );
             }
 
@@ -71,7 +78,8 @@ public class BankTransactionMatchingReviewService {
 
         return updateStatus(
                 bankTransactionId,
-                BankTransactionProcessingStatus.APPLIED
+                BankTransactionProcessingStatus.APPLIED,
+                MatchingReviewResult.APPLIED
         );
     }
 
@@ -89,7 +97,8 @@ public class BankTransactionMatchingReviewService {
 
         return updateStatus(
                 bankTransactionId,
-                BankTransactionProcessingStatus.UNMATCHED
+                BankTransactionProcessingStatus.UNMATCHED,
+                MatchingReviewResult.REJECTED
         );
     }
 
@@ -142,22 +151,70 @@ public class BankTransactionMatchingReviewService {
         throw MatchingErrorCode.MATCHING_TARGET_NOT_FOUND.toException();
     }
 
-    private boolean isIrrecoverableTargetError(
+    private MatchingReviewProcessResponse invalidateCandidate(
+            Long bankTransactionId,
+            Long matchCandidateId,
+            MatchingCandidateInvalidationReason invalidationReason
+    ) {
+        candidateService.invalidateCandidate(
+                matchCandidateId,
+                bankTransactionId,
+                invalidationReason
+        );
+
+        int availableCandidateCount =
+                candidateService.countAvailableCandidates(
+                        bankTransactionId
+                );
+
+        if (availableCandidateCount > 0) {
+            return new MatchingReviewProcessResponse(
+                    bankTransactionId,
+                    BankTransactionProcessingStatus.NEEDS_CHECK,
+                    MatchingReviewResult.CANDIDATE_INVALIDATED
+            );
+        }
+
+        boolean targetNotAvailable = invalidationReason
+                == MatchingCandidateInvalidationReason.TARGET_NOT_AVAILABLE;
+
+        BankTransactionProcessingStatus nextStatus =
+                targetNotAvailable
+                        ? BankTransactionProcessingStatus.UNMATCHED
+                        : BankTransactionProcessingStatus.FAILED;
+
+        return updateStatus(
+                bankTransactionId,
+                nextStatus,
+                MatchingReviewResult.CANDIDATE_INVALIDATED
+        );
+    }
+
+    private MatchingCandidateInvalidationReason toInvalidationReason(
             DomainException exception
     ) {
-        return exception.getErrorCode()
+        if (exception.getErrorCode()
                 == PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND
                 || exception.getErrorCode()
+                == RepaymentScheduleErrorCode.SCHEDULE_NOT_FOUND) {
+            return MatchingCandidateInvalidationReason.TARGET_NOT_FOUND;
+        }
+
+        if (exception.getErrorCode()
                 == PaymentErrorCode.PAYMENT_OBLIGATION_NOT_ACTIVE
                 || exception.getErrorCode()
-                == RepaymentScheduleErrorCode.SCHEDULE_NOT_FOUND
-                || exception.getErrorCode()
-                == RepaymentScheduleErrorCode.SCHEDULE_NOT_PENDING;
+                == RepaymentScheduleErrorCode.SCHEDULE_NOT_PENDING) {
+            return MatchingCandidateInvalidationReason
+                    .TARGET_NOT_AVAILABLE;
+        }
+
+        return null;
     }
 
     private MatchingReviewProcessResponse updateStatus(
             Long bankTransactionId,
-            BankTransactionProcessingStatus nextStatus
+            BankTransactionProcessingStatus nextStatus,
+            MatchingReviewResult reviewResult
     ) {
         bankTransactionService.updateStatus(
                 bankTransactionId,
@@ -167,7 +224,8 @@ public class BankTransactionMatchingReviewService {
 
         return new MatchingReviewProcessResponse(
                 bankTransactionId,
-                nextStatus
+                nextStatus,
+                reviewResult
         );
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
@@ -7,6 +7,7 @@ import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.Repayme
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.policy.MatchingReviewValidator;
 import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
 import org.teamsai.saibackend.domain.matching.type.MatchingReviewResult;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
@@ -17,7 +18,6 @@ import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDet
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
-import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 @Service
@@ -29,6 +29,7 @@ public class BankTransactionMatchingReviewService {
     private final SettlementPaymentService settlementPaymentService;
     private final LoanPaymentService loanPaymentService;
     private final BankTransactionService bankTransactionService;
+    private final MatchingReviewValidator matchingReviewValidator;
 
     @Transactional
     public MatchingReviewProcessResponse applyCandidate(
@@ -114,14 +115,7 @@ public class BankTransactionMatchingReviewService {
                         bankTransactionId
                 );
 
-        if (transaction.processingStatus()
-                != BankTransactionProcessingStatus.NEEDS_CHECK
-                || transaction.transactionType()
-                != BankTransactionType.DEPOSIT) {
-            throw MatchingErrorCode
-                    .MATCHING_REVIEW_NOT_REQUIRED
-                    .toException();
-        }
+        matchingReviewValidator.validate(transaction);
 
         return transaction;
     }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewService.java
@@ -1,0 +1,173 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.RepaymentScheduleErrorCode;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
+import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+@Service
+@RequiredArgsConstructor
+public class BankTransactionMatchingReviewService {
+
+    private final BankTransactionQueryService bankTransactionQueryService;
+    private final BankTransactionMatchCandidateService candidateService;
+    private final SettlementPaymentService settlementPaymentService;
+    private final LoanPaymentService loanPaymentService;
+    private final BankTransactionService bankTransactionService;
+
+    @Transactional
+    public MatchingReviewProcessResponse applyCandidate(
+            Long userId,
+            Long linkedAccountId,
+            Long bankTransactionId,
+            Long matchCandidateId
+    ) {
+        BankTransactionDetailResponse transaction =
+                getReviewableTransaction(
+                        userId,
+                        linkedAccountId,
+                        bankTransactionId
+                );
+
+        BankTransactionMatchCandidateDTO candidate =
+                candidateService.findByIdAndBankTransactionId(
+                        matchCandidateId,
+                        bankTransactionId
+                );
+
+        try {
+            applyPayment(transaction, candidate);
+        } catch (DomainException exception) {
+            if (exception.getErrorCode()
+                    == PaymentErrorCode.DUPLICATE_PAYMENT_RECORD) {
+                return updateStatus(
+                        bankTransactionId,
+                        BankTransactionProcessingStatus.APPLIED
+                );
+            }
+
+            if (isIrrecoverableTargetError(exception)) {
+                return updateStatus(
+                        bankTransactionId,
+                        BankTransactionProcessingStatus.FAILED
+                );
+            }
+
+            throw exception;
+        }
+
+        return updateStatus(
+                bankTransactionId,
+                BankTransactionProcessingStatus.APPLIED
+        );
+    }
+
+    @Transactional
+    public MatchingReviewProcessResponse rejectCandidates(
+            Long userId,
+            Long linkedAccountId,
+            Long bankTransactionId
+    ) {
+        getReviewableTransaction(
+                userId,
+                linkedAccountId,
+                bankTransactionId
+        );
+
+        return updateStatus(
+                bankTransactionId,
+                BankTransactionProcessingStatus.UNMATCHED
+        );
+    }
+
+    private BankTransactionDetailResponse getReviewableTransaction(
+            Long userId,
+            Long linkedAccountId,
+            Long bankTransactionId
+    ) {
+        BankTransactionDetailResponse transaction =
+                bankTransactionQueryService.getTransactionDetailForUpdate(
+                        userId,
+                        linkedAccountId,
+                        bankTransactionId
+                );
+
+        if (transaction.processingStatus()
+                != BankTransactionProcessingStatus.NEEDS_CHECK
+                || transaction.transactionType()
+                != BankTransactionType.DEPOSIT) {
+            throw MatchingErrorCode
+                    .MATCHING_REVIEW_NOT_REQUIRED
+                    .toException();
+        }
+
+        return transaction;
+    }
+
+    private void applyPayment(
+            BankTransactionDetailResponse transaction,
+            BankTransactionMatchCandidateDTO candidate
+    ) {
+        if (candidate.getTargetType() == MatchingTargetType.SETTLEMENT) {
+            settlementPaymentService.applyManuallyMatchedPayment(
+                    candidate.getTargetId(),
+                    transaction.bankTransactionId(),
+                    transaction.amount()
+            );
+            return;
+        }
+
+        if (candidate.getTargetType() == MatchingTargetType.LOAN) {
+            loanPaymentService.applyManuallyMatchedPayment(
+                    candidate.getTargetId(),
+                    transaction.bankTransactionId(),
+                    transaction.amount()
+            );
+            return;
+        }
+
+        throw MatchingErrorCode.MATCHING_TARGET_NOT_FOUND.toException();
+    }
+
+    private boolean isIrrecoverableTargetError(
+            DomainException exception
+    ) {
+        return exception.getErrorCode()
+                == PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND
+                || exception.getErrorCode()
+                == PaymentErrorCode.PAYMENT_OBLIGATION_NOT_ACTIVE
+                || exception.getErrorCode()
+                == RepaymentScheduleErrorCode.SCHEDULE_NOT_FOUND
+                || exception.getErrorCode()
+                == RepaymentScheduleErrorCode.SCHEDULE_NOT_PENDING;
+    }
+
+    private MatchingReviewProcessResponse updateStatus(
+            Long bankTransactionId,
+            BankTransactionProcessingStatus nextStatus
+    ) {
+        bankTransactionService.updateStatus(
+                bankTransactionId,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                nextStatus
+        );
+
+        return new MatchingReviewProcessResponse(
+                bankTransactionId,
+                nextStatus
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingAmountType.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingAmountType.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum MatchingAmountType {
+    EXACT,
+    PARTIAL,
+    EXCESS
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingCandidateInvalidationReason.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingCandidateInvalidationReason.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum MatchingCandidateInvalidationReason {
+    TARGET_NOT_FOUND,
+    TARGET_NOT_AVAILABLE
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingCandidateStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingCandidateStatus.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum MatchingCandidateStatus {
+    AVAILABLE,
+    INVALIDATED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingReviewChannel.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingReviewChannel.java
@@ -1,0 +1,6 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum MatchingReviewChannel {
+    NOTIFICATION,
+    TRANSACTION_HISTORY
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingReviewResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/type/MatchingReviewResult.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.matching.type;
+
+public enum MatchingReviewResult {
+    APPLIED,
+    REJECTED,
+    CANDIDATE_INVALIDATED
+}

--- a/src/main/java/org/teamsai/saibackend/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/notification/dto/response/NotificationResponse.java
@@ -1,6 +1,7 @@
 package org.teamsai.saibackend.domain.notification.dto.response;
 
 import org.teamsai.saibackend.domain.notification.type.NotificationType;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
 
 import java.time.LocalDateTime;
 
@@ -11,6 +12,8 @@ public record NotificationResponse(
         String content,
         Long referenceId,
         Long secondaryReferenceId,
+        BankTransactionProcessingStatus relatedTransactionStatus,
+        boolean resolved,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/org/teamsai/saibackend/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/notification/mapper/NotificationMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.notification.dto.NotificationDTO;
 import org.teamsai.saibackend.domain.notification.dto.response.NotificationResponse;
+import org.teamsai.saibackend.domain.notification.type.NotificationType;
 
 import java.util.List;
 
@@ -14,6 +15,12 @@ public interface NotificationMapper {
 
     List<NotificationResponse> findAllByUserId(
             @Param("userId") Long userId
+    );
+
+    boolean existsByUserIdAndTypeAndReferenceId(
+            @Param("userId") Long userId,
+            @Param("notificationType") NotificationType notificationType,
+            @Param("referenceId") Long referenceId
     );
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/notification/service/NotificationService.java
@@ -36,6 +36,33 @@ public class NotificationService {
         notificationMapper.insert(notification);
     }
 
+    @Transactional
+    public void createIfAbsent(
+            Long userId,
+            NotificationType type,
+            String title,
+            String content,
+            Long referenceId,
+            Long secondaryReferenceId
+    ) {
+        if (notificationMapper.existsByUserIdAndTypeAndReferenceId(
+                userId,
+                type,
+                referenceId
+        )) {
+            return;
+        }
+
+        create(
+                userId,
+                type,
+                title,
+                content,
+                referenceId,
+                secondaryReferenceId
+        );
+    }
+
     @Transactional(readOnly = true)
     public List<NotificationResponse> getNotifications(Long userId) {
         return notificationMapper.findAllByUserId(userId);

--- a/src/main/java/org/teamsai/saibackend/domain/notification/type/NotificationType.java
+++ b/src/main/java/org/teamsai/saibackend/domain/notification/type/NotificationType.java
@@ -3,5 +3,6 @@ package org.teamsai.saibackend.domain.notification.type;
 public enum NotificationType {
     SETTLEMENT_PARTICIPANT_ADDED,
     CONTRACT_REQUESTED,
-    CONTRACT_CHANGE
+    CONTRACT_CHANGE,
+    BANK_TRANSACTION_MATCHING_REVIEW
 }

--- a/src/main/java/org/teamsai/saibackend/domain/payment/service/LoanPaymentService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/service/LoanPaymentService.java
@@ -1,15 +1,15 @@
-package org.teamsai.saibackend.domain.matching.service;
+package org.teamsai.saibackend.domain.payment.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.dto.RepaymentScheduleDTO;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.RepaymentScheduleErrorCode;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.service.RepaymentScheduleService;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
-import org.teamsai.saibackend.domain.payment.service.PaymentRecordService;
 import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
 import org.teamsai.saibackend.domain.payment.type.SourceType;
 
@@ -24,8 +24,39 @@ public class LoanPaymentService {
     private final RepaymentScheduleService repaymentScheduleService;
     private final PaymentRecordService paymentRecordService;
 
-    @Transactional
+    @Transactional(propagation = Propagation.NESTED)
     public void applyAutoMatchedPayment(Long targetId, Long bankTransactionId, BigDecimal amount) {
+        applyPayment(
+                targetId,
+                bankTransactionId,
+                amount,
+                SourceType.AUTO_MATCH,
+                false
+        );
+    }
+
+    @Transactional(propagation = Propagation.NESTED)
+    public void applyManuallyMatchedPayment(
+            Long targetId,
+            Long bankTransactionId,
+            BigDecimal amount
+    ) {
+        applyPayment(
+                targetId,
+                bankTransactionId,
+                amount,
+                SourceType.MANUAL,
+                true
+        );
+    }
+
+    private void applyPayment(
+            Long targetId,
+            Long bankTransactionId,
+            BigDecimal amount,
+            SourceType sourceType,
+            boolean limitToRemainingAmount
+    ) {
 
         RepaymentScheduleDTO schedule = repaymentScheduleService.getScheduleByScheduleId(targetId);
 
@@ -44,7 +75,18 @@ public class LoanPaymentService {
         }
 
         BigDecimal expectedTotalAmount = schedule.getTotalPaymentDue();
-        BigDecimal totalPaidAfterThis = existingConfirmedAmount.add(amount);
+        BigDecimal remainingAmount =
+                expectedTotalAmount.subtract(existingConfirmedAmount);
+
+        if (remainingAmount.signum() <= 0) {
+            throw RepaymentScheduleErrorCode.SCHEDULE_NOT_PENDING.toException();
+        }
+
+        BigDecimal paymentAmount = limitToRemainingAmount
+                ? amount.min(remainingAmount)
+                : amount;
+        BigDecimal totalPaidAfterThis =
+                existingConfirmedAmount.add(paymentAmount);
 
 
         if (totalPaidAfterThis.compareTo(expectedTotalAmount) > 0) {
@@ -62,8 +104,8 @@ public class LoanPaymentService {
                 bankTransactionId,
                 PaymentTargetType.LOAN,
                 targetId,
-                amount,
-                SourceType.AUTO_MATCH
+                paymentAmount,
+                sourceType
         );
 
         log.info("[LoanPaymentService] PaymentRecord 생성 완료 - paymentRecordId: {}", paymentRecordId);

--- a/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
@@ -2,6 +2,7 @@ package org.teamsai.saibackend.domain.payment.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
@@ -17,7 +18,7 @@ public class SettlementPaymentService {
     private final PaymentObligationMapper paymentObligationMapper;
     private final PaymentRecordService paymentRecordService;
 
-    @Transactional
+    @Transactional(propagation = Propagation.NESTED)
     public void applyAutoMatchedPayment(
             Long paymentObligationId,
             Long bankTransactionId,
@@ -27,7 +28,23 @@ public class SettlementPaymentService {
                 paymentObligationId,
                 bankTransactionId,
                 amount,
-                SourceType.AUTO_MATCH
+                SourceType.AUTO_MATCH,
+                false
+        );
+    }
+
+    @Transactional(propagation = Propagation.NESTED)
+    public void applyManuallyMatchedPayment(
+            Long paymentObligationId,
+            Long bankTransactionId,
+            BigDecimal amount
+    ) {
+        applyPayment(
+                paymentObligationId,
+                bankTransactionId,
+                amount,
+                SourceType.MANUAL,
+                true
         );
     }
 
@@ -35,7 +52,8 @@ public class SettlementPaymentService {
             Long paymentObligationId,
             Long bankTransactionId,
             BigDecimal amount,
-            SourceType sourceType
+            SourceType sourceType,
+            boolean limitToRemainingAmount
     ) {
         validatePaymentAmount(amount);
         validateBankTransactionId(bankTransactionId);
@@ -54,19 +72,26 @@ public class SettlementPaymentService {
         BigDecimal remainingAmount =
                 obligation.getExpectedAmount().subtract(paidAmount);
 
-        if (amount.compareTo(remainingAmount) > 0) {
+        if (!limitToRemainingAmount
+                && amount.compareTo(remainingAmount) > 0) {
             throw PaymentErrorCode.PAYMENT_AMOUNT_EXCEEDS_REMAINING_AMOUNT.toException();
         }
+
+        BigDecimal paymentAmount = limitToRemainingAmount
+                ? amount.min(remainingAmount)
+                : amount;
+
+        validatePaymentAmount(paymentAmount);
 
         paymentRecordService.createConfirmedRecord(
                 bankTransactionId,
                 PaymentTargetType.SETTLEMENT,
                 paymentObligationId,
-                amount,
+                paymentAmount,
                 sourceType
         );
 
-        BigDecimal newPaidAmount = paidAmount.add(amount);
+        BigDecimal newPaidAmount = paidAmount.add(paymentAmount);
         PaymentStatus newPaymentStatus = calculatePaymentStatus(
                 obligation.getExpectedAmount(),
                 newPaidAmount
@@ -103,7 +128,8 @@ public class SettlementPaymentService {
     }
 
     private void validateActiveObligation(PaymentObligationDTO obligation) {
-        if (obligation.getObligationStatus() != ObligationStatus.ACTIVE) {
+        if (obligation.getObligationStatus() != ObligationStatus.ACTIVE
+                || obligation.getPaymentStatus() == PaymentStatus.PAID) {
             throw PaymentErrorCode.PAYMENT_OBLIGATION_NOT_ACTIVE.toException();
         }
     }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/controller/BankTransactionQueryController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/controller/BankTransactionQueryController.java
@@ -1,6 +1,9 @@
 package org.teamsai.saibackend.domain.transaction.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -10,6 +13,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewQueryService;
 import org.teamsai.saibackend.domain.transaction.dto.request.BankTransactionSearchCondition;
 import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
 import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionListItemResponse;
@@ -27,6 +32,8 @@ import java.time.LocalDate;
 public class BankTransactionQueryController {
 
     private final BankTransactionQueryService bankTransactionQueryService;
+    private final BankTransactionMatchingReviewQueryService
+            matchingReviewQueryService;
 
     @Operation(summary = "연동계좌 거래 목록 조회/검색")
     @GetMapping("/api/linked-accounts/{linkedAccountId}/transactions")
@@ -60,6 +67,50 @@ public class BankTransactionQueryController {
         return ResponseEntity.ok(
                 bankTransactionQueryService.getTransactionDetail(
                         userDetails.getUserId(), linkedAccountId, bankTransactionId
+                )
+        );
+    }
+
+    @Operation(
+            summary = "은행 거래 매칭 후보 조회",
+            description = "확인이 필요한 은행 거래와 저장된 정산·차용증 매칭 후보를 조회합니다. "
+                    + "정산과 차용증 후보가 모두 있으면 알림 검토 대상으로, "
+                    + "한 도메인의 후보만 있으면 거래내역 검토 대상으로 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "은행 거래 매칭 후보 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "연결 계좌에 대한 접근 권한 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "연결 계좌 또는 은행 거래를 찾을 수 없음"
+            )
+    })
+    @GetMapping(
+            "/api/linked-accounts/{linkedAccountId}"
+                    + "/transactions/{bankTransactionId}/match-candidates"
+    )
+    public ResponseEntity<BankTransactionMatchingReviewResponse>
+    getMatchCandidates(
+            @PathVariable Long linkedAccountId,
+            @PathVariable Long bankTransactionId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                matchingReviewQueryService.getReview(
+                        userDetails.getUserId(),
+                        linkedAccountId,
+                        bankTransactionId
                 )
         );
     }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/mapper/BankTransactionMapper.java
@@ -44,4 +44,9 @@ public interface BankTransactionMapper {
                        @Param("condition") BankTransactionSearchCondition condition);
 
     Optional<BankTransactionDTO> findByIdAndLinkedAccountId(@Param("bankTransactionId") Long bankTransactionId, @Param("linkedAccountId") Long linkedAccountId);
+
+    Optional<BankTransactionDTO> findByIdAndLinkedAccountIdForUpdate(
+            @Param("bankTransactionId") Long bankTransactionId,
+            @Param("linkedAccountId") Long linkedAccountId
+    );
 }

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionQueryService.java
@@ -52,6 +52,28 @@ public class BankTransactionQueryService {
         return BankTransactionDetailResponse.from(transaction);
     }
 
+    @Transactional
+    public BankTransactionDetailResponse getTransactionDetailForUpdate(
+            Long userId,
+            Long linkedAccountId,
+            Long bankTransactionId
+    ) {
+        validateOwnership(userId, linkedAccountId);
+
+        BankTransactionDTO transaction = bankTransactionMapper
+                .findByIdAndLinkedAccountIdForUpdate(
+                        bankTransactionId,
+                        linkedAccountId
+                )
+                .orElseThrow(
+                        BankTransactionErrorCode
+                                .BANK_TRANSACTION_NOT_FOUND
+                                ::toException
+                );
+
+        return BankTransactionDetailResponse.from(transaction);
+    }
+
     private void validateOwnership(Long userId, Long linkedAccountId) {
         LinkedBankAccountDTO linkedAccount = linkedBankAccountMapper.findById(linkedAccountId)
                 .orElseThrow(AccountErrorCode.LINKED_ACCOUNT_NOT_FOUND::toException);

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -105,12 +105,30 @@ public class BankTransactionService {
             BankTransactionProcessingStatus currentStatus,
             BankTransactionProcessingStatus nextStatus
     ) {
-        if (currentStatus != BankTransactionProcessingStatus.PENDING
-                || !isTerminalStatus(nextStatus)) {
+        if (!isValidStatusTransition(currentStatus, nextStatus)) {
             throw BankTransactionErrorCode
                     .INVALID_BANK_TRANSACTION_STATUS_TRANSITION
                     .toException();
         }
+    }
+
+    private boolean isValidStatusTransition(
+            BankTransactionProcessingStatus currentStatus,
+            BankTransactionProcessingStatus nextStatus
+    ) {
+        if (currentStatus == BankTransactionProcessingStatus.PENDING) {
+            return isTerminalStatus(nextStatus);
+        }
+
+        if (currentStatus == BankTransactionProcessingStatus.NEEDS_CHECK) {
+            return nextStatus == BankTransactionProcessingStatus.APPLIED
+                    || nextStatus
+                    == BankTransactionProcessingStatus.UNMATCHED
+                    || nextStatus
+                    == BankTransactionProcessingStatus.FAILED;
+        }
+
+        return false;
     }
 
     private boolean isTerminalStatus(

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/BankTransactionService.java
@@ -46,6 +46,22 @@ public class BankTransactionService {
     }
 
     @Transactional
+    public BankTransactionDTO findByIdAndLinkedAccountIdForUpdate(
+            Long bankTransactionId,
+            Long linkedAccountId
+    ) {
+        return bankTransactionMapper
+                .findByIdAndLinkedAccountIdForUpdate(
+                        bankTransactionId,
+                        linkedAccountId
+                )
+                .orElseThrow(
+                        BankTransactionErrorCode
+                                .BANK_TRANSACTION_NOT_FOUND::toException
+                );
+    }
+
+    @Transactional
     public void updateStatus(
             Long bankTransactionId,
             BankTransactionProcessingStatus currentStatus,

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
@@ -25,7 +25,7 @@ public class TransactionSyncFacade {
 
     public AutoMatchingExecutionResult syncAndMatch(Long userId, Long linkedAccountId) {
         transactionSyncService.syncTransactions(userId, linkedAccountId);
-        return bankMatchingService.execute(linkedAccountId);
+        return bankMatchingService.execute(userId, linkedAccountId);
     }
 
     public TransactionSyncAllResponse syncAll(Long userId){

--- a/src/main/resources/db/bank_transaction_match_candidate.sql
+++ b/src/main/resources/db/bank_transaction_match_candidate.sql
@@ -15,6 +15,20 @@ CREATE TABLE IF NOT EXISTS bank_transaction_match_candidate (
         amount_match_type IN ('EXACT', 'PARTIAL', 'EXCESS')
     ),
 
+    candidate_status VARCHAR(30) NOT NULL DEFAULT 'AVAILABLE' CHECK (
+        candidate_status IN ('AVAILABLE', 'INVALIDATED')
+    ),
+
+    invalidated_at DATETIME NULL,
+
+    invalidation_reason VARCHAR(50) NULL CHECK (
+        invalidation_reason IS NULL
+        OR invalidation_reason IN (
+            'TARGET_NOT_FOUND',
+            'TARGET_NOT_AVAILABLE'
+        )
+    ),
+
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY (match_candidate_id),
@@ -28,7 +42,22 @@ CREATE TABLE IF NOT EXISTS bank_transaction_match_candidate (
 
     CONSTRAINT fk_match_candidate_bank_transaction
         FOREIGN KEY (bank_transaction_id)
-        REFERENCES bank_transaction (bank_transaction_id)
+        REFERENCES bank_transaction (bank_transaction_id),
+
+    CONSTRAINT chk_match_candidate_invalidation
+        CHECK (
+            (
+                candidate_status = 'AVAILABLE'
+                AND invalidated_at IS NULL
+                AND invalidation_reason IS NULL
+            )
+            OR
+            (
+                candidate_status = 'INVALIDATED'
+                AND invalidated_at IS NOT NULL
+                AND invalidation_reason IS NOT NULL
+            )
+        )
 ) ENGINE=InnoDB
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/bank_transaction_match_candidate.sql
+++ b/src/main/resources/db/bank_transaction_match_candidate.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS bank_transaction_match_candidate (
+    match_candidate_id BIGINT NOT NULL AUTO_INCREMENT,
+    bank_transaction_id BIGINT NOT NULL,
+
+    target_type VARCHAR(30) NOT NULL CHECK (
+        target_type IN ('SETTLEMENT', 'LOAN')
+    ),
+    target_id BIGINT NOT NULL,
+
+    expected_remaining_amount DECIMAL(19, 2) NOT NULL CHECK (
+        expected_remaining_amount > 0
+    ),
+
+    amount_match_type VARCHAR(30) NOT NULL CHECK (
+        amount_match_type IN ('EXACT', 'PARTIAL', 'EXCESS')
+    ),
+
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (match_candidate_id),
+
+    CONSTRAINT uk_bank_transaction_match_candidate
+        UNIQUE (
+            bank_transaction_id,
+            target_type,
+            target_id
+        ),
+
+    CONSTRAINT fk_match_candidate_bank_transaction
+        FOREIGN KEY (bank_transaction_id)
+        REFERENCES bank_transaction (bank_transaction_id)
+) ENGINE=InnoDB
+DEFAULT CHARSET=utf8mb4
+COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -18,6 +18,13 @@
         <result property="amountMatchType"
                 column="amount_match_type"
                 javaType="org.teamsai.saibackend.domain.matching.type.MatchingAmountType"/>
+        <result property="candidateStatus"
+                column="candidate_status"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus"/>
+        <result property="invalidatedAt" column="invalidated_at"/>
+        <result property="invalidationReason"
+                column="invalidation_reason"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason"/>
         <result property="createdAt" column="created_at"/>
     </resultMap>
 
@@ -45,6 +52,9 @@
         target_id,
         expected_remaining_amount,
         amount_match_type,
+        candidate_status,
+        invalidated_at,
+        invalidation_reason,
         created_at
     </sql>
 
@@ -55,6 +65,7 @@
             target_id,
             expected_remaining_amount,
             amount_match_type,
+            candidate_status,
             created_at
         )
         VALUES
@@ -67,6 +78,7 @@
                 #{candidate.targetId},
                 #{candidate.expectedRemainingAmount},
                 #{candidate.amountMatchType},
+                #{candidate.candidateStatus},
                 #{candidate.createdAt}
             )
         </foreach>
@@ -109,6 +121,7 @@
         LEFT JOIN users debtor
             ON debtor.user_id = contract.debtor_id
         WHERE mc.bank_transaction_id = #{bankTransactionId}
+        AND mc.candidate_status = 'AVAILABLE'
         ORDER BY mc.match_candidate_id ASC
     </select>
 
@@ -119,6 +132,25 @@
         FROM bank_transaction_match_candidate
         WHERE match_candidate_id = #{matchCandidateId}
         AND bank_transaction_id = #{bankTransactionId}
+        AND candidate_status = 'AVAILABLE'
+    </select>
+
+    <update id="invalidate">
+        UPDATE bank_transaction_match_candidate
+        SET candidate_status = 'INVALIDATED',
+            invalidated_at = #{invalidatedAt},
+            invalidation_reason = #{invalidationReason}
+        WHERE match_candidate_id = #{matchCandidateId}
+        AND bank_transaction_id = #{bankTransactionId}
+        AND candidate_status = 'AVAILABLE'
+    </update>
+
+    <select id="countAvailableByBankTransactionId"
+            resultType="int">
+        SELECT COUNT(*)
+        FROM bank_transaction_match_candidate
+        WHERE bank_transaction_id = #{bankTransactionId}
+        AND candidate_status = 'AVAILABLE'
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchCandidateMapper">
+
+    <resultMap id="BankTransactionMatchCandidateResultMap"
+               type="org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO">
+        <id property="matchCandidateId" column="match_candidate_id"/>
+        <result property="bankTransactionId" column="bank_transaction_id"/>
+        <result property="targetType"
+                column="target_type"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
+        <result property="targetId" column="target_id"/>
+        <result property="expectedRemainingAmount"
+                column="expected_remaining_amount"/>
+        <result property="amountMatchType"
+                column="amount_match_type"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingAmountType"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <resultMap id="BankTransactionMatchCandidateQueryResultMap"
+               type="org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO">
+        <id property="matchCandidateId" column="match_candidate_id"/>
+        <result property="bankTransactionId" column="bank_transaction_id"/>
+        <result property="targetType"
+                column="target_type"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
+        <result property="targetId" column="target_id"/>
+        <result property="participantName" column="participant_name"/>
+        <result property="expectedRemainingAmount"
+                column="expected_remaining_amount"/>
+        <result property="amountMatchType"
+                column="amount_match_type"
+                javaType="org.teamsai.saibackend.domain.matching.type.MatchingAmountType"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <sql id="BankTransactionMatchCandidateColumns">
+        match_candidate_id,
+        bank_transaction_id,
+        target_type,
+        target_id,
+        expected_remaining_amount,
+        amount_match_type,
+        created_at
+    </sql>
+
+    <insert id="insertAll">
+        INSERT INTO bank_transaction_match_candidate (
+            bank_transaction_id,
+            target_type,
+            target_id,
+            expected_remaining_amount,
+            amount_match_type,
+            created_at
+        )
+        VALUES
+        <foreach collection="candidates"
+                 item="candidate"
+                 separator=",">
+            (
+                #{candidate.bankTransactionId},
+                #{candidate.targetType},
+                #{candidate.targetId},
+                #{candidate.expectedRemainingAmount},
+                #{candidate.amountMatchType},
+                #{candidate.createdAt}
+            )
+        </foreach>
+    </insert>
+
+    <select id="findAllByBankTransactionId"
+            resultMap="BankTransactionMatchCandidateResultMap">
+        SELECT
+        <include refid="BankTransactionMatchCandidateColumns"/>
+        FROM bank_transaction_match_candidate
+        WHERE bank_transaction_id = #{bankTransactionId}
+        ORDER BY match_candidate_id ASC
+    </select>
+
+    <select id="findAllForReviewByBankTransactionId"
+            resultMap="BankTransactionMatchCandidateQueryResultMap">
+        SELECT
+            mc.match_candidate_id,
+            mc.bank_transaction_id,
+            mc.target_type,
+            mc.target_id,
+            COALESCE(settlement_user.name, debtor.name)
+                AS participant_name,
+            mc.expected_remaining_amount,
+            mc.amount_match_type,
+            mc.created_at
+        FROM bank_transaction_match_candidate mc
+        LEFT JOIN payment_obligation obligation
+            ON mc.target_type = 'SETTLEMENT'
+            AND obligation.payment_obligation_id = mc.target_id
+        LEFT JOIN settlement_participant participant
+            ON participant.participant_id = obligation.participant_id
+        LEFT JOIN users settlement_user
+            ON settlement_user.user_id = participant.user_id
+        LEFT JOIN repayment_schedule schedule
+            ON mc.target_type = 'LOAN'
+            AND schedule.schedule_id = mc.target_id
+        LEFT JOIN loan_contract contract
+            ON contract.contract_id = schedule.contract_id
+        LEFT JOIN users debtor
+            ON debtor.user_id = contract.debtor_id
+        WHERE mc.bank_transaction_id = #{bankTransactionId}
+        ORDER BY mc.match_candidate_id ASC
+    </select>
+
+    <select id="findByIdAndBankTransactionId"
+            resultMap="BankTransactionMatchCandidateResultMap">
+        SELECT
+        <include refid="BankTransactionMatchCandidateColumns"/>
+        FROM bank_transaction_match_candidate
+        WHERE match_candidate_id = #{matchCandidateId}
+        AND bank_transaction_id = #{bankTransactionId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/notification/NotificationMapper.xml
+++ b/src/main/resources/mapper/notification/NotificationMapper.xml
@@ -37,22 +37,47 @@
             resultType="org.teamsai.saibackend.domain.notification.dto.response.NotificationResponse">
 
         SELECT
-        notification_id AS notificationId,
-        notification_type AS notificationType,
-        title,
-        content,
-        reference_id AS referenceId,
-        secondary_reference_id AS secondaryReferenceId,
-        created_at AS createdAt
+        n.notification_id AS notificationId,
+        n.notification_type AS notificationType,
+        n.title,
+        n.content,
+        n.reference_id AS referenceId,
+        n.secondary_reference_id AS secondaryReferenceId,
+        bt.processing_status AS relatedTransactionStatus,
+        CASE
+            WHEN n.notification_type =
+                 'BANK_TRANSACTION_MATCHING_REVIEW'
+             AND bt.processing_status IS NOT NULL
+             AND bt.processing_status != 'NEEDS_CHECK'
+            THEN TRUE
+            ELSE FALSE
+        END AS resolved,
+        n.created_at AS createdAt
 
-        FROM notification
+        FROM notification n
+        LEFT JOIN bank_transaction bt
+            ON n.notification_type =
+               'BANK_TRANSACTION_MATCHING_REVIEW'
+            AND bt.bank_transaction_id = n.reference_id
+            AND bt.linked_account_id = n.secondary_reference_id
 
-        WHERE user_id = #{userId}
+        WHERE n.user_id = #{userId}
 
         ORDER BY
-        created_at DESC,
-        notification_id DESC
+        n.created_at DESC,
+        n.notification_id DESC
 
+    </select>
+
+    <select id="existsByUserIdAndTypeAndReferenceId"
+            resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM notification
+            WHERE user_id = #{userId}
+            AND notification_type = #{notificationType}
+            AND reference_id = #{referenceId}
+        )
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/transaction/BankTransactionMapper.xml
+++ b/src/main/resources/mapper/transaction/BankTransactionMapper.xml
@@ -169,5 +169,24 @@
         WHERE bank_transaction_id = #{bankTransactionId}
         AND linked_account_id = #{linkedAccountId}
     </select>
+
+    <select id="findByIdAndLinkedAccountIdForUpdate"
+            resultMap="BankTransactionResultMap">
+        SELECT
+        bank_transaction_id,
+        linked_account_id,
+        external_transaction_id,
+        amount,
+        transaction_type,
+        processing_status,
+        transaction_at,
+        counterparty_name,
+        memo,
+        synced_at
+        FROM bank_transaction
+        WHERE bank_transaction_id = #{bankTransactionId}
+        AND linked_account_id = #{linkedAccountId}
+        FOR UPDATE
+    </select>
 </mapper>
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingJudgeTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingJudgeTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingResult;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.policy.AutoMatchingJudge;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingDecisionType;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -53,7 +55,7 @@ class AutoMatchingJudgeTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
-            assertThat(result.matchedCandidates()).isEmpty();
+            assertThat(result.evaluatedCandidates()).isEmpty();
         }
 
         @Test
@@ -78,7 +80,12 @@ class AutoMatchingJudgeTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.MATCHABLE);
-            assertThat(result.matchedCandidates()).containsExactly(candidate);
+            assertThat(result.evaluatedCandidates()).containsExactly(
+                    new EvaluatedMatchingCandidate(
+                            candidate,
+                            MatchingAmountType.EXACT
+                    )
+            );
         }
 
         @Test
@@ -100,8 +107,16 @@ class AutoMatchingJudgeTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
-            assertThat(result.matchedCandidates())
-                    .containsExactly(first, second);
+            assertThat(result.evaluatedCandidates()).containsExactly(
+                    new EvaluatedMatchingCandidate(
+                            first,
+                            MatchingAmountType.EXACT
+                    ),
+                    new EvaluatedMatchingCandidate(
+                            second,
+                            MatchingAmountType.EXACT
+                    )
+            );
         }
 
         @Test
@@ -126,7 +141,7 @@ class AutoMatchingJudgeTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
-            assertThat(result.matchedCandidates()).isEmpty();
+            assertThat(result.evaluatedCandidates()).isEmpty();
         }
 
         @Test
@@ -151,12 +166,12 @@ class AutoMatchingJudgeTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
-            assertThat(result.matchedCandidates()).isEmpty();
+            assertThat(result.evaluatedCandidates()).isEmpty();
         }
 
         @Test
         @DisplayName("입금액이 남은 납부금액보다 작으면 부분 상환으로 자동매칭하지 않는다")
-        void depositWithPartialAmountIsUnmatched() {
+        void depositWithPartialAmountNeedsCheck() {
             MatchingTransaction transaction = transaction(
                     AutoMatchingTransactionType.DEPOSIT,
                     "HongGilDong",
@@ -175,8 +190,107 @@ class AutoMatchingJudgeTest {
             );
 
             assertThat(result.decisionType())
+                    .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
+            assertThat(result.evaluatedCandidates()).containsExactly(
+                    new EvaluatedMatchingCandidate(
+                            candidate,
+                            MatchingAmountType.PARTIAL
+                    )
+            );
+        }
+
+        @Test
+        void depositAtTenPercentNeedsCheckAsPartial() {
+            MatchingTransaction transaction = transaction(
+                    AutoMatchingTransactionType.DEPOSIT,
+                    "HongGilDong",
+                    "1000"
+            );
+            MatchingCandidate candidate = candidate(
+                    1L,
+                    "HongGilDong",
+                    "10000"
+            );
+
+            AutoMatchingResult result = judge.judge(
+                    transaction,
+                    List.of(candidate)
+            );
+
+            assertThat(result.decisionType())
+                    .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
+            assertThat(result.evaluatedCandidates().get(0).amountMatchType())
+                    .isEqualTo(MatchingAmountType.PARTIAL);
+        }
+
+        @Test
+        void depositBelowTenPercentIsUnmatched() {
+            MatchingTransaction transaction = transaction(
+                    AutoMatchingTransactionType.DEPOSIT,
+                    "HongGilDong",
+                    "999"
+            );
+            MatchingCandidate candidate = candidate(
+                    1L,
+                    "HongGilDong",
+                    "10000"
+            );
+
+            AutoMatchingResult result = judge.judge(
+                    transaction,
+                    List.of(candidate)
+            );
+
+            assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
-            assertThat(result.matchedCandidates()).isEmpty();
+            assertThat(result.evaluatedCandidates()).isEmpty();
+        }
+
+        @Test
+        void depositAtOneHundredTenPercentNeedsCheckAsExcess() {
+            MatchingTransaction transaction = transaction(
+                    AutoMatchingTransactionType.DEPOSIT,
+                    "HongGilDong",
+                    "11000"
+            );
+            MatchingCandidate candidate = candidate(
+                    1L,
+                    "HongGilDong",
+                    "10000"
+            );
+
+            AutoMatchingResult result = judge.judge(
+                    transaction,
+                    List.of(candidate)
+            );
+
+            assertThat(result.decisionType())
+                    .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
+            assertThat(result.evaluatedCandidates().get(0).amountMatchType())
+                    .isEqualTo(MatchingAmountType.EXCESS);
+        }
+
+        @Test
+        void depositAboveOneHundredTenPercentIsUnmatched() {
+            MatchingTransaction transaction = transaction(
+                    AutoMatchingTransactionType.DEPOSIT,
+                    "HongGilDong",
+                    "11001"
+            );
+            MatchingCandidate candidate = candidate(
+                    1L,
+                    "HongGilDong",
+                    "10000"
+            );
+
+            AutoMatchingResult result = judge.judge(
+                    transaction,
+                    List.of(candidate)
+            );
+
+            assertThat(result.decisionType())
+                    .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
+            assertThat(result.evaluatedCandidates()).isEmpty();
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingResultTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingResultTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingResult;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingDecisionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -40,20 +42,23 @@ class AutoMatchingResultTest {
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.UNMATCHED);
-            assertThat(result.matchedCandidates()).isEmpty();
+            assertThat(result.evaluatedCandidates()).isEmpty();
         }
 
         @Test
         @DisplayName("매칭 후보가 하나이면 매칭 가능으로 판정한다")
         void oneCandidateIsMatchable() {
             MatchingCandidate candidate = createCandidate(1L);
+            EvaluatedMatchingCandidate evaluatedCandidate =
+                    evaluatedCandidate(candidate, MatchingAmountType.EXACT);
 
             AutoMatchingResult result =
-                    new AutoMatchingResult(List.of(candidate));
+                    new AutoMatchingResult(List.of(evaluatedCandidate));
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.MATCHABLE);
-            assertThat(result.matchedCandidates()).containsExactly(candidate);
+            assertThat(result.evaluatedCandidates())
+                    .containsExactly(evaluatedCandidate);
         }
 
         @Test
@@ -61,28 +66,52 @@ class AutoMatchingResultTest {
         void multipleCandidatesNeedsCheck() {
             MatchingCandidate first = createCandidate(1L);
             MatchingCandidate second = createCandidate(2L);
+            EvaluatedMatchingCandidate evaluatedFirst =
+                    evaluatedCandidate(first, MatchingAmountType.EXACT);
+            EvaluatedMatchingCandidate evaluatedSecond =
+                    evaluatedCandidate(second, MatchingAmountType.EXACT);
 
             AutoMatchingResult result =
-                    new AutoMatchingResult(List.of(first, second));
+                    new AutoMatchingResult(
+                            List.of(evaluatedFirst, evaluatedSecond)
+                    );
 
             assertThat(result.decisionType())
                     .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
-            assertThat(result.matchedCandidates())
-                    .containsExactly(first, second);
+            assertThat(result.evaluatedCandidates())
+                    .containsExactly(evaluatedFirst, evaluatedSecond);
+        }
+
+        @Test
+        void onePartialCandidateNeedsCheck() {
+            MatchingCandidate candidate = createCandidate(1L);
+            EvaluatedMatchingCandidate evaluatedCandidate =
+                    evaluatedCandidate(candidate, MatchingAmountType.PARTIAL);
+
+            AutoMatchingResult result =
+                    new AutoMatchingResult(List.of(evaluatedCandidate));
+
+            assertThat(result.decisionType())
+                    .isEqualTo(AutoMatchingDecisionType.NEEDS_CHECK);
+            assertThat(result.evaluatedCandidates())
+                    .containsExactly(evaluatedCandidate);
         }
 
         @Test
         @DisplayName("매칭 후보 목록을 방어적으로 복사한다")
         void copiesMatchedCandidatesDefensively() {
             MatchingCandidate candidate = createCandidate(1L);
-            List<MatchingCandidate> candidates = new ArrayList<>();
-            candidates.add(candidate);
+            EvaluatedMatchingCandidate evaluatedCandidate =
+                    evaluatedCandidate(candidate, MatchingAmountType.EXACT);
+            List<EvaluatedMatchingCandidate> candidates = new ArrayList<>();
+            candidates.add(evaluatedCandidate);
 
             AutoMatchingResult result = new AutoMatchingResult(candidates);
 
             candidates.clear();
 
-            assertThat(result.matchedCandidates()).containsExactly(candidate);
+            assertThat(result.evaluatedCandidates())
+                    .containsExactly(evaluatedCandidate);
         }
     }
 
@@ -94,6 +123,13 @@ class AutoMatchingResultTest {
                 "HongGilDong",
                 new BigDecimal("10000")
         );
+    }
+
+    private EvaluatedMatchingCandidate evaluatedCandidate(
+            MatchingCandidate candidate,
+            MatchingAmountType amountMatchType
+    ) {
+        return new EvaluatedMatchingCandidate(candidate, amountMatchType);
     }
 
     private void assertInvalidMatchingRequestThrownBy(

--- a/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/AutoMatchingServiceTest.java
@@ -9,11 +9,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.policy.AutoMatchingJudge;
 import org.teamsai.saibackend.domain.matching.service.AutoMatchingService;
-import org.teamsai.saibackend.domain.matching.service.LoanPaymentService;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
@@ -43,6 +46,9 @@ class AutoMatchingServiceTest {
     @Mock
     private LoanPaymentService loanPaymentService;
 
+    @Mock
+    private BankTransactionMatchCandidateService candidateService;
+
     private final AutoMatchingJudge autoMatchingJudge = new AutoMatchingJudge();
 
     private AutoMatchingService autoMatchingService;
@@ -52,7 +58,8 @@ class AutoMatchingServiceTest {
         autoMatchingService = new AutoMatchingService(
                 autoMatchingJudge,
                 paymentService,
-                loanPaymentService
+                loanPaymentService,
+                candidateService
         );
     }
 
@@ -134,7 +141,6 @@ class AutoMatchingServiceTest {
                     org.mockito.ArgumentMatchers.any(),
                     org.mockito.ArgumentMatchers.any()
             );
-
             assertThat(result.totalTransactionCount()).isEqualTo(1);
             assertThat(result.appliedCount()).isZero();
             assertThat(result.needsCheckCount()).isZero();
@@ -152,6 +158,48 @@ class AutoMatchingServiceTest {
                                     AutoMatchingProcessStatus.UNMATCHED
                             )
                     );
+        }
+
+        @Test
+        void executeSavesPartialCandidateForReview() {
+            MatchingTransaction transaction = transaction(
+                    101L,
+                    AutoMatchingTransactionType.DEPOSIT,
+                    "HongGilDong",
+                    "5000"
+            );
+            MatchingCandidate candidate = candidate(
+                    MatchingTargetType.SETTLEMENT,
+                    1L,
+                    "HongGilDong",
+                    "10000"
+            );
+
+            AutoMatchingExecutionResult result = autoMatchingService.execute(
+                    List.of(transaction),
+                    List.of(candidate)
+            );
+
+            verify(candidateService).saveAll(
+                    101L,
+                    List.of(
+                            new EvaluatedMatchingCandidate(
+                                    candidate,
+                                    MatchingAmountType.PARTIAL
+                            )
+                    )
+            );
+            verify(paymentService, never()).applyAutoMatchedPayment(
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any()
+            );
+            verify(loanPaymentService, never()).applyAutoMatchedPayment(
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any()
+            );
+            assertThat(result.needsCheckCount()).isEqualTo(1);
         }
 
         @Test
@@ -186,6 +234,19 @@ class AutoMatchingServiceTest {
                     org.mockito.ArgumentMatchers.any(),
                     org.mockito.ArgumentMatchers.any(),
                     org.mockito.ArgumentMatchers.any()
+            );
+            verify(candidateService).saveAll(
+                    101L,
+                    List.of(
+                            new EvaluatedMatchingCandidate(
+                                    firstCandidate,
+                                    MatchingAmountType.EXACT
+                            ),
+                            new EvaluatedMatchingCandidate(
+                                    secondCandidate,
+                                    MatchingAmountType.EXACT
+                            )
+                    )
             );
 
             assertThat(result.totalTransactionCount()).isEqualTo(1);
@@ -280,6 +341,13 @@ class AutoMatchingServiceTest {
                     1L,
                     101L,
                     new BigDecimal("10000")
+            );
+            verify(candidateService).saveAll(
+                    101L,
+                    List.of(new EvaluatedMatchingCandidate(
+                            candidate,
+                            MatchingAmountType.EXACT
+                    ))
             );
 
             assertThat(result.totalTransactionCount()).isEqualTo(1);

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingServiceTest.java
@@ -1,26 +1,18 @@
 package org.teamsai.saibackend.domain.matching;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
-import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
-import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
-import org.teamsai.saibackend.domain.matching.service.AutoMatchingService;
 import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
+import org.teamsai.saibackend.domain.matching.service.BankMatchingTransactionService;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
-import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
-import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
-import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
-import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
@@ -33,7 +25,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -43,459 +34,107 @@ import static org.mockito.Mockito.verify;
 @DisplayName("BankMatchingService 단위 테스트")
 class BankMatchingServiceTest {
 
+    private static final Long USER_ID = 10L;
     private static final Long LINKED_ACCOUNT_ID = 1L;
 
     @Mock
     private BankTransactionService bankTransactionService;
 
     @Mock
-    private PaymentObligationMapper paymentObligationMapper;
-
-    @Mock
-    private AutoMatchingService autoMatchingService;
+    private BankMatchingTransactionService transactionService;
 
     @InjectMocks
     private BankMatchingService bankMatchingService;
 
-    @Nested
-    @DisplayName("연결 계좌 기준 자동매칭 실행")
-    class Execute {
+    @Test
+    @DisplayName("처리 대기 거래가 없으면 빈 결과를 반환한다")
+    void returnsEmptyResultWhenPendingDepositsDoNotExist() {
+        given(bankTransactionService
+                .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                .willReturn(List.of());
 
-        @Test
-        @DisplayName("처리 대기 입금 거래가 없으면 빈 결과를 반환한다")
-        void returnsEmptyResultWhenPendingDepositsDoNotExist() {
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of());
+        AutoMatchingExecutionResult result =
+                bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID);
 
-            AutoMatchingExecutionResult result =
-                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            assertThat(result.totalTransactionCount()).isZero();
-            assertThat(result.transactionResults()).isEmpty();
-            verify(paymentObligationMapper, never())
-                    .findMatchCandidatesByLinkedAccountId(any(), any());
-            verify(autoMatchingService, never()).execute(any(), any());
-        }
-
-        @Test
-        @DisplayName("유효한 입금 거래와 정산 후보로 자동매칭을 실행한다")
-        void executesAutoMatchingWithPendingDepositsAndCandidates() {
-            BankTransactionDTO transaction = bankTransaction(
-                    101L,
-                    "Hong Gil Dong"
-            );
-            MatchingCandidate candidate = candidate();
-            AutoMatchingExecutionResult matchingResult = executionResult(
-                    result(101L, AutoMatchingProcessStatus.APPLIED)
-            );
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(transaction));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(
-                            LINKED_ACCOUNT_ID,
-                            transaction.getTransactionAt()
-                    ))
-                    .willReturn(List.of(candidate));
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(matchingResult);
-
-            AutoMatchingExecutionResult result =
-                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            ArgumentCaptor<List<MatchingTransaction>> transactionsCaptor =
-                    ArgumentCaptor.forClass(List.class);
-            verify(autoMatchingService).execute(
-                    transactionsCaptor.capture(),
-                    org.mockito.ArgumentMatchers.eq(List.of(candidate))
-            );
-
-            assertThat(transactionsCaptor.getValue())
-                    .extracting(
-                            MatchingTransaction::transactionId,
-                            MatchingTransaction::transactionType,
-                            MatchingTransaction::amount,
-                            MatchingTransaction::counterpartyName,
-                            MatchingTransaction::transactionAt
-                    )
-                    .containsExactly(tuple(
-                            101L,
-                            AutoMatchingTransactionType.DEPOSIT,
-                            new BigDecimal("10000.00"),
-                            "Hong Gil Dong",
-                            transaction.getTransactionAt()
-                    ));
-            assertThat(result.transactionResults())
-                    .extracting(
-                            AutoMatchingTransactionResult::transactionId,
-                            AutoMatchingTransactionResult::processStatus
-                    )
-                    .containsExactly(tuple(
-                            101L,
-                            AutoMatchingProcessStatus.APPLIED
-                    ));
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.APPLIED
-            );
-        }
-
-        @Test
-        @DisplayName("입금자명이 없으면 자동매칭 없이 확인 필요로 처리한다")
-        void classifiesBlankCounterpartyNameAsNeedsCheck() {
-            BankTransactionDTO transaction = bankTransaction(101L, " ");
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(transaction));
-
-            AutoMatchingExecutionResult result =
-                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            assertThat(result.totalTransactionCount()).isEqualTo(1);
-            assertThat(result.needsCheckCount()).isEqualTo(1);
-            assertThat(result.transactionResults())
-                    .extracting(
-                            AutoMatchingTransactionResult::transactionId,
-                            AutoMatchingTransactionResult::processStatus
-                    )
-                    .containsExactly(tuple(
-                            101L,
-                            AutoMatchingProcessStatus.NEEDS_CHECK
-                    ));
-            verify(paymentObligationMapper, never())
-                    .findMatchCandidatesByLinkedAccountId(any(), any());
-            verify(autoMatchingService, never()).execute(any(), any());
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.NEEDS_CHECK
-            );
-        }
-
-        @Test
-        @DisplayName("원본 거래 조회 순서대로 최종 결과를 재조합한다")
-        void preservesOriginalTransactionOrder() {
-            BankTransactionDTO first = bankTransaction(101L, "Hong Gil Dong");
-            BankTransactionDTO second = bankTransaction(102L, null);
-            BankTransactionDTO third = bankTransaction(103L, "Kim Chul Soo");
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(first, second, third));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(any(), any()))
-                    .willReturn(List.of(candidate()));
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(
-                            executionResult(
-                                    result(
-                                            101L,
-                                            AutoMatchingProcessStatus.APPLIED
-                                    )
-                            ),
-                            executionResult(
-                                    result(
-                                            103L,
-                                            AutoMatchingProcessStatus.UNMATCHED
-                                    )
-                            )
-                    );
-
-            AutoMatchingExecutionResult result =
-                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            assertThat(result.transactionResults())
-                    .extracting(
-                            AutoMatchingTransactionResult::transactionId,
-                            AutoMatchingTransactionResult::processStatus
-                    )
-                    .containsExactly(
-                            tuple(101L, AutoMatchingProcessStatus.APPLIED),
-                            tuple(102L, AutoMatchingProcessStatus.NEEDS_CHECK),
-                            tuple(103L, AutoMatchingProcessStatus.UNMATCHED)
-                    );
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.APPLIED
-            );
-            verify(bankTransactionService).updateStatus(
-                    102L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.NEEDS_CHECK
-            );
-            verify(bankTransactionService).updateStatus(
-                    103L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.UNMATCHED
-            );
-        }
-
-        @Test
-        @DisplayName("자동매칭 결과별 은행 거래 상태를 변경한다")
-        void doesNotReuseCandidateAfterPreviousTransactionIsApplied() {
-            BankTransactionDTO first = bankTransaction(
-                    101L,
-                    "Hong Gil Dong",
-                    LocalDateTime.of(2026, 8, 5, 10, 0)
-            );
-            BankTransactionDTO second = bankTransaction(
-                    102L,
-                    "Hong Gil Dong",
-                    LocalDateTime.of(2026, 8, 5, 11, 0)
-            );
-            MatchingCandidate candidate = candidate();
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(first, second));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(
-                            LINKED_ACCOUNT_ID,
-                            first.getTransactionAt()
-                    ))
-                    .willReturn(List.of(candidate));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(
-                            LINKED_ACCOUNT_ID,
-                            second.getTransactionAt()
-                    ))
-                    .willReturn(List.of());
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(
-                            executionResult(
-                                    result(
-                                            101L,
-                                            AutoMatchingProcessStatus.APPLIED
-                                    )
-                            ),
-                            executionResult(
-                                    result(
-                                            102L,
-                                            AutoMatchingProcessStatus.UNMATCHED
-                                    )
-                            )
-                    );
-
-            AutoMatchingExecutionResult result =
-                    bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            ArgumentCaptor<List<MatchingCandidate>> candidatesCaptor =
-                    ArgumentCaptor.forClass(List.class);
-            verify(autoMatchingService, org.mockito.Mockito.times(2))
-                    .execute(any(), candidatesCaptor.capture());
-
-            assertThat(candidatesCaptor.getAllValues())
-                    .containsExactly(List.of(candidate), List.of());
-            assertThat(result.transactionResults())
-                    .extracting(
-                            AutoMatchingTransactionResult::transactionId,
-                            AutoMatchingTransactionResult::processStatus
-                    )
-                    .containsExactly(
-                            tuple(101L, AutoMatchingProcessStatus.APPLIED),
-                            tuple(102L, AutoMatchingProcessStatus.UNMATCHED)
-                    );
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.APPLIED
-            );
-            verify(bankTransactionService).updateStatus(
-                    102L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.UNMATCHED
-            );
-        }
-
-        @Test
-        @DisplayName("자동매칭 결과별 은행 거래 상태를 변경한다")
-        void updatesBankTransactionStatusByResultStatus() {
-            BankTransactionDTO applied = bankTransaction(
-                    101L,
-                    "Hong Gil Dong"
-            );
-            BankTransactionDTO needsCheck = bankTransaction(
-                    102L,
-                    "Kim Chul Soo"
-            );
-            BankTransactionDTO unmatched = bankTransaction(
-                    103L,
-                    "Lee Young Hee"
-            );
-            BankTransactionDTO failed = bankTransaction(
-                    104L,
-                    "Park Min Soo"
-            );
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(
-                            applied,
-                            needsCheck,
-                            unmatched,
-                            failed
-                    ));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(any(), any()))
-                    .willReturn(List.of(candidate()));
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(
-                            executionResult(
-                                    result(
-                                            101L,
-                                            AutoMatchingProcessStatus.APPLIED
-                                    )
-                            ),
-                            executionResult(
-                                    result(
-                                            102L,
-                                            AutoMatchingProcessStatus.NEEDS_CHECK
-                                    )
-                            ),
-                            executionResult(
-                                    result(
-                                            103L,
-                                            AutoMatchingProcessStatus.UNMATCHED
-                                    )
-                            ),
-                            executionResult(
-                                    result(
-                                            104L,
-                                            AutoMatchingProcessStatus.FAILED
-                                    )
-                            )
-                    );
-
-            bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.APPLIED
-            );
-            verify(bankTransactionService).updateStatus(
-                    102L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.NEEDS_CHECK
-            );
-            verify(bankTransactionService).updateStatus(
-                    103L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.UNMATCHED
-            );
-            verify(bankTransactionService).updateStatus(
-                    104L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.FAILED
-            );
-        }
-
-        @Test
-        @DisplayName("중복 결과는 자동 반영 상태로 저장한다")
-        void updatesDuplicatedResultAsApplied() {
-            BankTransactionDTO transaction = bankTransaction(
-                    101L,
-                    "Hong Gil Dong"
-            );
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(transaction));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(
-                            LINKED_ACCOUNT_ID,
-                            transaction.getTransactionAt()
-                    ))
-                    .willReturn(List.of(candidate()));
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(executionResult(
-                            result(
-                                    101L,
-                                    AutoMatchingProcessStatus.DUPLICATE
-                            )
-                    ));
-
-            bankMatchingService.execute(LINKED_ACCOUNT_ID);
-
-            verify(bankTransactionService).updateStatus(
-                    101L,
-                    BankTransactionProcessingStatus.PENDING,
-                    BankTransactionProcessingStatus.APPLIED
-            );
-        }
-
-        @Test
-        @DisplayName("상태 변경 실패 예외는 그대로 전파한다")
-        void propagatesStatusUpdateFailure() {
-            BankTransactionDTO transaction = bankTransaction(
-                    101L,
-                    "Hong Gil Dong"
-            );
-
-            given(bankTransactionService
-                    .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
-                    .willReturn(List.of(transaction));
-            given(paymentObligationMapper
-                    .findMatchCandidatesByLinkedAccountId(
-                            LINKED_ACCOUNT_ID,
-                            transaction.getTransactionAt()
-                    ))
-                    .willReturn(List.of(candidate()));
-            given(autoMatchingService.execute(any(), any()))
-                    .willReturn(executionResult(
-                            result(101L, AutoMatchingProcessStatus.FAILED)
-                    ));
-            willThrow(BankTransactionErrorCode
-                    .BANK_TRANSACTION_STATUS_UPDATE_FAILED
-                    .toException())
-                    .given(bankTransactionService)
-                    .updateStatus(
-                            101L,
-                            BankTransactionProcessingStatus.PENDING,
-                            BankTransactionProcessingStatus.FAILED
-                    );
-
-            assertThatThrownBy(
-                    () -> bankMatchingService.execute(LINKED_ACCOUNT_ID)
-            ).isInstanceOf(DomainException.class);
-        }
-
-        @Test
-        @DisplayName("연결 계좌 ID가 올바르지 않으면 예외가 발생한다")
-        void throwsExceptionWhenLinkedAccountIdIsInvalid() {
-            assertThatThrownBy(() -> bankMatchingService.execute(0L))
-                    .isInstanceOfSatisfying(
-                            DomainException.class,
-                            exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(
-                                            MatchingErrorCode
-                                                    .INVALID_MATCHING_REQUEST
-                                    )
-                    );
-        }
-    }
-
-    private BankTransactionDTO bankTransaction(
-            Long bankTransactionId,
-            String counterpartyName
-    ) {
-        return bankTransaction(
-                bankTransactionId,
-                counterpartyName,
-                LocalDateTime.of(2026, 8, 5, 10, 0)
+        assertThat(result.totalTransactionCount()).isZero();
+        assertThat(result.transactionResults()).isEmpty();
+        verify(transactionService, never()).process(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
         );
     }
 
-    private BankTransactionDTO bankTransaction(
-            Long bankTransactionId,
-            String counterpartyName,
-            LocalDateTime transactionAt
-    ) {
+    @Test
+    @DisplayName("각 거래를 조회 순서대로 처리하고 결과를 집계한다")
+    void processesTransactionsInOrderAndAggregatesResults() {
+        BankTransactionDTO first = bankTransaction(101L);
+        BankTransactionDTO second = bankTransaction(102L);
+        BankTransactionDTO third = bankTransaction(103L);
+
+        given(bankTransactionService
+                .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                .willReturn(List.of(first, second, third));
+        given(transactionService.process(USER_ID, LINKED_ACCOUNT_ID, first))
+                .willReturn(result(101L, AutoMatchingProcessStatus.APPLIED));
+        given(transactionService.process(USER_ID, LINKED_ACCOUNT_ID, second))
+                .willReturn(result(102L, AutoMatchingProcessStatus.NEEDS_CHECK));
+        given(transactionService.process(USER_ID, LINKED_ACCOUNT_ID, third))
+                .willReturn(result(103L, AutoMatchingProcessStatus.UNMATCHED));
+
+        AutoMatchingExecutionResult result =
+                bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID);
+
+        assertThat(result.totalTransactionCount()).isEqualTo(3);
+        assertThat(result.appliedCount()).isEqualTo(1);
+        assertThat(result.needsCheckCount()).isEqualTo(1);
+        assertThat(result.unmatchedCount()).isEqualTo(1);
+        assertThat(result.transactionResults())
+                .extracting(
+                        AutoMatchingTransactionResult::transactionId,
+                        AutoMatchingTransactionResult::processStatus
+                )
+                .containsExactly(
+                        tuple(101L, AutoMatchingProcessStatus.APPLIED),
+                        tuple(102L, AutoMatchingProcessStatus.NEEDS_CHECK),
+                        tuple(103L, AutoMatchingProcessStatus.UNMATCHED)
+                );
+    }
+
+    @Test
+    @DisplayName("단건 처리 실패를 그대로 전파한다")
+    void propagatesTransactionProcessingFailure() {
+        BankTransactionDTO transaction = bankTransaction(101L);
+        DomainException exception = MatchingErrorCode
+                .INVALID_MATCHING_REQUEST
+                .toException();
+
+        given(bankTransactionService
+                .findPendingDepositsByLinkedAccountId(LINKED_ACCOUNT_ID))
+                .willReturn(List.of(transaction));
+        willThrow(exception)
+                .given(transactionService)
+                .process(USER_ID, LINKED_ACCOUNT_ID, transaction);
+
+        assertThatThrownBy(
+                () -> bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID)
+        ).isSameAs(exception);
+    }
+
+    @Test
+    @DisplayName("연결 계좌 ID가 유효하지 않으면 예외가 발생한다")
+    void throwsExceptionWhenLinkedAccountIdIsInvalid() {
+        assertThatThrownBy(() -> bankMatchingService.execute(USER_ID, 0L))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        MatchingErrorCode.INVALID_MATCHING_REQUEST
+                                )
+                );
+    }
+
+    private BankTransactionDTO bankTransaction(Long bankTransactionId) {
         return BankTransactionDTO.builder()
                 .bankTransactionId(bankTransactionId)
                 .linkedAccountId(LINKED_ACCOUNT_ID)
@@ -503,20 +142,10 @@ class BankMatchingServiceTest {
                 .amount(new BigDecimal("10000.00"))
                 .transactionType(BankTransactionType.DEPOSIT)
                 .processingStatus(BankTransactionProcessingStatus.PENDING)
-                .transactionAt(transactionAt)
-                .counterpartyName(counterpartyName)
+                .transactionAt(LocalDateTime.of(2026, 8, 5, 10, 0))
+                .counterpartyName("Hong Gil Dong")
                 .syncedAt(LocalDateTime.of(2026, 8, 5, 10, 5))
                 .build();
-    }
-
-    private MatchingCandidate candidate() {
-        return new MatchingCandidate(
-                MatchingTargetType.SETTLEMENT,
-                1L,
-                1L,
-                "Hong Gil Dong",
-                new BigDecimal("10000.00")
-        );
     }
 
     private AutoMatchingTransactionResult result(
@@ -526,37 +155,6 @@ class BankMatchingServiceTest {
         return new AutoMatchingTransactionResult(
                 transactionId,
                 processStatus
-        );
-    }
-
-    private AutoMatchingExecutionResult executionResult(
-            AutoMatchingTransactionResult... transactionResults
-    ) {
-        int appliedCount = 0;
-        int needsCheckCount = 0;
-        int unmatchedCount = 0;
-        int duplicateCount = 0;
-        int failedCount = 0;
-
-        for (AutoMatchingTransactionResult transactionResult
-                : transactionResults) {
-            switch (transactionResult.processStatus()) {
-                case APPLIED -> appliedCount++;
-                case NEEDS_CHECK -> needsCheckCount++;
-                case UNMATCHED -> unmatchedCount++;
-                case DUPLICATE -> duplicateCount++;
-                case FAILED -> failedCount++;
-            }
-        }
-
-        return new AutoMatchingExecutionResult(
-                transactionResults.length,
-                appliedCount,
-                needsCheckCount,
-                unmatchedCount,
-                duplicateCount,
-                failedCount,
-                List.of(transactionResults)
         );
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
@@ -71,6 +71,7 @@ class BankMatchingTransactionServiceTest {
     @DisplayName("상대방명이 없으면 후보를 조회하지 않고 미매칭으로 변경한다")
     void classifiesBlankCounterpartyNameAsUnmatched() {
         BankTransactionDTO transaction = bankTransaction(101L, " ");
+        givenLockedTransaction(transaction);
 
         AutoMatchingTransactionResult result =
                 transactionService.process(
@@ -94,10 +95,15 @@ class BankMatchingTransactionServiceTest {
     @Test
     @DisplayName("후보를 조회해 자동매칭하고 은행 거래 상태를 변경한다")
     void executesAutoMatchingAndUpdatesStatus() {
-        BankTransactionDTO transaction = bankTransaction(
+        BankTransactionDTO staleTransaction = bankTransaction(
+                101L,
+                "Old Name"
+        );
+        BankTransactionDTO lockedTransaction = bankTransaction(
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(lockedTransaction);
         MatchingCandidate candidate = candidate();
         AutoMatchingTransactionResult transactionResult = result(
                 101L,
@@ -106,7 +112,7 @@ class BankMatchingTransactionServiceTest {
 
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
-                transaction.getTransactionAt()
+                lockedTransaction.getTransactionAt()
         )).willReturn(List.of(candidate));
         given(autoMatchingService.execute(any(), any()))
                 .willReturn(executionResult(transactionResult));
@@ -115,7 +121,7 @@ class BankMatchingTransactionServiceTest {
                 transactionService.process(
                         USER_ID,
                         LINKED_ACCOUNT_ID,
-                        transaction
+                        staleTransaction
                 );
 
         ArgumentCaptor<List<MatchingTransaction>> transactionsCaptor =
@@ -149,6 +155,7 @@ class BankMatchingTransactionServiceTest {
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(transaction);
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
                 transaction.getTransactionAt()
@@ -175,6 +182,7 @@ class BankMatchingTransactionServiceTest {
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(transaction);
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
                 transaction.getTransactionAt()
@@ -208,6 +216,7 @@ class BankMatchingTransactionServiceTest {
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(transaction);
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
                 transaction.getTransactionAt()
@@ -243,6 +252,7 @@ class BankMatchingTransactionServiceTest {
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(transaction);
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
                 transaction.getTransactionAt()
@@ -284,6 +294,7 @@ class BankMatchingTransactionServiceTest {
                 101L,
                 "Hong Gil Dong"
         );
+        givenLockedTransaction(transaction);
         given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
                 LINKED_ACCOUNT_ID,
                 transaction.getTransactionAt()
@@ -315,9 +326,52 @@ class BankMatchingTransactionServiceTest {
         );
     }
 
+    @Test
+    @DisplayName("잠금 조회한 거래가 이미 처리됐으면 자동매칭을 다시 실행하지 않는다")
+    void skipsTransactionAlreadyProcessedByConcurrentRequest() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong",
+                BankTransactionProcessingStatus.APPLIED
+        );
+        givenLockedTransaction(transaction);
+
+        AutoMatchingTransactionResult result = transactionService.process(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                transaction
+        );
+
+        assertThat(result.processStatus())
+                .isEqualTo(AutoMatchingProcessStatus.DUPLICATE);
+        verify(paymentObligationMapper, never())
+                .findMatchCandidatesByLinkedAccountId(any(), any());
+        verify(autoMatchingService, never()).execute(any(), any());
+        verify(candidateService, never())
+                .findAllByBankTransactionId(any());
+        verify(notificationService, never()).createIfAbsent(
+                any(), any(), any(), any(), any(), any()
+        );
+        verify(bankTransactionService, never()).updateStatus(
+                any(), any(), any()
+        );
+    }
+
     private BankTransactionDTO bankTransaction(
             Long bankTransactionId,
             String counterpartyName
+    ) {
+        return bankTransaction(
+                bankTransactionId,
+                counterpartyName,
+                BankTransactionProcessingStatus.PENDING
+        );
+    }
+
+    private BankTransactionDTO bankTransaction(
+            Long bankTransactionId,
+            String counterpartyName,
+            BankTransactionProcessingStatus processingStatus
     ) {
         return BankTransactionDTO.builder()
                 .bankTransactionId(bankTransactionId)
@@ -325,11 +379,18 @@ class BankMatchingTransactionServiceTest {
                 .externalTransactionId("external-" + bankTransactionId)
                 .amount(new BigDecimal("10000.00"))
                 .transactionType(BankTransactionType.DEPOSIT)
-                .processingStatus(BankTransactionProcessingStatus.PENDING)
+                .processingStatus(processingStatus)
                 .transactionAt(LocalDateTime.of(2026, 8, 5, 10, 0))
                 .counterpartyName(counterpartyName)
                 .syncedAt(LocalDateTime.of(2026, 8, 5, 10, 5))
                 .build();
+    }
+
+    private void givenLockedTransaction(BankTransactionDTO transaction) {
+        given(bankTransactionService.findByIdAndLinkedAccountIdForUpdate(
+                transaction.getBankTransactionId(),
+                LINKED_ACCOUNT_ID
+        )).willReturn(transaction);
     }
 
     private MatchingCandidate candidate() {

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
@@ -1,0 +1,400 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
+import org.teamsai.saibackend.domain.matching.service.AutoMatchingService;
+import org.teamsai.saibackend.domain.matching.service.BankMatchingTransactionService;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.notification.service.NotificationService;
+import org.teamsai.saibackend.domain.notification.type.NotificationType;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankMatchingTransactionService 단위 테스트")
+class BankMatchingTransactionServiceTest {
+
+    private static final Long USER_ID = 10L;
+    private static final Long LINKED_ACCOUNT_ID = 1L;
+
+    @Mock
+    private PaymentObligationMapper paymentObligationMapper;
+
+    @Mock
+    private AutoMatchingService autoMatchingService;
+
+    @Mock
+    private BankTransactionService bankTransactionService;
+
+    @Mock
+    private BankTransactionMatchCandidateService candidateService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private BankMatchingTransactionService transactionService;
+
+    @Test
+    @DisplayName("상대방명이 없으면 후보를 조회하지 않고 미매칭으로 변경한다")
+    void classifiesBlankCounterpartyNameAsUnmatched() {
+        BankTransactionDTO transaction = bankTransaction(101L, " ");
+
+        AutoMatchingTransactionResult result =
+                transactionService.process(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        transaction
+                );
+
+        assertThat(result.processStatus())
+                .isEqualTo(AutoMatchingProcessStatus.UNMATCHED);
+        verify(paymentObligationMapper, never())
+                .findMatchCandidatesByLinkedAccountId(any(), any());
+        verify(autoMatchingService, never()).execute(any(), any());
+        verify(bankTransactionService).updateStatus(
+                101L,
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.UNMATCHED
+        );
+    }
+
+    @Test
+    @DisplayName("후보를 조회해 자동매칭하고 은행 거래 상태를 변경한다")
+    void executesAutoMatchingAndUpdatesStatus() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        MatchingCandidate candidate = candidate();
+        AutoMatchingTransactionResult transactionResult = result(
+                101L,
+                AutoMatchingProcessStatus.APPLIED
+        );
+
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult(transactionResult));
+
+        AutoMatchingTransactionResult result =
+                transactionService.process(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        transaction
+                );
+
+        ArgumentCaptor<List<MatchingTransaction>> transactionsCaptor =
+                ArgumentCaptor.forClass(List.class);
+        verify(autoMatchingService).execute(
+                transactionsCaptor.capture(),
+                org.mockito.ArgumentMatchers.eq(List.of(candidate))
+        );
+
+        MatchingTransaction matchingTransaction =
+                transactionsCaptor.getValue().get(0);
+        assertThat(matchingTransaction.transactionId()).isEqualTo(101L);
+        assertThat(matchingTransaction.transactionType())
+                .isEqualTo(AutoMatchingTransactionType.DEPOSIT);
+        assertThat(matchingTransaction.amount())
+                .isEqualByComparingTo("10000.00");
+        assertThat(matchingTransaction.counterpartyName())
+                .isEqualTo("Hong Gil Dong");
+        assertThat(result).isEqualTo(transactionResult);
+        verify(bankTransactionService).updateStatus(
+                101L,
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.APPLIED
+        );
+    }
+
+    @Test
+    @DisplayName("중복 납부 결과는 이미 반영된 거래로 저장한다")
+    void updatesDuplicatedResultAsApplied() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate()));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult(result(
+                        101L,
+                        AutoMatchingProcessStatus.DUPLICATE
+                )));
+
+        transactionService.process(USER_ID, LINKED_ACCOUNT_ID, transaction);
+
+        verify(bankTransactionService).updateStatus(
+                101L,
+                BankTransactionProcessingStatus.PENDING,
+                BankTransactionProcessingStatus.APPLIED
+        );
+    }
+
+    @Test
+    @DisplayName("자동매칭 결과가 거래 한 건이 아니면 예외가 발생한다")
+    void throwsExceptionWhenMatchingResultCountIsInvalid() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate()));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult());
+
+        assertThatThrownBy(
+                () -> transactionService.process(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        transaction
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(MatchingErrorCode.INVALID_MATCHING_REQUEST)
+        );
+
+        verify(bankTransactionService, never()).updateStatus(
+                any(),
+                any(),
+                any()
+        );
+    }
+
+    @Test
+    @DisplayName("상태 변경 실패를 그대로 전파한다")
+    void propagatesStatusUpdateFailure() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate()));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult(result(
+                        101L,
+                        AutoMatchingProcessStatus.NEEDS_CHECK
+                )));
+        willThrow(BankTransactionErrorCode
+                .BANK_TRANSACTION_STATUS_UPDATE_FAILED
+                .toException())
+                .given(bankTransactionService)
+                .updateStatus(
+                        101L,
+                        BankTransactionProcessingStatus.PENDING,
+                        BankTransactionProcessingStatus.NEEDS_CHECK
+                );
+
+        assertThatThrownBy(
+                () -> transactionService.process(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        transaction
+                )
+        ).isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("정산과 차용증 후보가 모두 있으면 매칭 검토 알림을 생성한다")
+    void createsNotificationForCrossDomainCandidates() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate()));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult(result(
+                        101L,
+                        AutoMatchingProcessStatus.NEEDS_CHECK
+                )));
+        given(candidateService.findAllByBankTransactionId(101L))
+                .willReturn(List.of(
+                        candidateDto(
+                                1L,
+                                MatchingTargetType.SETTLEMENT
+                        ),
+                        candidateDto(2L, MatchingTargetType.LOAN)
+                ));
+
+        transactionService.process(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                transaction
+        );
+
+        verify(notificationService).createIfAbsent(
+                USER_ID,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                "입금 거래 확인이 필요합니다.",
+                "Hong Gil Dong님의 10000.00원 입금에 정산과 차용증 후보가 모두 발견되었습니다.",
+                101L,
+                LINKED_ACCOUNT_ID
+        );
+    }
+
+    @Test
+    @DisplayName("한 도메인의 후보만 있으면 매칭 검토 알림을 생성하지 않는다")
+    void doesNotCreateNotificationForSingleDomainCandidates() {
+        BankTransactionDTO transaction = bankTransaction(
+                101L,
+                "Hong Gil Dong"
+        );
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt()
+        )).willReturn(List.of(candidate()));
+        given(autoMatchingService.execute(any(), any()))
+                .willReturn(executionResult(result(
+                        101L,
+                        AutoMatchingProcessStatus.NEEDS_CHECK
+                )));
+        given(candidateService.findAllByBankTransactionId(101L))
+                .willReturn(List.of(candidateDto(
+                        1L,
+                        MatchingTargetType.SETTLEMENT
+                )));
+
+        transactionService.process(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                transaction
+        );
+
+        verify(notificationService, never()).createIfAbsent(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+        );
+    }
+
+    private BankTransactionDTO bankTransaction(
+            Long bankTransactionId,
+            String counterpartyName
+    ) {
+        return BankTransactionDTO.builder()
+                .bankTransactionId(bankTransactionId)
+                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .externalTransactionId("external-" + bankTransactionId)
+                .amount(new BigDecimal("10000.00"))
+                .transactionType(BankTransactionType.DEPOSIT)
+                .processingStatus(BankTransactionProcessingStatus.PENDING)
+                .transactionAt(LocalDateTime.of(2026, 8, 5, 10, 0))
+                .counterpartyName(counterpartyName)
+                .syncedAt(LocalDateTime.of(2026, 8, 5, 10, 5))
+                .build();
+    }
+
+    private MatchingCandidate candidate() {
+        return new MatchingCandidate(
+                MatchingTargetType.SETTLEMENT,
+                1L,
+                1L,
+                "Hong Gil Dong",
+                new BigDecimal("10000.00")
+        );
+    }
+
+    private BankTransactionMatchCandidateDTO candidateDto(
+            Long matchCandidateId,
+            MatchingTargetType targetType
+    ) {
+        return BankTransactionMatchCandidateDTO.builder()
+                .matchCandidateId(matchCandidateId)
+                .bankTransactionId(101L)
+                .targetType(targetType)
+                .targetId(matchCandidateId * 10)
+                .expectedRemainingAmount(new BigDecimal("10000.00"))
+                .amountMatchType(MatchingAmountType.EXACT)
+                .createdAt(LocalDateTime.of(2026, 8, 5, 10, 5))
+                .build();
+    }
+
+    private AutoMatchingTransactionResult result(
+            Long transactionId,
+            AutoMatchingProcessStatus processStatus
+    ) {
+        return new AutoMatchingTransactionResult(
+                transactionId,
+                processStatus
+        );
+    }
+
+    private AutoMatchingExecutionResult executionResult(
+            AutoMatchingTransactionResult... transactionResults
+    ) {
+        int appliedCount = 0;
+        int needsCheckCount = 0;
+        int unmatchedCount = 0;
+        int duplicateCount = 0;
+        int failedCount = 0;
+
+        for (AutoMatchingTransactionResult transactionResult
+                : transactionResults) {
+            switch (transactionResult.processStatus()) {
+                case APPLIED -> appliedCount++;
+                case NEEDS_CHECK -> needsCheckCount++;
+                case UNMATCHED -> unmatchedCount++;
+                case DUPLICATE -> duplicateCount++;
+                case FAILED -> failedCount++;
+            }
+        }
+
+        return new AutoMatchingExecutionResult(
+                transactionResults.length,
+                appliedCount,
+                needsCheckCount,
+                unmatchedCount,
+                duplicateCount,
+                failedCount,
+                List.of(transactionResults)
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
@@ -1,0 +1,258 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchCandidateMapper;
+import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
+import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BankTransactionMatchCandidateServiceTest {
+
+    @Mock
+    private BankTransactionMatchCandidateMapper candidateMapper;
+
+    private BankTransactionMatchCandidateService candidateService;
+
+    @BeforeEach
+    void setUp() {
+        candidateService = new BankTransactionMatchCandidateService(
+                candidateMapper
+        );
+    }
+
+    @Test
+    void savesEvaluatedCandidatesAsDtos() {
+        Long bankTransactionId = 100L;
+        EvaluatedMatchingCandidate settlementCandidate =
+                evaluatedCandidate(
+                        MatchingTargetType.SETTLEMENT,
+                        10L,
+                        "10000",
+                        MatchingAmountType.PARTIAL
+                );
+        EvaluatedMatchingCandidate loanCandidate =
+                evaluatedCandidate(
+                        MatchingTargetType.LOAN,
+                        20L,
+                        "20000",
+                        MatchingAmountType.EXACT
+                );
+
+        when(candidateMapper.insertAll(org.mockito.ArgumentMatchers.anyList()))
+                .thenReturn(2);
+
+        candidateService.saveAll(
+                bankTransactionId,
+                List.of(settlementCandidate, loanCandidate)
+        );
+
+        ArgumentCaptor<List<BankTransactionMatchCandidateDTO>> captor =
+                ArgumentCaptor.forClass(List.class);
+        verify(candidateMapper).insertAll(captor.capture());
+
+        List<BankTransactionMatchCandidateDTO> savedCandidates =
+                captor.getValue();
+
+        assertThat(savedCandidates).hasSize(2);
+        assertThat(savedCandidates)
+                .extracting(
+                        BankTransactionMatchCandidateDTO::getBankTransactionId,
+                        BankTransactionMatchCandidateDTO::getTargetType,
+                        BankTransactionMatchCandidateDTO::getTargetId,
+                        BankTransactionMatchCandidateDTO::getExpectedRemainingAmount,
+                        BankTransactionMatchCandidateDTO::getAmountMatchType
+                )
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                100L,
+                                MatchingTargetType.SETTLEMENT,
+                                10L,
+                                new BigDecimal("10000"),
+                                MatchingAmountType.PARTIAL
+                        ),
+                        org.assertj.core.groups.Tuple.tuple(
+                                100L,
+                                MatchingTargetType.LOAN,
+                                20L,
+                                new BigDecimal("20000"),
+                                MatchingAmountType.EXACT
+                        )
+                );
+        assertThat(savedCandidates)
+                .extracting(BankTransactionMatchCandidateDTO::getCreatedAt)
+                .doesNotContainNull()
+                .allMatch(createdAt -> createdAt.equals(
+                        savedCandidates.get(0).getCreatedAt()
+                ));
+    }
+
+    @Test
+    void doesNotCallMapperWhenCandidatesAreEmpty() {
+        candidateService.saveAll(100L, List.of());
+
+        verify(candidateMapper, never()).insertAll(
+                org.mockito.ArgumentMatchers.anyList()
+        );
+    }
+
+    @Test
+    void failsWhenInsertedCountDoesNotMatchCandidateCount() {
+        EvaluatedMatchingCandidate candidate = evaluatedCandidate(
+                MatchingTargetType.SETTLEMENT,
+                10L,
+                "10000",
+                MatchingAmountType.EXACT
+        );
+
+        when(candidateMapper.insertAll(org.mockito.ArgumentMatchers.anyList()))
+                .thenReturn(0);
+
+        assertThatThrownBy(() -> candidateService.saveAll(
+                100L,
+                List.of(candidate)
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode
+                                        .MATCHING_CANDIDATE_SAVE_FAILED
+                        )
+        );
+    }
+
+    @Test
+    void failsWhenSaveRequestContainsNullCandidate() {
+        assertThatThrownBy(() -> candidateService.saveAll(
+                100L,
+                java.util.Arrays.asList(
+                        (EvaluatedMatchingCandidate) null
+                )
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(MatchingErrorCode.INVALID_MATCHING_REQUEST)
+        );
+    }
+
+    @Test
+    void returnsCandidatesForBankTransaction() {
+        BankTransactionMatchCandidateDTO candidate = dto(1L, 100L);
+
+        when(candidateMapper.findAllByBankTransactionId(100L))
+                .thenReturn(List.of(candidate));
+
+        List<BankTransactionMatchCandidateDTO> result =
+                candidateService.findAllByBankTransactionId(100L);
+
+        assertThat(result).containsExactly(candidate);
+    }
+
+    @Test
+    void returnsCandidatesWithParticipantNameForReview() {
+        BankTransactionMatchCandidateQueryDTO candidate =
+                BankTransactionMatchCandidateQueryDTO.builder()
+                        .matchCandidateId(1L)
+                        .bankTransactionId(100L)
+                        .targetType(MatchingTargetType.SETTLEMENT)
+                        .targetId(10L)
+                        .participantName("홍길동")
+                        .expectedRemainingAmount(
+                                new BigDecimal("10000")
+                        )
+                        .amountMatchType(MatchingAmountType.EXACT)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        when(candidateMapper.findAllForReviewByBankTransactionId(100L))
+                .thenReturn(List.of(candidate));
+
+        List<BankTransactionMatchCandidateQueryDTO> result =
+                candidateService.findAllForReviewByBankTransactionId(100L);
+
+        assertThat(result).containsExactly(candidate);
+    }
+
+    @Test
+    void returnsCandidateBelongingToBankTransaction() {
+        BankTransactionMatchCandidateDTO candidate = dto(1L, 100L);
+
+        when(candidateMapper.findByIdAndBankTransactionId(1L, 100L))
+                .thenReturn(Optional.of(candidate));
+
+        BankTransactionMatchCandidateDTO result =
+                candidateService.findByIdAndBankTransactionId(1L, 100L);
+
+        assertThat(result).isSameAs(candidate);
+    }
+
+    @Test
+    void failsWhenCandidateDoesNotBelongToBankTransaction() {
+        when(candidateMapper.findByIdAndBankTransactionId(1L, 100L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                candidateService.findByIdAndBankTransactionId(1L, 100L)
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode.MATCHING_CANDIDATE_NOT_FOUND
+                        )
+        );
+    }
+
+    private EvaluatedMatchingCandidate evaluatedCandidate(
+            MatchingTargetType targetType,
+            Long targetId,
+            String remainingAmount,
+            MatchingAmountType amountMatchType
+    ) {
+        MatchingCandidate candidate = new MatchingCandidate(
+                targetType,
+                targetId,
+                targetId,
+                "HongGilDong",
+                new BigDecimal(remainingAmount)
+        );
+
+        return new EvaluatedMatchingCandidate(candidate, amountMatchType);
+    }
+
+    private BankTransactionMatchCandidateDTO dto(
+            Long matchCandidateId,
+            Long bankTransactionId
+    ) {
+        return BankTransactionMatchCandidateDTO.builder()
+                .matchCandidateId(matchCandidateId)
+                .bankTransactionId(bankTransactionId)
+                .targetType(MatchingTargetType.SETTLEMENT)
+                .targetId(10L)
+                .expectedRemainingAmount(new BigDecimal("10000"))
+                .amountMatchType(MatchingAmountType.EXACT)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
@@ -14,6 +14,8 @@ import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -83,7 +85,8 @@ class BankTransactionMatchCandidateServiceTest {
                         BankTransactionMatchCandidateDTO::getTargetType,
                         BankTransactionMatchCandidateDTO::getTargetId,
                         BankTransactionMatchCandidateDTO::getExpectedRemainingAmount,
-                        BankTransactionMatchCandidateDTO::getAmountMatchType
+                        BankTransactionMatchCandidateDTO::getAmountMatchType,
+                        BankTransactionMatchCandidateDTO::getCandidateStatus
                 )
                 .containsExactly(
                         org.assertj.core.groups.Tuple.tuple(
@@ -91,16 +94,23 @@ class BankTransactionMatchCandidateServiceTest {
                                 MatchingTargetType.SETTLEMENT,
                                 10L,
                                 new BigDecimal("10000"),
-                                MatchingAmountType.PARTIAL
+                                MatchingAmountType.PARTIAL,
+                                MatchingCandidateStatus.AVAILABLE
                         ),
                         org.assertj.core.groups.Tuple.tuple(
                                 100L,
                                 MatchingTargetType.LOAN,
                                 20L,
                                 new BigDecimal("20000"),
-                                MatchingAmountType.EXACT
+                                MatchingAmountType.EXACT,
+                                MatchingCandidateStatus.AVAILABLE
                         )
                 );
+        assertThat(savedCandidates)
+                .allSatisfy(candidate -> {
+                    assertThat(candidate.getInvalidatedAt()).isNull();
+                    assertThat(candidate.getInvalidationReason()).isNull();
+                });
         assertThat(savedCandidates)
                 .extracting(BankTransactionMatchCandidateDTO::getCreatedAt)
                 .doesNotContainNull()
@@ -224,6 +234,90 @@ class BankTransactionMatchCandidateServiceTest {
         );
     }
 
+    @Test
+    void invalidatesAvailableCandidate() {
+        when(candidateMapper.invalidate(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq(100L),
+                org.mockito.ArgumentMatchers.eq(
+                        MatchingCandidateInvalidationReason
+                                .TARGET_NOT_AVAILABLE
+                ),
+                org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+        )).thenReturn(1);
+
+        candidateService.invalidateCandidate(
+                1L,
+                100L,
+                MatchingCandidateInvalidationReason.TARGET_NOT_AVAILABLE
+        );
+
+        verify(candidateMapper).invalidate(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq(100L),
+                org.mockito.ArgumentMatchers.eq(
+                        MatchingCandidateInvalidationReason
+                                .TARGET_NOT_AVAILABLE
+                ),
+                org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    void failsWhenCandidateCannotBeInvalidated() {
+        when(candidateMapper.invalidate(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq(100L),
+                org.mockito.ArgumentMatchers.eq(
+                        MatchingCandidateInvalidationReason.TARGET_NOT_FOUND
+                ),
+                org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+        )).thenReturn(0);
+
+        assertThatThrownBy(() -> candidateService.invalidateCandidate(
+                1L,
+                100L,
+                MatchingCandidateInvalidationReason.TARGET_NOT_FOUND
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode
+                                        .MATCHING_CANDIDATE_INVALIDATION_FAILED
+                        )
+        );
+    }
+
+    @Test
+    void failsWhenInvalidationReasonIsNull() {
+        assertThatThrownBy(() -> candidateService.invalidateCandidate(
+                1L,
+                100L,
+                null
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(MatchingErrorCode.INVALID_MATCHING_REQUEST)
+        );
+
+        verify(candidateMapper, never()).invalidate(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void returnsAvailableCandidateCount() {
+        when(candidateMapper.countAvailableByBankTransactionId(100L))
+                .thenReturn(2);
+
+        int result = candidateService.countAvailableCandidates(100L);
+
+        assertThat(result).isEqualTo(2);
+    }
+
     private EvaluatedMatchingCandidate evaluatedCandidate(
             MatchingTargetType targetType,
             Long targetId,
@@ -252,6 +346,7 @@ class BankTransactionMatchCandidateServiceTest {
                 .targetId(10L)
                 .expectedRemainingAmount(new BigDecimal("10000"))
                 .amountMatchType(MatchingAmountType.EXACT)
+                .candidateStatus(MatchingCandidateStatus.AVAILABLE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
@@ -1,0 +1,178 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewQueryService;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankTransactionMatchingReviewQueryService 단위 테스트")
+class BankTransactionMatchingReviewQueryServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long LINKED_ACCOUNT_ID = 2L;
+    private static final Long BANK_TRANSACTION_ID = 3L;
+
+    @Mock
+    private BankTransactionQueryService bankTransactionQueryService;
+
+    @Mock
+    private BankTransactionMatchCandidateService candidateService;
+
+    @InjectMocks
+    private BankTransactionMatchingReviewQueryService reviewQueryService;
+
+    @Test
+    @DisplayName("한 도메인의 후보만 있으면 거래내역 검토 대상으로 반환한다")
+    void returnsTransactionHistoryChannelForSingleDomainCandidates() {
+        BankTransactionDetailResponse transaction = transaction();
+        BankTransactionMatchCandidateQueryDTO candidate = candidate(
+                10L,
+                MatchingTargetType.SETTLEMENT,
+                MatchingAmountType.PARTIAL
+        );
+
+        given(bankTransactionQueryService.getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction);
+        given(candidateService.findAllForReviewByBankTransactionId(
+                BANK_TRANSACTION_ID
+        )).willReturn(List.of(candidate));
+
+        BankTransactionMatchingReviewResponse response =
+                reviewQueryService.getReview(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID
+                );
+
+        assertThat(response.transaction()).isEqualTo(transaction);
+        assertThat(response.reviewChannel())
+                .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
+        assertThat(response.candidates()).hasSize(1);
+        assertThat(response.candidates().get(0).matchCandidateId())
+                .isEqualTo(10L);
+        assertThat(response.candidates().get(0).participantName())
+                .isEqualTo("홍길동");
+        assertThat(response.candidates().get(0).amountMatchType())
+                .isEqualTo(MatchingAmountType.PARTIAL);
+    }
+
+    @Test
+    @DisplayName("정산과 차용증 후보가 모두 있으면 알림 검토 대상으로 반환한다")
+    void returnsNotificationChannelForCrossDomainCandidates() {
+        given(bankTransactionQueryService.getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction());
+        given(candidateService.findAllForReviewByBankTransactionId(
+                BANK_TRANSACTION_ID
+        )).willReturn(List.of(
+                candidate(
+                        10L,
+                        MatchingTargetType.SETTLEMENT,
+                        MatchingAmountType.EXACT
+                ),
+                candidate(
+                        11L,
+                        MatchingTargetType.LOAN,
+                        MatchingAmountType.PARTIAL
+                )
+        ));
+
+        BankTransactionMatchingReviewResponse response =
+                reviewQueryService.getReview(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID
+                );
+
+        assertThat(response.reviewChannel())
+                .isEqualTo(MatchingReviewChannel.NOTIFICATION);
+        assertThat(response.candidates()).hasSize(2);
+        verify(bankTransactionQueryService).getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        );
+    }
+
+    @Test
+    @DisplayName("후보가 없어도 거래내역 검토 대상으로 반환한다")
+    void returnsTransactionHistoryChannelWhenCandidatesAreEmpty() {
+        given(bankTransactionQueryService.getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction());
+        given(candidateService.findAllForReviewByBankTransactionId(
+                BANK_TRANSACTION_ID
+        )).willReturn(List.of());
+
+        BankTransactionMatchingReviewResponse response =
+                reviewQueryService.getReview(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID
+                );
+
+        assertThat(response.reviewChannel())
+                .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
+        assertThat(response.candidates()).isEmpty();
+    }
+
+    private BankTransactionDetailResponse transaction() {
+        return new BankTransactionDetailResponse(
+                BANK_TRANSACTION_ID,
+                LINKED_ACCOUNT_ID,
+                new BigDecimal("5000.00"),
+                BankTransactionType.DEPOSIT,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                LocalDateTime.of(2026, 8, 15, 10, 0),
+                "홍길동",
+                null,
+                LocalDateTime.of(2026, 8, 15, 10, 5)
+        );
+    }
+
+    private BankTransactionMatchCandidateQueryDTO candidate(
+            Long matchCandidateId,
+            MatchingTargetType targetType,
+            MatchingAmountType amountMatchType
+    ) {
+        return BankTransactionMatchCandidateQueryDTO.builder()
+                .matchCandidateId(matchCandidateId)
+                .bankTransactionId(BANK_TRANSACTION_ID)
+                .targetType(targetType)
+                .targetId(20L + matchCandidateId)
+                .participantName("홍길동")
+                .expectedRemainingAmount(new BigDecimal("10000.00"))
+                .amountMatchType(amountMatchType)
+                .createdAt(LocalDateTime.of(2026, 8, 15, 10, 5))
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
@@ -1,13 +1,15 @@
 package org.teamsai.saibackend.domain.matching;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
 import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.policy.MatchingReviewValidator;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewQueryService;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
@@ -17,13 +19,16 @@ import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDet
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,8 +45,16 @@ class BankTransactionMatchingReviewQueryServiceTest {
     @Mock
     private BankTransactionMatchCandidateService candidateService;
 
-    @InjectMocks
     private BankTransactionMatchingReviewQueryService reviewQueryService;
+
+    @BeforeEach
+    void setUp() {
+        reviewQueryService = new BankTransactionMatchingReviewQueryService(
+                bankTransactionQueryService,
+                candidateService,
+                new MatchingReviewValidator()
+        );
+    }
 
     @Test
     @DisplayName("한 도메인의 후보만 있으면 거래내역 검토 대상으로 반환한다")
@@ -145,13 +158,79 @@ class BankTransactionMatchingReviewQueryServiceTest {
         assertThat(response.candidates()).isEmpty();
     }
 
+    @Test
+    @DisplayName("이미 처리된 거래의 과거 후보는 반환하지 않는다")
+    void rejectsReviewForProcessedTransaction() {
+        given(bankTransactionQueryService.getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction(
+                BankTransactionProcessingStatus.APPLIED,
+                BankTransactionType.DEPOSIT
+        ));
+
+        assertThatThrownBy(() -> reviewQueryService.getReview(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode.MATCHING_REVIEW_NOT_REQUIRED
+                        )
+        );
+
+        verify(candidateService, never())
+                .findAllForReviewByBankTransactionId(BANK_TRANSACTION_ID);
+    }
+
+    @Test
+    @DisplayName("출금 거래의 매칭 후보는 반환하지 않는다")
+    void rejectsReviewForWithdrawalTransaction() {
+        given(bankTransactionQueryService.getTransactionDetail(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction(
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionType.WITHDRAWAL
+        ));
+
+        assertThatThrownBy(() -> reviewQueryService.getReview(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode.MATCHING_REVIEW_NOT_REQUIRED
+                        )
+        );
+
+        verify(candidateService, never())
+                .findAllForReviewByBankTransactionId(BANK_TRANSACTION_ID);
+    }
+
     private BankTransactionDetailResponse transaction() {
+        return transaction(
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionType.DEPOSIT
+        );
+    }
+
+    private BankTransactionDetailResponse transaction(
+            BankTransactionProcessingStatus processingStatus,
+            BankTransactionType transactionType
+    ) {
         return new BankTransactionDetailResponse(
                 BANK_TRANSACTION_ID,
                 LINKED_ACCOUNT_ID,
                 new BigDecimal("5000.00"),
-                BankTransactionType.DEPOSIT,
-                BankTransactionProcessingStatus.NEEDS_CHECK,
+                transactionType,
+                processingStatus,
                 LocalDateTime.of(2026, 8, 15, 10, 0),
                 "홍길동",
                 null,

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
@@ -13,6 +13,9 @@ import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewService;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewResult;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
 import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
@@ -101,6 +104,8 @@ class BankTransactionMatchingReviewServiceTest {
         verifyStatusUpdatedTo(BankTransactionProcessingStatus.APPLIED);
         assertThat(response.processingStatus())
                 .isEqualTo(BankTransactionProcessingStatus.APPLIED);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.APPLIED);
     }
 
     @Test
@@ -142,6 +147,8 @@ class BankTransactionMatchingReviewServiceTest {
         verifyStatusUpdatedTo(BankTransactionProcessingStatus.UNMATCHED);
         assertThat(response.processingStatus())
                 .isEqualTo(BankTransactionProcessingStatus.UNMATCHED);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.REJECTED);
     }
 
     @Test
@@ -175,11 +182,16 @@ class BankTransactionMatchingReviewServiceTest {
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any()
         );
+        verify(candidateService, never()).invalidateCandidate(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 
     @Test
-    @DisplayName("복구 불가능한 대상 상태 불일치는 실패로 처리한다")
-    void marksIrrecoverableTargetMismatchAsFailed() {
+    @DisplayName("선택한 후보가 무효여도 다른 후보가 남으면 확인 필요 상태를 유지한다")
+    void keepsReviewOpenWhenAnotherCandidateRemains() {
         givenReviewableTransaction();
         given(candidateService.findByIdAndBankTransactionId(
                 MATCH_CANDIDATE_ID,
@@ -192,6 +204,8 @@ class BankTransactionMatchingReviewServiceTest {
                         BANK_TRANSACTION_ID,
                         new BigDecimal("5000")
                 );
+        given(candidateService.countAvailableCandidates(BANK_TRANSACTION_ID))
+                .willReturn(1);
 
         MatchingReviewProcessResponse response =
                 matchingReviewService.applyCandidate(
@@ -201,9 +215,90 @@ class BankTransactionMatchingReviewServiceTest {
                         MATCH_CANDIDATE_ID
                 );
 
+        verifyCandidateInvalidatedAs(
+                MatchingCandidateInvalidationReason.TARGET_NOT_AVAILABLE
+        );
+        verify(bankTransactionService, never()).updateStatus(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.NEEDS_CHECK);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.CANDIDATE_INVALIDATED);
+    }
+
+    @Test
+    @DisplayName("마지막 후보가 더 이상 처리 가능하지 않으면 미매칭으로 처리한다")
+    void marksTransactionAsUnmatchedWhenLastCandidateIsUnavailable() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.SETTLEMENT, 10L));
+        willThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_ACTIVE.toException())
+                .given(settlementPaymentService)
+                .applyManuallyMatchedPayment(
+                        10L,
+                        BANK_TRANSACTION_ID,
+                        new BigDecimal("5000")
+                );
+        given(candidateService.countAvailableCandidates(BANK_TRANSACTION_ID))
+                .willReturn(0);
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.applyCandidate(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID,
+                        MATCH_CANDIDATE_ID
+                );
+
+        verifyCandidateInvalidatedAs(
+                MatchingCandidateInvalidationReason.TARGET_NOT_AVAILABLE
+        );
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.UNMATCHED);
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.UNMATCHED);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.CANDIDATE_INVALIDATED);
+    }
+
+    @Test
+    @DisplayName("마지막 후보의 실제 대상이 없으면 실패로 처리한다")
+    void marksTransactionAsFailedWhenLastCandidateTargetIsMissing() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.LOAN, 20L));
+        willThrow(RepaymentScheduleErrorCode.SCHEDULE_NOT_FOUND.toException())
+                .given(loanPaymentService)
+                .applyManuallyMatchedPayment(
+                        20L,
+                        BANK_TRANSACTION_ID,
+                        new BigDecimal("5000")
+                );
+        given(candidateService.countAvailableCandidates(BANK_TRANSACTION_ID))
+                .willReturn(0);
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.applyCandidate(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID,
+                        MATCH_CANDIDATE_ID
+                );
+
+        verifyCandidateInvalidatedAs(
+                MatchingCandidateInvalidationReason.TARGET_NOT_FOUND
+        );
         verifyStatusUpdatedTo(BankTransactionProcessingStatus.FAILED);
         assertThat(response.processingStatus())
                 .isEqualTo(BankTransactionProcessingStatus.FAILED);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.CANDIDATE_INVALIDATED);
     }
 
     @Test
@@ -233,6 +328,8 @@ class BankTransactionMatchingReviewServiceTest {
         verifyStatusUpdatedTo(BankTransactionProcessingStatus.APPLIED);
         assertThat(response.processingStatus())
                 .isEqualTo(BankTransactionProcessingStatus.APPLIED);
+        assertThat(response.reviewResult())
+                .isEqualTo(MatchingReviewResult.APPLIED);
     }
 
     @Test
@@ -301,8 +398,19 @@ class BankTransactionMatchingReviewServiceTest {
                 .targetId(targetId)
                 .expectedRemainingAmount(new BigDecimal("10000"))
                 .amountMatchType(MatchingAmountType.PARTIAL)
+                .candidateStatus(MatchingCandidateStatus.AVAILABLE)
                 .createdAt(LocalDateTime.of(2026, 8, 15, 10, 5))
                 .build();
+    }
+
+    private void verifyCandidateInvalidatedAs(
+            MatchingCandidateInvalidationReason invalidationReason
+    ) {
+        verify(candidateService).invalidateCandidate(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID,
+                invalidationReason
+        );
     }
 
     private void verifyStatusUpdatedTo(

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
@@ -1,0 +1,317 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.RepaymentScheduleErrorCode;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
+import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewService;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.service.LoanPaymentService;
+import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionQueryService;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankTransactionMatchingReviewService 단위 테스트")
+class BankTransactionMatchingReviewServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long LINKED_ACCOUNT_ID = 2L;
+    private static final Long BANK_TRANSACTION_ID = 3L;
+    private static final Long MATCH_CANDIDATE_ID = 4L;
+
+    @Mock
+    private BankTransactionQueryService bankTransactionQueryService;
+
+    @Mock
+    private BankTransactionMatchCandidateService candidateService;
+
+    @Mock
+    private SettlementPaymentService settlementPaymentService;
+
+    @Mock
+    private LoanPaymentService loanPaymentService;
+
+    @Mock
+    private BankTransactionService bankTransactionService;
+
+    private BankTransactionMatchingReviewService matchingReviewService;
+
+    @BeforeEach
+    void setUp() {
+        matchingReviewService = new BankTransactionMatchingReviewService(
+                bankTransactionQueryService,
+                candidateService,
+                settlementPaymentService,
+                loanPaymentService,
+                bankTransactionService
+        );
+    }
+
+    @Test
+    @DisplayName("선택한 정산 후보를 수동 납부로 반영하고 거래를 완료한다")
+    void appliesSelectedSettlementCandidate() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.SETTLEMENT, 10L));
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.applyCandidate(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID,
+                        MATCH_CANDIDATE_ID
+                );
+
+        verify(settlementPaymentService).applyManuallyMatchedPayment(
+                10L,
+                BANK_TRANSACTION_ID,
+                new BigDecimal("5000")
+        );
+        verify(loanPaymentService, never()).applyManuallyMatchedPayment(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.APPLIED);
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.APPLIED);
+    }
+
+    @Test
+    @DisplayName("선택한 차용증 후보를 수동 상환으로 반영한다")
+    void appliesSelectedLoanCandidate() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.LOAN, 20L));
+
+        matchingReviewService.applyCandidate(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID,
+                MATCH_CANDIDATE_ID
+        );
+
+        verify(loanPaymentService).applyManuallyMatchedPayment(
+                20L,
+                BANK_TRANSACTION_ID,
+                new BigDecimal("5000")
+        );
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.APPLIED);
+    }
+
+    @Test
+    @DisplayName("어느 후보도 선택하지 않으면 미매칭으로 처리한다")
+    void rejectsAllCandidatesAsUnmatched() {
+        givenReviewableTransaction();
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.rejectCandidates(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID
+                );
+
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.UNMATCHED);
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.UNMATCHED);
+    }
+
+    @Test
+    @DisplayName("일시적인 납부 실패는 확인 필요 상태를 유지하도록 예외를 전파한다")
+    void keepsReviewOpenForRetryablePaymentFailure() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.SETTLEMENT, 10L));
+        DomainException exception = PaymentErrorCode
+                .PAYMENT_RECORD_CREATE_FAILED
+                .toException();
+        willThrow(exception)
+                .given(settlementPaymentService)
+                .applyManuallyMatchedPayment(
+                        10L,
+                        BANK_TRANSACTION_ID,
+                        new BigDecimal("5000")
+                );
+
+        assertThatThrownBy(() -> matchingReviewService.applyCandidate(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID,
+                MATCH_CANDIDATE_ID
+        )).isSameAs(exception);
+
+        verify(bankTransactionService, never()).updateStatus(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    @DisplayName("복구 불가능한 대상 상태 불일치는 실패로 처리한다")
+    void marksIrrecoverableTargetMismatchAsFailed() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.LOAN, 20L));
+        willThrow(RepaymentScheduleErrorCode.SCHEDULE_NOT_PENDING.toException())
+                .given(loanPaymentService)
+                .applyManuallyMatchedPayment(
+                        20L,
+                        BANK_TRANSACTION_ID,
+                        new BigDecimal("5000")
+                );
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.applyCandidate(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID,
+                        MATCH_CANDIDATE_ID
+                );
+
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.FAILED);
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("중복 납부기록이면 이미 반영된 거래로 처리한다")
+    void marksDuplicatedPaymentAsApplied() {
+        givenReviewableTransaction();
+        given(candidateService.findByIdAndBankTransactionId(
+                MATCH_CANDIDATE_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(candidate(MatchingTargetType.SETTLEMENT, 10L));
+        willThrow(PaymentErrorCode.DUPLICATE_PAYMENT_RECORD.toException())
+                .given(settlementPaymentService)
+                .applyManuallyMatchedPayment(
+                        10L,
+                        BANK_TRANSACTION_ID,
+                        new BigDecimal("5000")
+                );
+
+        MatchingReviewProcessResponse response =
+                matchingReviewService.applyCandidate(
+                        USER_ID,
+                        LINKED_ACCOUNT_ID,
+                        BANK_TRANSACTION_ID,
+                        MATCH_CANDIDATE_ID
+                );
+
+        verifyStatusUpdatedTo(BankTransactionProcessingStatus.APPLIED);
+        assertThat(response.processingStatus())
+                .isEqualTo(BankTransactionProcessingStatus.APPLIED);
+    }
+
+    @Test
+    @DisplayName("확인 필요 상태가 아닌 거래는 선택 처리하지 않는다")
+    void rejectsTransactionThatDoesNotNeedReview() {
+        given(bankTransactionQueryService.getTransactionDetailForUpdate(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction(BankTransactionProcessingStatus.APPLIED));
+
+        assertThatThrownBy(() -> matchingReviewService.applyCandidate(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID,
+                MATCH_CANDIDATE_ID
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                MatchingErrorCode.MATCHING_REVIEW_NOT_REQUIRED
+                        )
+        );
+
+        verify(candidateService, never())
+                .findByIdAndBankTransactionId(
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any()
+                );
+    }
+
+    private void givenReviewableTransaction() {
+        given(bankTransactionQueryService.getTransactionDetailForUpdate(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                BANK_TRANSACTION_ID
+        )).willReturn(transaction(
+                BankTransactionProcessingStatus.NEEDS_CHECK
+        ));
+    }
+
+    private BankTransactionDetailResponse transaction(
+            BankTransactionProcessingStatus processingStatus
+    ) {
+        return new BankTransactionDetailResponse(
+                BANK_TRANSACTION_ID,
+                LINKED_ACCOUNT_ID,
+                new BigDecimal("5000"),
+                BankTransactionType.DEPOSIT,
+                processingStatus,
+                LocalDateTime.of(2026, 8, 15, 10, 0),
+                "홍길동",
+                null,
+                LocalDateTime.of(2026, 8, 15, 10, 5)
+        );
+    }
+
+    private BankTransactionMatchCandidateDTO candidate(
+            MatchingTargetType targetType,
+            Long targetId
+    ) {
+        return BankTransactionMatchCandidateDTO.builder()
+                .matchCandidateId(MATCH_CANDIDATE_ID)
+                .bankTransactionId(BANK_TRANSACTION_ID)
+                .targetType(targetType)
+                .targetId(targetId)
+                .expectedRemainingAmount(new BigDecimal("10000"))
+                .amountMatchType(MatchingAmountType.PARTIAL)
+                .createdAt(LocalDateTime.of(2026, 8, 15, 10, 5))
+                .build();
+    }
+
+    private void verifyStatusUpdatedTo(
+            BankTransactionProcessingStatus nextStatus
+    ) {
+        verify(bankTransactionService).updateStatus(
+                BANK_TRANSACTION_ID,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                nextStatus
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewServiceTest.java
@@ -10,6 +10,7 @@ import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.Repayme
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.dto.response.MatchingReviewProcessResponse;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.policy.MatchingReviewValidator;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
 import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewService;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
@@ -70,7 +71,8 @@ class BankTransactionMatchingReviewServiceTest {
                 candidateService,
                 settlementPaymentService,
                 loanPaymentService,
-                bankTransactionService
+                bankTransactionService,
+                new MatchingReviewValidator()
         );
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/notification/NotificationServiceTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,6 +102,8 @@ class NotificationServiceTest {
                                 "정산 금액 30000원이 등록되었습니다.",
                                 10L,
                                 null,          // ← 이 줄 추가 (secondaryReferenceId)
+                                null,
+                                false,
                                 createdAt
                         )
                 );
@@ -111,5 +114,56 @@ class NotificationServiceTest {
 
         assertThat(result).isEqualTo(expected);
         verify(notificationMapper).findAllByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("같은 은행 거래의 매칭 검토 알림이 없으면 생성한다")
+    void createsMatchingReviewNotificationWhenItDoesNotExist() {
+        when(notificationMapper.existsByUserIdAndTypeAndReferenceId(
+                2L,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                100L
+        )).thenReturn(false);
+
+        notificationService.createIfAbsent(
+                2L,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                "입금 거래 확인이 필요합니다.",
+                "정산과 차용증 후보가 모두 발견되었습니다.",
+                100L,
+                10L
+        );
+
+        verify(notificationMapper).insert(
+                org.mockito.ArgumentMatchers.argThat(notification ->
+                        notification.getUserId().equals(2L)
+                                && notification.getReferenceId().equals(100L)
+                                && notification.getSecondaryReferenceId()
+                                .equals(10L)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("같은 은행 거래의 매칭 검토 알림이 있으면 중복 생성하지 않는다")
+    void doesNotCreateDuplicatedMatchingReviewNotification() {
+        when(notificationMapper.existsByUserIdAndTypeAndReferenceId(
+                2L,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                100L
+        )).thenReturn(true);
+
+        notificationService.createIfAbsent(
+                2L,
+                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+                "입금 거래 확인이 필요합니다.",
+                "정산과 차용증 후보가 모두 발견되었습니다.",
+                100L,
+                10L
+        );
+
+        verify(notificationMapper, never()).insert(
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/payment/service/LoanPaymentServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/service/LoanPaymentServiceTest.java
@@ -1,4 +1,4 @@
-package org.teamsai.saibackend.domain.matching;
+package org.teamsai.saibackend.domain.payment.service;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,9 +12,7 @@ import org.teamsai.saibackend.domain.contractrepaymentschedule.dto.RepaymentSche
 import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.exception.RepaymentScheduleErrorCode;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.service.RepaymentScheduleService;
-import org.teamsai.saibackend.domain.matching.service.LoanPaymentService;
 import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
-import org.teamsai.saibackend.domain.payment.service.PaymentRecordService;
 import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
 import org.teamsai.saibackend.domain.payment.type.SourceType;
 import org.teamsai.saibackend.global.exception.DomainException;
@@ -166,6 +164,78 @@ class LoanPaymentServiceTest {
 
             verify(paymentRecordService, never()).createConfirmedRecord(any(), any(), any(), any(), any());
             verify(repaymentScheduleService, never()).markAsPaid(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 선택 납부 반영")
+    class ApplyManuallyMatchedPayment {
+
+        @Test
+        @DisplayName("초과입금은 현재 잔여금액까지만 수동 납부로 반영한다")
+        void limitsExcessAmountToCurrentRemainingAmount() {
+            given(repaymentScheduleService
+                    .getScheduleByScheduleId(SCHEDULE_ID))
+                    .willReturn(schedule(
+                            RepaymentScheduleStatus.PENDING,
+                            new BigDecimal("100000")
+                    ));
+            given(paymentRecordService.sumConfirmedAmountByTarget(
+                    PaymentTargetType.LOAN,
+                    SCHEDULE_ID
+            )).willReturn(new BigDecimal("70000"));
+
+            loanPaymentService.applyManuallyMatchedPayment(
+                    SCHEDULE_ID,
+                    BANK_TRANSACTION_ID,
+                    new BigDecimal("32000")
+            );
+
+            verify(paymentRecordService).createConfirmedRecord(
+                    BANK_TRANSACTION_ID,
+                    PaymentTargetType.LOAN,
+                    SCHEDULE_ID,
+                    new BigDecimal("30000"),
+                    SourceType.MANUAL
+            );
+            verify(repaymentScheduleService).markAsPaid(
+                    eq(SCHEDULE_ID),
+                    any()
+            );
+        }
+
+        @Test
+        @DisplayName("확정 납부금액상 잔여액이 없으면 수동 납부를 반영하지 않는다")
+        void rejectsPaymentWhenConfirmedAmountAlreadyCoversSchedule() {
+            given(repaymentScheduleService
+                    .getScheduleByScheduleId(SCHEDULE_ID))
+                    .willReturn(schedule(
+                            RepaymentScheduleStatus.PENDING,
+                            new BigDecimal("100000")
+                    ));
+            given(paymentRecordService.sumConfirmedAmountByTarget(
+                    PaymentTargetType.LOAN,
+                    SCHEDULE_ID
+            )).willReturn(new BigDecimal("100000"));
+
+            assertThatThrownBy(() ->
+                    loanPaymentService.applyManuallyMatchedPayment(
+                            SCHEDULE_ID,
+                            BANK_TRANSACTION_ID,
+                            new BigDecimal("10000")
+                    )
+            ).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(
+                                    RepaymentScheduleErrorCode
+                                            .SCHEDULE_NOT_PENDING
+                            )
+            );
+
+            verify(paymentRecordService, never()).createConfirmedRecord(
+                    any(), any(), any(), any(), any()
+            );
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentServiceTest.java
@@ -1,0 +1,113 @@
+package org.teamsai.saibackend.domain.payment.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.payment.type.ObligationStatus;
+import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+import org.teamsai.saibackend.domain.payment.type.SourceType;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SettlementPaymentService 단위 테스트")
+class SettlementPaymentServiceTest {
+
+    @Mock
+    private PaymentObligationMapper paymentObligationMapper;
+
+    @Mock
+    private PaymentRecordService paymentRecordService;
+
+    @Test
+    @DisplayName("초과입금은 현재 잔여금액까지만 수동 납부로 반영한다")
+    void limitsExcessAmountToCurrentRemainingAmount() {
+        SettlementPaymentService settlementPaymentService =
+                new SettlementPaymentService(
+                        paymentObligationMapper,
+                        paymentRecordService
+                );
+        PaymentObligationDTO obligation = PaymentObligationDTO.builder()
+                .paymentObligationId(10L)
+                .expectedAmount(new BigDecimal("100000"))
+                .paymentStatus(PaymentStatus.PARTIALLY_PAID)
+                .obligationStatus(ObligationStatus.ACTIVE)
+                .build();
+
+        given(paymentRecordService.existsByBankTransactionId(101L))
+                .willReturn(false);
+        given(paymentObligationMapper.findByIdForUpdate(10L))
+                .willReturn(Optional.of(obligation));
+        given(paymentRecordService.sumConfirmedAmountByTarget(
+                PaymentTargetType.SETTLEMENT,
+                10L
+        )).willReturn(new BigDecimal("70000"));
+        given(paymentObligationMapper.updatePaymentStatus(
+                10L,
+                PaymentStatus.PAID
+        )).willReturn(1);
+
+        settlementPaymentService.applyManuallyMatchedPayment(
+                10L,
+                101L,
+                new BigDecimal("32000")
+        );
+
+        verify(paymentRecordService).createConfirmedRecord(
+                101L,
+                PaymentTargetType.SETTLEMENT,
+                10L,
+                new BigDecimal("30000"),
+                SourceType.MANUAL
+        );
+        verify(paymentObligationMapper).updatePaymentStatus(
+                10L,
+                PaymentStatus.PAID
+        );
+    }
+
+    @Test
+    @DisplayName("이미 완납된 정산 대상에는 수동 납부를 반영하지 않는다")
+    void rejectsManuallyMatchedPaymentForPaidObligation() {
+        SettlementPaymentService settlementPaymentService =
+                new SettlementPaymentService(
+                        paymentObligationMapper,
+                        paymentRecordService
+                );
+        PaymentObligationDTO obligation = PaymentObligationDTO.builder()
+                .paymentObligationId(10L)
+                .expectedAmount(new BigDecimal("100000"))
+                .paymentStatus(PaymentStatus.PAID)
+                .obligationStatus(ObligationStatus.ACTIVE)
+                .build();
+
+        given(paymentRecordService.existsByBankTransactionId(101L))
+                .willReturn(false);
+        given(paymentObligationMapper.findByIdForUpdate(10L))
+                .willReturn(Optional.of(obligation));
+
+        assertThatThrownBy(() ->
+                settlementPaymentService.applyManuallyMatchedPayment(
+                        10L,
+                        101L,
+                        new BigDecimal("10000")
+                )
+        ).isInstanceOfSatisfying(
+                org.teamsai.saibackend.global.exception.DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_ACTIVE)
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -1,0 +1,69 @@
+package org.teamsai.saibackend.domain.transaction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper;
+import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BankTransactionService 단위 테스트")
+class BankTransactionServiceTest {
+
+    @Mock
+    private BankTransactionMapper bankTransactionMapper;
+
+    @InjectMocks
+    private BankTransactionService bankTransactionService;
+
+    @Test
+    @DisplayName("확인 필요 거래를 반영 완료 상태로 변경할 수 있다")
+    void updatesNeedsCheckTransactionToApplied() {
+        given(bankTransactionMapper.updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.APPLIED
+        )).willReturn(1);
+
+        bankTransactionService.updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.APPLIED
+        );
+
+        verify(bankTransactionMapper).updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.APPLIED
+        );
+    }
+
+    @Test
+    @DisplayName("확인 필요 거래를 미매칭 상태로 변경할 수 있다")
+    void updatesNeedsCheckTransactionToUnmatched() {
+        given(bankTransactionMapper.updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.UNMATCHED
+        )).willReturn(1);
+
+        bankTransactionService.updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.UNMATCHED
+        );
+
+        verify(bankTransactionMapper).updateStatus(
+                1L,
+                BankTransactionProcessingStatus.NEEDS_CHECK,
+                BankTransactionProcessingStatus.UNMATCHED
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/BankTransactionServiceTest.java
@@ -6,10 +6,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
 import org.teamsai.saibackend.domain.transaction.mapper.BankTransactionMapper;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
 import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.global.exception.DomainException;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -22,6 +29,45 @@ class BankTransactionServiceTest {
 
     @InjectMocks
     private BankTransactionService bankTransactionService;
+
+    @Test
+    @DisplayName("연결계좌와 거래 ID로 은행 거래를 잠금 조회한다")
+    void findsTransactionByIdAndLinkedAccountIdForUpdate() {
+        BankTransactionDTO transaction = BankTransactionDTO.builder()
+                .bankTransactionId(101L)
+                .linkedAccountId(1L)
+                .processingStatus(BankTransactionProcessingStatus.PENDING)
+                .build();
+        given(bankTransactionMapper.findByIdAndLinkedAccountIdForUpdate(
+                101L,
+                1L
+        )).willReturn(Optional.of(transaction));
+
+        BankTransactionDTO result = bankTransactionService
+                .findByIdAndLinkedAccountIdForUpdate(101L, 1L);
+
+        assertThat(result).isSameAs(transaction);
+    }
+
+    @Test
+    @DisplayName("잠금 조회할 은행 거래가 없으면 예외가 발생한다")
+    void throwsWhenTransactionForUpdateDoesNotExist() {
+        given(bankTransactionMapper.findByIdAndLinkedAccountIdForUpdate(
+                101L,
+                1L
+        )).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bankTransactionService
+                .findByIdAndLinkedAccountIdForUpdate(101L, 1L)
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                BankTransactionErrorCode
+                                        .BANK_TRANSACTION_NOT_FOUND
+                        )
+        );
+    }
 
     @Test
     @DisplayName("확인 필요 거래를 반영 완료 상태로 변경할 수 있다")

--- a/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/transaction/TransactionSyncFacadeTest.java
@@ -59,7 +59,7 @@ class TransactionSyncFacadeTest {
         );
 
         given(transactionSyncService.syncTransactions(USER_ID, LINKED_ACCOUNT_ID)).willReturn(1);
-        given(bankMatchingService.execute(LINKED_ACCOUNT_ID)).willReturn(expectedResult);
+        given(bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID)).willReturn(expectedResult);
 
         AutoMatchingExecutionResult result = transactionSyncFacade.syncAndMatch(USER_ID, LINKED_ACCOUNT_ID);
 
@@ -67,7 +67,7 @@ class TransactionSyncFacadeTest {
 
         InOrder inOrder = inOrder(transactionSyncService, bankMatchingService);
         inOrder.verify(transactionSyncService).syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
-        inOrder.verify(bankMatchingService).execute(LINKED_ACCOUNT_ID);
+        inOrder.verify(bankMatchingService).execute(USER_ID, LINKED_ACCOUNT_ID);
     }
 
     @Test
@@ -78,12 +78,12 @@ class TransactionSyncFacadeTest {
         );
 
         given(transactionSyncService.syncTransactions(USER_ID, LINKED_ACCOUNT_ID)).willReturn(0);
-        given(bankMatchingService.execute(LINKED_ACCOUNT_ID)).willReturn(emptyResult);
+        given(bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID)).willReturn(emptyResult);
 
         AutoMatchingExecutionResult result = transactionSyncFacade.syncAndMatch(USER_ID, LINKED_ACCOUNT_ID);
 
         assertThat(result.totalTransactionCount()).isZero();
-        verify(bankMatchingService).execute(LINKED_ACCOUNT_ID);
+        verify(bankMatchingService).execute(USER_ID, LINKED_ACCOUNT_ID);
     }
 
     @Test
@@ -97,7 +97,7 @@ class TransactionSyncFacadeTest {
         assertThatThrownBy(() -> transactionSyncFacade.syncAndMatch(USER_ID, LINKED_ACCOUNT_ID))
                 .isSameAs(syncFailure);
 
-        verify(bankMatchingService, never()).execute(any());
+        verify(bankMatchingService, never()).execute(any(), any());
     }
 
     @Test
@@ -107,7 +107,7 @@ class TransactionSyncFacadeTest {
 
         given(transactionSyncService.syncTransactions(USER_ID, LINKED_ACCOUNT_ID)).willReturn(2);
         willThrow(matchingFailure)
-                .given(bankMatchingService).execute(LINKED_ACCOUNT_ID);
+                .given(bankMatchingService).execute(USER_ID, LINKED_ACCOUNT_ID);
 
         assertThatThrownBy(() -> transactionSyncFacade.syncAndMatch(USER_ID, LINKED_ACCOUNT_ID))
                 .isSameAs(matchingFailure);
@@ -172,9 +172,9 @@ class TransactionSyncFacadeTest {
                 .willReturn(2);
         given(transactionSyncService.syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID))
                 .willReturn(3);
-        given(bankMatchingService.execute(LINKED_ACCOUNT_ID))
+        given(bankMatchingService.execute(USER_ID, LINKED_ACCOUNT_ID))
                 .willReturn(firstResult);
-        given(bankMatchingService.execute(SECOND_LINKED_ACCOUNT_ID))
+        given(bankMatchingService.execute(USER_ID, SECOND_LINKED_ACCOUNT_ID))
                 .willReturn(secondResult);
 
         TransactionSyncAllResponse result =
@@ -196,10 +196,13 @@ class TransactionSyncFacadeTest {
         inOrder.verify(linkedBankAccountService).getLinkedAccounts(USER_ID);
         inOrder.verify(transactionSyncService)
                 .syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
-        inOrder.verify(bankMatchingService).execute(LINKED_ACCOUNT_ID);
+        inOrder.verify(bankMatchingService).execute(USER_ID, LINKED_ACCOUNT_ID);
         inOrder.verify(transactionSyncService)
                 .syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID);
-        inOrder.verify(bankMatchingService).execute(SECOND_LINKED_ACCOUNT_ID);
+        inOrder.verify(bankMatchingService).execute(
+                USER_ID,
+                SECOND_LINKED_ACCOUNT_ID
+        );
     }
 
     @Test
@@ -227,7 +230,7 @@ class TransactionSyncFacadeTest {
                 .syncTransactions(USER_ID, LINKED_ACCOUNT_ID);
         given(transactionSyncService.syncTransactions(USER_ID, SECOND_LINKED_ACCOUNT_ID))
                 .willReturn(1);
-        given(bankMatchingService.execute(SECOND_LINKED_ACCOUNT_ID))
+        given(bankMatchingService.execute(USER_ID, SECOND_LINKED_ACCOUNT_ID))
                 .willReturn(successResult);
 
         TransactionSyncAllResponse result = transactionSyncFacade.syncAll(USER_ID);
@@ -260,7 +263,7 @@ class TransactionSyncFacadeTest {
         assertThat(result.failedCount()).isZero();
 
         verify(transactionSyncService, never()).syncTransactions(any(), any());
-        verify(bankMatchingService, never()).execute(any());
+        verify(bankMatchingService, never()).execute(any(), any());
     }
 
     private LinkedBankAccountResponse linkedAccount(Long linkedAccountId) {


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #140 

## 🛠 작업 사항

  - 자동매칭 금액 범위를 잔여 예정금액 기준 10%~110%로 확장
    - `PARTIAL / EXACT / EXCESS` 구분
    - 전체 유효 후보가 정확 일치 1건일 때만 자동 반영
  - 확인 필요 거래의 매칭 후보 저장
    - `bank_transaction_match_candidate` 테이블 및 Mapper 추가
    - 판정 당시 잔여 예정금액 저장
  - 확인 필요 후보 조회 및 사용자 선택 반영 API 추가
    - 후보 선택 시 정산/차용증 납부 반영
    - `어느 후보도 아님` 선택 시 `UNMATCHED` 처리
  - 정산·차용증 중복 후보 알림 생성 및 처리 상태 조회 추가
  - 거래별 트랜잭션 처리 분리 및 중복 반영 방지
  - `LoanPaymentService`를 `matching`에서 `payment` 패키지로 이동

## ✅ 테스트

  - [x] 로컬 서버 테스트 완료
  - [x] 핵심 기능 테스트 코드 작성 및 실행 완료
  - [x] 관련 코드 컴파일 및 단위 테스트 통과
  - [ ] 실제 DB/API 통합 테스트

## 📌 주의 사항 및 참고사항

- 공용 DB에 `bank_transaction_match_candidate` 테이블 적용 완료
- 화면 연동 및 실제 API 통합 검증은 후속 PR에서 진행 예정

## 👀 리뷰 가이드

  전체 변경은 48개 파일, `+3,238 / -727`줄입니다.

  - 운영 코드: `+1,434 / -201`
  - 테스트 코드: `+1,804 / -526`
  - 큰 변경량의 절반 이상은 테스트 추가 및 기존 테스트 재구성입니다.

  ### 우선 확인 부탁드리는 부분

  1. `AutoMatchingJudge`, `AutoMatchingResult`
     - 10%~110% 금액 판정
     - 정확 일치 후보 1건만 자동 반영

  2. `AutoMatchingService`, `BankMatchingTransactionService`
     - 후보 저장 및 거래별 트랜잭션 처리
     - `APPLIED / NEEDS_CHECK / UNMATCHED / FAILED` 상태 결정

  3. `BankTransactionMatchingReviewService`
     - 사용자 후보 선택 및 미매칭 처리
     - 실패·재시도·중복 반영 처리

  4. `SettlementPaymentService`, `LoanPaymentService`
     - 수동 부분·초과납부 반영
     - 현재 잔여금액 기준 반영

  5. `bank_transaction_match_candidate.sql`
     및 `BankTransactionMatchCandidateMapper.xml`
     - 후보 스냅샷 저장 및 조회 구조

  ### 가볍게 확인해도 되는 부분

  - 요청·응답 DTO와 Enum
  - 단순 Mapper 인터페이스
  - 기존 서비스 분리에 따라 재구성된 테스트 코드
  - `LoanPaymentService` 패키지 이동에 따른 경로·import 변경