### PR TITLE
feat(#141): 정기정산 자동생성

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface PaymentObligationMapper {
     Optional<PaymentObligationDTO> findByParticipantId(@Param("participantId") Long participantId);
 
+    List<PaymentObligationDTO> findByParticipantIds(@Param("participantIds") List<Long> participantIds);
+
     Optional<PaymentObligationDTO> findByIdForUpdate(
             @Param("paymentObligationId") Long paymentObligationId
     );

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 @Mapper
 public interface PaymentObligationMapper {
+    Optional<PaymentObligationDTO> findByParticipantId(@Param("participantId") Long participantId);
+
     Optional<PaymentObligationDTO> findByIdForUpdate(
             @Param("paymentObligationId") Long paymentObligationId
     );
@@ -27,6 +29,5 @@ public interface PaymentObligationMapper {
     );
 
     int insert(PaymentObligationDTO paymentObligation);
-
 }
 

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 @Mapper
 public interface PaymentObligationMapper {
-    Optional<PaymentObligationDTO> findByParticipantId(@Param("participantId") Long participantId);
 
     List<PaymentObligationDTO> findByParticipantIds(@Param("participantIds") List<Long> participantIds);
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/RecurringSettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/RecurringSettlementMapper.java
@@ -1,0 +1,14 @@
+package org.teamsai.saibackend.domain.settlement.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface RecurringSettlementMapper {
+    List<RecurringSettlementDTO> findActiveInRange(@Param("baseDate") LocalDate baseDate);
+
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -33,5 +33,5 @@ public interface SettlementMapper {
             @Param("settlementId") Long settlementId,
             @Param("userId") Long userId
     );
-
+    SettlementDTO findLatestByRecurringId(@Param("recurringSettlementId") Long recurringSettlementId);
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -34,4 +34,8 @@ public interface SettlementMapper {
             @Param("userId") Long userId
     );
     SettlementDTO findLatestByRecurringId(@Param("recurringSettlementId") Long recurringSettlementId);
+
+    SettlementDTO findLatestByRecurringIdForUpdate(@Param("recurringSettlementId") Long recurringSettlementId);
+
+    int countByRecurringId(@Param("recurringSettlementId") Long recurringSettlementId);
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
@@ -17,5 +17,4 @@ public interface  SettlementParticipantMapper {
             @Param("settlementId") Long settlementId,
             @Param("userId") Long userId
     );
-    List<SettlementParticipantDTO> findBySettlementId(@Param("settlementId") Long settlementId);
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
@@ -4,9 +4,13 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 
+import java.util.List;
+
 @Mapper
 public interface  SettlementParticipantMapper {
     int insert(SettlementParticipantDTO participant);
+
+    List<SettlementParticipantDTO> findBySettlementId(@Param("settlementId") Long settlementId);
 
     boolean existsActiveParticipant(
             @Param("settlementId") Long settlementId,

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/CycleGenerationOutcome.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/CycleGenerationOutcome.java
@@ -1,0 +1,18 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+
+public record CycleGenerationOutcome(CycleGenerationResult result, SettlementDTO settlement) {
+
+    public static CycleGenerationOutcome created(SettlementDTO settlement) {
+        return new CycleGenerationOutcome(CycleGenerationResult.CREATED, settlement);
+    }
+
+    public static CycleGenerationOutcome concurrentlySkipped() {
+        return new CycleGenerationOutcome(CycleGenerationResult.CONCURRENTLY_SKIPPED, null);
+    }
+
+    public static CycleGenerationOutcome noActiveParticipant() {
+        return new CycleGenerationOutcome(CycleGenerationResult.NO_ACTIVE_PARTICIPANT, null);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/CycleGenerationResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/CycleGenerationResult.java
@@ -1,0 +1,7 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+public enum CycleGenerationResult {
+    CREATED,
+    CONCURRENTLY_SKIPPED,
+    NO_ACTIVE_PARTICIPANT
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementBatchResult.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementBatchResult.java
@@ -1,0 +1,11 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import java.util.List;
+
+public record RecurringSettlementBatchResult(
+        int totalCandidates,
+        int succeeded,
+        int failed,
+        List<Long> failedRecurringIds
+) {
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,12 +38,13 @@ public class RecurringSettlementCycleGenerator {
     private final SettlementAmountCalculator settlementAmountCalculator;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public SettlementDTO generateOneCycle(RecurringSettlementDTO recurring, SettlementDTO previousSettlement, LocalDate cycleDate) {
+    public CycleGenerationOutcome generateOneCycle(RecurringSettlementDTO recurring, SettlementDTO previousSettlement, LocalDate cycleDate) {
         SettlementDTO lockedLatest =
                 settlementMapper.findLatestByRecurringIdForUpdate(recurring.getRecurringSettlementId());
+
         if (lockedLatest == null || !lockedLatest.getSettlementId().equals(previousSettlement.getSettlementId())) {
             log.warn("동시 생성 감지, 스킵 recurringId={}", recurring.getRecurringSettlementId());
-            return null;
+            return CycleGenerationOutcome.concurrentlySkipped();
         }
 
         List<SettlementParticipantDTO> activeParticipants =
@@ -54,7 +56,7 @@ public class RecurringSettlementCycleGenerator {
         if (activeParticipants.isEmpty()) {
             log.warn("ACTIVE 참여자 없음, 생성 스킵 recurringId={}, cycleDate={}",
                     recurring.getRecurringSettlementId(), cycleDate);
-            return null;
+            return CycleGenerationOutcome.noActiveParticipant();
         }
 
         SettlementDTO newSettlement = SettlementDTO.builder()
@@ -76,32 +78,50 @@ public class RecurringSettlementCycleGenerator {
             throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
         }
 
-        BigDecimal equalAmount = null;
-        Map<Long, BigDecimal> latestObligationByParticipant = Map.of();
-
         if (recurring.getSplitType() == SplitType.EQUAL) {
-            equalAmount = settlementAmountCalculator.calculateEqualAmountForTotalCount(
-                    recurring.getTotalAmount(), activeParticipants.size());
+            copyParticipantsWithEqualSplit(activeParticipants, newSettlement, recurring.getTotalAmount());
         } else {
-            List<Long> participantIds = activeParticipants.stream()
-                    .map(SettlementParticipantDTO::getParticipantId)
-                    .toList();
-
-            latestObligationByParticipant = paymentObligationMapper.findByParticipantIds(participantIds)
-                    .stream()
-                    .collect(Collectors.toMap(PaymentObligationDTO::getParticipantId, PaymentObligationDTO::getExpectedAmount));
+            copyParticipantsWithCustomAmounts(activeParticipants, newSettlement);
         }
+
+        return CycleGenerationOutcome.created(newSettlement);
+    }
+
+    private void copyParticipantsWithEqualSplit(
+            List<SettlementParticipantDTO> activeParticipants, SettlementDTO newSettlement, BigDecimal totalAmount
+    ) {
+        List<BigDecimal> distributedAmounts = settlementAmountCalculator.distributeEqualAmounts(
+                totalAmount, activeParticipants.size());
+
+        for (int i = 0; i < activeParticipants.size(); i++) {
+            SettlementParticipantDTO oldParticipant = activeParticipants.get(i);
+            BigDecimal expectedAmount = distributedAmounts.get(i);
+            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), expectedAmount);
+        }
+    }
+
+    private void copyParticipantsWithCustomAmounts(
+            List<SettlementParticipantDTO> activeParticipants, SettlementDTO newSettlement
+    ) {
+        List<Long> participantIds = activeParticipants.stream()
+                .map(SettlementParticipantDTO::getParticipantId)
+                .toList();
+
+        Map<Long, BigDecimal> latestObligationByParticipant = paymentObligationMapper.findByParticipantIds(participantIds)
+                .stream()
+                .collect(Collectors.toMap(PaymentObligationDTO::getParticipantId, PaymentObligationDTO::getExpectedAmount));
 
         for (SettlementParticipantDTO oldParticipant : activeParticipants) {
-            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), recurring.getSplitType(), equalAmount, latestObligationByParticipant);
+            BigDecimal expectedAmount = latestObligationByParticipant.get(oldParticipant.getParticipantId());
+            if (expectedAmount == null) {
+                throw PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND.toException();
+            }
+            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), expectedAmount);
         }
-
-        return newSettlement;
     }
 
     private void copyParticipantWithObligation(
-            SettlementParticipantDTO oldParticipant, Long newSettlementId, SplitType splitType,
-            BigDecimal equalAmount, Map<Long, BigDecimal> latestObligationByParticipant
+            SettlementParticipantDTO oldParticipant, Long newSettlementId, BigDecimal expectedAmount
     ) {
         SettlementParticipantDTO newParticipant = SettlementParticipantDTO.builder()
                 .userId(oldParticipant.getUserId())
@@ -114,16 +134,6 @@ public class RecurringSettlementCycleGenerator {
         int inserted = participantMapper.insert(newParticipant);
         if (inserted != 1) {
             throw SettlementErrorCode.SETTLEMENT_PARTICIPANT_CREATE_FAILED.toException();
-        }
-
-        BigDecimal expectedAmount;
-        if (splitType == SplitType.EQUAL) {
-            expectedAmount = equalAmount;
-        } else {
-            expectedAmount = latestObligationByParticipant.get(oldParticipant.getParticipantId());
-            if (expectedAmount == null) {
-                throw PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND.toException();
-            }
         }
 
         settlementPaymentService.createObligation(newParticipant.getParticipantId(), expectedAmount);

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -15,50 +15,45 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
-import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
-import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
-import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+import org.teamsai.saibackend.domain.settlement.type.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class RecurringSettlementCycleGenerator {
+
     private final SettlementMapper settlementMapper;
     private final SettlementParticipantMapper participantMapper;
     private final PaymentObligationMapper paymentObligationMapper;
-    private final SettlementPaymentService settlementPaymentService; // 기존 서비스 재사용
-
+    private final SettlementPaymentService settlementPaymentService;
+    private final SettlementAmountCalculator settlementAmountCalculator;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void generateNextCycle(RecurringSettlementDTO recurring, LocalDate baseDate) {
-        SettlementDTO latestSettlement =
-                settlementMapper.findLatestByRecurringId(recurring.getRecurringSettlementId());
+    public SettlementDTO generateOneCycle(RecurringSettlementDTO recurring, SettlementDTO previousSettlement, LocalDate cycleDate) {
+        SettlementDTO lockedLatest =
+                settlementMapper.findLatestByRecurringIdForUpdate(recurring.getRecurringSettlementId());
 
-        if (latestSettlement == null) {
-            log.warn("직전 회차 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
-            return;
-        }
-
-        if (!isDueToday(recurring, latestSettlement, baseDate)) {
-            return;
+        if (lockedLatest == null || !lockedLatest.getSettlementId().equals(previousSettlement.getSettlementId())) {
+            log.warn("동시 생성 감지, 스킵 recurringId={}", recurring.getRecurringSettlementId());
+            return null;
         }
 
         List<SettlementParticipantDTO> activeParticipants =
-                participantMapper.findBySettlementId(latestSettlement.getSettlementId())
+                participantMapper.findBySettlementId(previousSettlement.getSettlementId())
                         .stream()
                         .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
                         .toList();
 
         if (activeParticipants.isEmpty()) {
-            log.warn("ACTIVE 참여자 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
-            return;
+            log.warn("ACTIVE 참여자 없음, 생성 스킵 recurringId={}, cycleDate={}",
+                    recurring.getRecurringSettlementId(), cycleDate);
+            return null;
         }
 
         SettlementDTO newSettlement = SettlementDTO.builder()
@@ -70,7 +65,7 @@ public class RecurringSettlementCycleGenerator {
                 .title(recurring.getTitle())
                 .splitType(recurring.getSplitType())
                 .totalAmount(recurring.getTotalAmount())
-                .cycleDate(baseDate)
+                .cycleDate(cycleDate)
                 .dueDate(null)
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -80,43 +75,20 @@ public class RecurringSettlementCycleGenerator {
             throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
         }
 
+        BigDecimal equalAmount = recurring.getSplitType() == SplitType.EQUAL
+                ? settlementAmountCalculator.calculateEqualAmount(recurring.getTotalAmount(), activeParticipants.size())
+                : null;
+
         for (SettlementParticipantDTO oldParticipant : activeParticipants) {
-            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId());
+            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), recurring.getSplitType(), equalAmount);
         }
+
+        return newSettlement;
     }
 
-    private boolean isDueToday(RecurringSettlementDTO recurring, SettlementDTO latestSettlement, LocalDate baseDate) {
-        LocalDate lastCycleDate = latestSettlement.getCycleDate();
-
-        return switch (recurring.getCycleRule()) {
-            case DAILY -> !lastCycleDate.isEqual(baseDate);
-            case WEEKLY -> ChronoUnit.WEEKS.between(lastCycleDate, baseDate) >= 1;
-            case MONTHLY -> isDueByMonthlyAnchor(recurring.getStartDate(), lastCycleDate, baseDate);
-            case YEARLY -> isDueByYearlyAnchor(recurring.getStartDate(), lastCycleDate, baseDate);
-        };
-    }
-
-    private boolean isDueByMonthlyAnchor(LocalDate startDate, LocalDate lastCycleDate, LocalDate baseDate) {
-        int anchorDay = startDate.getDayOfMonth();
-        YearMonth nextTargetMonth = YearMonth.from(lastCycleDate).plusMonths(1);
-        LocalDate expectedNextDate = clampToMonth(nextTargetMonth, anchorDay);
-        return !baseDate.isBefore(expectedNextDate);
-    }
-
-    private boolean isDueByYearlyAnchor(LocalDate startDate, LocalDate lastCycleDate, LocalDate baseDate) {
-        int anchorMonth = startDate.getMonthValue();
-        int anchorDay = startDate.getDayOfMonth();
-        YearMonth nextTargetMonth = YearMonth.of(lastCycleDate.getYear() + 1, anchorMonth);
-        LocalDate expectedNextDate = clampToMonth(nextTargetMonth, anchorDay);
-        return !baseDate.isBefore(expectedNextDate);
-    }
-
-    private LocalDate clampToMonth(YearMonth targetMonth, int anchorDay) {
-        int actualDay = Math.min(anchorDay, targetMonth.lengthOfMonth());
-        return targetMonth.atDay(actualDay);
-    }
-
-    private void copyParticipantWithObligation(SettlementParticipantDTO oldParticipant, Long newSettlementId) {
+    private void copyParticipantWithObligation(
+            SettlementParticipantDTO oldParticipant, Long newSettlementId, SplitType splitType, BigDecimal equalAmount
+    ) {
         SettlementParticipantDTO newParticipant = SettlementParticipantDTO.builder()
                 .userId(oldParticipant.getUserId())
                 .settlementId(newSettlementId)
@@ -130,10 +102,29 @@ public class RecurringSettlementCycleGenerator {
             throw SettlementErrorCode.SETTLEMENT_PARTICIPANT_CREATE_FAILED.toException();
         }
 
-        BigDecimal expectedAmount = paymentObligationMapper.findByParticipantId(oldParticipant.getParticipantId())
-                .map(PaymentObligationDTO::getExpectedAmount)
-                .orElseThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND::toException);
+        BigDecimal expectedAmount;
+        if (splitType == SplitType.EQUAL) {
+            expectedAmount = equalAmount;
+        } else {
+            expectedAmount = paymentObligationMapper.findByParticipantId(oldParticipant.getParticipantId())
+                    .map(PaymentObligationDTO::getExpectedAmount)
+                    .orElseThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND::toException);
+        }
 
         settlementPaymentService.createObligation(newParticipant.getParticipantId(), expectedAmount);
+    }
+
+    public LocalDate calculateNthCycleDate(LocalDate startDate, CycleRule cycleRule, int n) {
+        return switch (cycleRule) {
+            case DAILY -> startDate.plusDays(n);
+            case WEEKLY -> startDate.plusWeeks(n);
+            case MONTHLY -> clampToMonth(YearMonth.from(startDate).plusMonths(n), startDate.getDayOfMonth());
+            case YEARLY -> clampToMonth(YearMonth.of(startDate.getYear() + n, startDate.getMonthValue()), startDate.getDayOfMonth());
+        };
+    }
+
+    private LocalDate clampToMonth(YearMonth targetMonth, int anchorDay) {
+        int actualDay = Math.min(anchorDay, targetMonth.lengthOfMonth());
+        return targetMonth.atDay(actualDay);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -76,7 +76,7 @@ public class RecurringSettlementCycleGenerator {
         }
 
         BigDecimal equalAmount = recurring.getSplitType() == SplitType.EQUAL
-                ? settlementAmountCalculator.calculateEqualAmount(recurring.getTotalAmount(), activeParticipants.size())
+                ? settlementAmountCalculator.calculateEqualAmountForTotalCount(recurring.getTotalAmount(), activeParticipants.size())
                 : null;
 
         for (SettlementParticipantDTO oldParticipant : activeParticipants) {

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -1,0 +1,121 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecurringSettlementCycleGenerator {
+    private final SettlementMapper settlementMapper;
+    private final SettlementParticipantMapper participantMapper;
+    private final PaymentObligationMapper paymentObligationMapper;
+    private final SettlementPaymentService settlementPaymentService; // 기존 서비스 재사용
+
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void generateNextCycle(RecurringSettlementDTO recurring, LocalDate baseDate) {
+        SettlementDTO latestSettlement =
+                settlementMapper.findLatestByRecurringId(recurring.getRecurringSettlementId());
+
+        if (latestSettlement == null) {
+            log.warn("직전 회차 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
+            return;
+        }
+
+        if (!isDueToday(recurring, latestSettlement, baseDate)) {
+            return;
+        }
+
+        List<SettlementParticipantDTO> activeParticipants =
+                participantMapper.findBySettlementId(latestSettlement.getSettlementId())
+                        .stream()
+                        .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
+                        .toList();
+
+        if (activeParticipants.isEmpty()) {
+            log.warn("ACTIVE 참여자 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
+            return;
+        }
+
+        SettlementDTO newSettlement = SettlementDTO.builder()
+                .recurringSettlementId(recurring.getRecurringSettlementId())
+                .ownerId(recurring.getOwnerId())
+                .settlementType(SettlementType.RECURRING)
+                .settlementStatus(SettlementStatus.IN_PROGRESS)
+                .settlementCategory(recurring.getSettlementCategory())
+                .title(recurring.getTitle())
+                .splitType(recurring.getSplitType())
+                .totalAmount(recurring.getTotalAmount())
+                .cycleDate(baseDate)
+                .dueDate(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        int inserted = settlementMapper.insertSettlement(newSettlement);
+        if (inserted != 1) {
+            throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
+        }
+
+        for (SettlementParticipantDTO oldParticipant : activeParticipants) {
+            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId());
+        }
+    }
+
+    private boolean isDueToday(RecurringSettlementDTO recurring, SettlementDTO latestSettlement, LocalDate baseDate) {
+        LocalDate lastCycleDate = latestSettlement.getCycleDate();
+
+        return switch (recurring.getCycleRule()) {
+            case DAILY -> !lastCycleDate.isEqual(baseDate);
+            case WEEKLY -> ChronoUnit.WEEKS.between(lastCycleDate, baseDate) >= 1;
+            case MONTHLY -> ChronoUnit.MONTHS.between(lastCycleDate, baseDate) >= 1
+                    && lastCycleDate.getDayOfMonth() == baseDate.getDayOfMonth();
+            case YEARLY -> ChronoUnit.YEARS.between(lastCycleDate, baseDate) >= 1
+                    && lastCycleDate.getMonth() == baseDate.getMonth()
+                    && lastCycleDate.getDayOfMonth() == baseDate.getDayOfMonth();
+        };
+    }
+
+    private void copyParticipantWithObligation(SettlementParticipantDTO oldParticipant, Long newSettlementId) {
+        SettlementParticipantDTO newParticipant = SettlementParticipantDTO.builder()
+                .userId(oldParticipant.getUserId())
+                .settlementId(newSettlementId)
+                .participantRole(oldParticipant.getParticipantRole())
+                .participantStatus(SettlementParticipantStatus.ACTIVE)
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        int inserted = participantMapper.insert(newParticipant);
+        if (inserted != 1) {
+            throw SettlementErrorCode.SETTLEMENT_PARTICIPANT_CREATE_FAILED.toException();
+        }
+
+        BigDecimal expectedAmount = paymentObligationMapper.findByParticipantId(oldParticipant.getParticipantId())
+                .map(PaymentObligationDTO::getExpectedAmount)
+                .orElseThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND::toException);
+        
+        settlementPaymentService.createObligation(newParticipant.getParticipantId(), expectedAmount);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -22,6 +22,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -38,7 +40,6 @@ public class RecurringSettlementCycleGenerator {
     public SettlementDTO generateOneCycle(RecurringSettlementDTO recurring, SettlementDTO previousSettlement, LocalDate cycleDate) {
         SettlementDTO lockedLatest =
                 settlementMapper.findLatestByRecurringIdForUpdate(recurring.getRecurringSettlementId());
-
         if (lockedLatest == null || !lockedLatest.getSettlementId().equals(previousSettlement.getSettlementId())) {
             log.warn("동시 생성 감지, 스킵 recurringId={}", recurring.getRecurringSettlementId());
             return null;
@@ -75,19 +76,32 @@ public class RecurringSettlementCycleGenerator {
             throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
         }
 
-        BigDecimal equalAmount = recurring.getSplitType() == SplitType.EQUAL
-                ? settlementAmountCalculator.calculateEqualAmountForTotalCount(recurring.getTotalAmount(), activeParticipants.size())
-                : null;
+        BigDecimal equalAmount = null;
+        Map<Long, BigDecimal> latestObligationByParticipant = Map.of();
+
+        if (recurring.getSplitType() == SplitType.EQUAL) {
+            equalAmount = settlementAmountCalculator.calculateEqualAmountForTotalCount(
+                    recurring.getTotalAmount(), activeParticipants.size());
+        } else {
+            List<Long> participantIds = activeParticipants.stream()
+                    .map(SettlementParticipantDTO::getParticipantId)
+                    .toList();
+
+            latestObligationByParticipant = paymentObligationMapper.findByParticipantIds(participantIds)
+                    .stream()
+                    .collect(Collectors.toMap(PaymentObligationDTO::getParticipantId, PaymentObligationDTO::getExpectedAmount));
+        }
 
         for (SettlementParticipantDTO oldParticipant : activeParticipants) {
-            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), recurring.getSplitType(), equalAmount);
+            copyParticipantWithObligation(oldParticipant, newSettlement.getSettlementId(), recurring.getSplitType(), equalAmount, latestObligationByParticipant);
         }
 
         return newSettlement;
     }
 
     private void copyParticipantWithObligation(
-            SettlementParticipantDTO oldParticipant, Long newSettlementId, SplitType splitType, BigDecimal equalAmount
+            SettlementParticipantDTO oldParticipant, Long newSettlementId, SplitType splitType,
+            BigDecimal equalAmount, Map<Long, BigDecimal> latestObligationByParticipant
     ) {
         SettlementParticipantDTO newParticipant = SettlementParticipantDTO.builder()
                 .userId(oldParticipant.getUserId())
@@ -106,9 +120,10 @@ public class RecurringSettlementCycleGenerator {
         if (splitType == SplitType.EQUAL) {
             expectedAmount = equalAmount;
         } else {
-            expectedAmount = paymentObligationMapper.findByParticipantId(oldParticipant.getParticipantId())
-                    .map(PaymentObligationDTO::getExpectedAmount)
-                    .orElseThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND::toException);
+            expectedAmount = latestObligationByParticipant.get(oldParticipant.getParticipantId());
+            if (expectedAmount == null) {
+                throw PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND.toException();
+            }
         }
 
         settlementPaymentService.createObligation(newParticipant.getParticipantId(), expectedAmount);

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementCycleGenerator.java
@@ -22,6 +22,7 @@ import org.teamsai.saibackend.domain.settlement.type.SettlementType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -90,12 +91,29 @@ public class RecurringSettlementCycleGenerator {
         return switch (recurring.getCycleRule()) {
             case DAILY -> !lastCycleDate.isEqual(baseDate);
             case WEEKLY -> ChronoUnit.WEEKS.between(lastCycleDate, baseDate) >= 1;
-            case MONTHLY -> ChronoUnit.MONTHS.between(lastCycleDate, baseDate) >= 1
-                    && lastCycleDate.getDayOfMonth() == baseDate.getDayOfMonth();
-            case YEARLY -> ChronoUnit.YEARS.between(lastCycleDate, baseDate) >= 1
-                    && lastCycleDate.getMonth() == baseDate.getMonth()
-                    && lastCycleDate.getDayOfMonth() == baseDate.getDayOfMonth();
+            case MONTHLY -> isDueByMonthlyAnchor(recurring.getStartDate(), lastCycleDate, baseDate);
+            case YEARLY -> isDueByYearlyAnchor(recurring.getStartDate(), lastCycleDate, baseDate);
         };
+    }
+
+    private boolean isDueByMonthlyAnchor(LocalDate startDate, LocalDate lastCycleDate, LocalDate baseDate) {
+        int anchorDay = startDate.getDayOfMonth();
+        YearMonth nextTargetMonth = YearMonth.from(lastCycleDate).plusMonths(1);
+        LocalDate expectedNextDate = clampToMonth(nextTargetMonth, anchorDay);
+        return !baseDate.isBefore(expectedNextDate);
+    }
+
+    private boolean isDueByYearlyAnchor(LocalDate startDate, LocalDate lastCycleDate, LocalDate baseDate) {
+        int anchorMonth = startDate.getMonthValue();
+        int anchorDay = startDate.getDayOfMonth();
+        YearMonth nextTargetMonth = YearMonth.of(lastCycleDate.getYear() + 1, anchorMonth);
+        LocalDate expectedNextDate = clampToMonth(nextTargetMonth, anchorDay);
+        return !baseDate.isBefore(expectedNextDate);
+    }
+
+    private LocalDate clampToMonth(YearMonth targetMonth, int anchorDay) {
+        int actualDay = Math.min(anchorDay, targetMonth.lengthOfMonth());
+        return targetMonth.atDay(actualDay);
     }
 
     private void copyParticipantWithObligation(SettlementParticipantDTO oldParticipant, Long newSettlementId) {
@@ -115,7 +133,7 @@ public class RecurringSettlementCycleGenerator {
         BigDecimal expectedAmount = paymentObligationMapper.findByParticipantId(oldParticipant.getParticipantId())
                 .map(PaymentObligationDTO::getExpectedAmount)
                 .orElseThrow(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND::toException);
-        
+
         settlementPaymentService.createObligation(newParticipant.getParticipantId(), expectedAmount);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
@@ -1,0 +1,31 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
+
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecurringSettlementGenerationService {
+    private final RecurringSettlementMapper recurringSettlementMapper;
+    private final RecurringSettlementCycleGenerator cycleGenerator;
+
+    public void generateTodaySettlements(LocalDate baseDate) {
+        List<RecurringSettlementDTO> candidates = recurringSettlementMapper.findActiveInRange(baseDate);
+
+        for (RecurringSettlementDTO recurring : candidates) {
+            try {
+                cycleGenerator.generateNextCycle(recurring, baseDate); // 다른 Bean 통해 호출 → 프록시 거침
+            } catch (Exception e) {
+                log.error("정산 회차 생성 실패 recurringId={}", recurring.getRecurringSettlementId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
@@ -8,8 +8,8 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 
-
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -17,49 +17,90 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecurringSettlementGenerationService {
 
+    private static final int MAX_CATCHUP_CYCLES_PER_SETTLEMENT = 31;
+
     private final RecurringSettlementMapper recurringSettlementMapper;
     private final SettlementMapper settlementMapper;
     private final RecurringSettlementCycleGenerator cycleGenerator;
 
-    public void generateTodaySettlements(LocalDate baseDate) {
+    public RecurringSettlementBatchResult generateTodaySettlements(LocalDate baseDate) {
         List<RecurringSettlementDTO> candidates =
                 recurringSettlementMapper.findActiveInRange(baseDate);
 
+        int succeeded = 0;
+        int failed = 0;
+        List<Long> failedRecurringIds = new ArrayList<>();
+
         for (RecurringSettlementDTO recurring : candidates) {
-            catchUpCycles(recurring, baseDate);
+            boolean ok = catchUpCycles(recurring, baseDate);
+            if (ok) {
+                succeeded++;
+            } else {
+                failed++;
+                failedRecurringIds.add(recurring.getRecurringSettlementId());
+            }
         }
+
+        RecurringSettlementBatchResult result =
+                new RecurringSettlementBatchResult(candidates.size(), succeeded, failed, failedRecurringIds);
+
+        log.info("정기정산 회차 생성 배치 종료 결과={}", result);
+        return result;
     }
 
-    private void catchUpCycles(RecurringSettlementDTO recurring, LocalDate baseDate) {
+    /**
+     * @return 이 정기정산 처리 중 예외 없이 정상 종료됐으면 true, 캐치업 도중 예외로 중단됐으면 false
+     */
+    private boolean catchUpCycles(RecurringSettlementDTO recurring, LocalDate baseDate) {
         SettlementDTO cursorSettlement =
                 settlementMapper.findLatestByRecurringId(recurring.getRecurringSettlementId());
 
         if (cursorSettlement == null) {
             log.warn("직전 회차 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
-            return;
+            return true; // 데이터 이상은 아니고 정상적인 "생성 대상 아님" 케이스
         }
 
         int cycleCount = settlementMapper.countByRecurringId(recurring.getRecurringSettlementId());
+        int generatedThisRun = 0;
 
         while (true) {
             LocalDate theoreticalNextDate =
                     cycleGenerator.calculateNthCycleDate(recurring.getStartDate(), recurring.getCycleRule(), cycleCount);
 
             if (baseDate.isBefore(theoreticalNextDate)) {
-                break;
+                return true; // 정상 종료
+            }
+            if (recurring.getEndDate() != null && theoreticalNextDate.isAfter(recurring.getEndDate())) {
+                return true; // 종료일 도달, 정상 종료
+            }
+            if (generatedThisRun >= MAX_CATCHUP_CYCLES_PER_SETTLEMENT) {
+                log.warn("정기정산 캐치업 상한 도달, 다음 배치에서 이어서 처리 예정 recurringId={}, 생성={}건",
+                        recurring.getRecurringSettlementId(), generatedThisRun);
+                return true; // 상한 도달은 실패가 아니라 다음 배치로 이어지는 정상 흐름
             }
 
             try {
-                SettlementDTO created = cycleGenerator.generateOneCycle(recurring, cursorSettlement, theoreticalNextDate);
-                if (created == null) {
-                    break;
+                CycleGenerationOutcome outcome =
+                        cycleGenerator.generateOneCycle(recurring, cursorSettlement, theoreticalNextDate);
+
+                switch (outcome.result()) {
+                    case CREATED -> {
+                        cursorSettlement = outcome.settlement();
+                        cycleCount++;
+                        generatedThisRun++;
+                    }
+                    case CONCURRENTLY_SKIPPED -> {
+                        return true; // 다른 트랜잭션이 이미 처리 중, 정상
+                    }
+                    case NO_ACTIVE_PARTICIPANT -> {
+                        log.warn("데이터 확인 필요: ACTIVE 참여자 없음 recurringId={}", recurring.getRecurringSettlementId());
+                        return true; // 실패는 아니지만 확인이 필요한 상태로 로그만 강조
+                    }
                 }
-                cursorSettlement = created;
-                cycleCount++;
             } catch (Exception e) {
-                log.error("정산 회차 생성 실패, 다음 배치에서 재시도 예정 recurringId={}, targetDate={}",
+                log.error("정산 회차 생성 실패 recurringId={}, targetDate={}",
                         recurring.getRecurringSettlementId(), theoreticalNextDate, e);
-                break;
+                return false; // 진짜 실패 -> 집계에 반영됨
             }
         }
     }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementGenerationService.java
@@ -4,27 +4,62 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class RecurringSettlementGenerationService {
+
     private final RecurringSettlementMapper recurringSettlementMapper;
+    private final SettlementMapper settlementMapper;
     private final RecurringSettlementCycleGenerator cycleGenerator;
 
     public void generateTodaySettlements(LocalDate baseDate) {
-        List<RecurringSettlementDTO> candidates = recurringSettlementMapper.findActiveInRange(baseDate);
+        List<RecurringSettlementDTO> candidates =
+                recurringSettlementMapper.findActiveInRange(baseDate);
 
         for (RecurringSettlementDTO recurring : candidates) {
+            catchUpCycles(recurring, baseDate);
+        }
+    }
+
+    private void catchUpCycles(RecurringSettlementDTO recurring, LocalDate baseDate) {
+        SettlementDTO cursorSettlement =
+                settlementMapper.findLatestByRecurringId(recurring.getRecurringSettlementId());
+
+        if (cursorSettlement == null) {
+            log.warn("직전 회차 없음, 생성 스킵 recurringId={}", recurring.getRecurringSettlementId());
+            return;
+        }
+
+        int cycleCount = settlementMapper.countByRecurringId(recurring.getRecurringSettlementId());
+
+        while (true) {
+            LocalDate theoreticalNextDate =
+                    cycleGenerator.calculateNthCycleDate(recurring.getStartDate(), recurring.getCycleRule(), cycleCount);
+
+            if (baseDate.isBefore(theoreticalNextDate)) {
+                break;
+            }
+
             try {
-                cycleGenerator.generateNextCycle(recurring, baseDate); // 다른 Bean 통해 호출 → 프록시 거침
+                SettlementDTO created = cycleGenerator.generateOneCycle(recurring, cursorSettlement, theoreticalNextDate);
+                if (created == null) {
+                    break;
+                }
+                cursorSettlement = created;
+                cycleCount++;
             } catch (Exception e) {
-                log.error("정산 회차 생성 실패 recurringId={}", recurring.getRecurringSettlementId(), e);
+                log.error("정산 회차 생성 실패, 다음 배치에서 재시도 예정 recurringId={}, targetDate={}",
+                        recurring.getRecurringSettlementId(), theoreticalNextDate, e);
+                break;
             }
         }
     }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAmountCalculator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAmountCalculator.java
@@ -5,6 +5,8 @@ import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class SettlementAmountCalculator {
@@ -15,18 +17,46 @@ public class SettlementAmountCalculator {
         return calculateEqualAmountForTotalCount(totalAmount, participantCount + 1);
     }
 
-    public BigDecimal calculateEqualAmountForTotalCount(
-            BigDecimal totalAmount,
-            int totalParticipantCount
-    ) {
-        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
-        }
+    public BigDecimal calculateEqualAmountForTotalCount(BigDecimal totalAmount, int totalParticipantCount) {
+        validateInput(totalAmount, totalParticipantCount);
+
         BigDecimal perPersonAmount = totalAmount.divide(
                 BigDecimal.valueOf(totalParticipantCount), WON_SCALE, RoundingMode.DOWN);
+
         if (perPersonAmount.compareTo(BigDecimal.ZERO) <= 0) {
             throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
         }
         return perPersonAmount;
+    }
+
+    /**
+     * 총액을 totalParticipantCount명에게 균등 분배하되, 나머지(반올림 손실분)는
+     * 마지막 참여자에게 배정하여 합계가 totalAmount와 정확히 일치하도록 한다.
+     */
+    public List<BigDecimal> distributeEqualAmounts(BigDecimal totalAmount, int totalParticipantCount) {
+        validateInput(totalAmount, totalParticipantCount);
+
+        BigDecimal baseAmount = totalAmount.divide(
+                BigDecimal.valueOf(totalParticipantCount), WON_SCALE, RoundingMode.DOWN);
+        BigDecimal remainder = totalAmount.subtract(
+                baseAmount.multiply(BigDecimal.valueOf(totalParticipantCount)));
+
+        List<BigDecimal> amounts = new ArrayList<>();
+        for (int i = 0; i < totalParticipantCount; i++) {
+            amounts.add(baseAmount);
+        }
+        int lastIndex = totalParticipantCount - 1;
+        amounts.set(lastIndex, amounts.get(lastIndex).add(remainder));
+
+        return amounts;
+    }
+
+    private void validateInput(BigDecimal totalAmount, int totalParticipantCount) {
+        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
+        }
+        if (totalParticipantCount <= 0) {
+            throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
+        }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAmountCalculator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/SettlementAmountCalculator.java
@@ -11,32 +11,22 @@ public class SettlementAmountCalculator {
 
     private static final int WON_SCALE = 0;
 
-    public BigDecimal calculateEqualAmount(
+    public BigDecimal calculateEqualAmount(BigDecimal totalAmount, int participantCount) {
+        return calculateEqualAmountForTotalCount(totalAmount, participantCount + 1);
+    }
+
+    public BigDecimal calculateEqualAmountForTotalCount(
             BigDecimal totalAmount,
-            int participantCount
+            int totalParticipantCount
     ) {
-        if (totalAmount == null
-                || totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw SettlementErrorCode
-                    .INVALID_SETTLEMENT_AMOUNT
-                    .toException();
+        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
         }
-
-        int totalParticipantCount = participantCount + 1;
-
-        BigDecimal perPersonAmount =
-                totalAmount.divide(
-                        BigDecimal.valueOf(totalParticipantCount),
-                        WON_SCALE,
-                        RoundingMode.DOWN
-                );
-
+        BigDecimal perPersonAmount = totalAmount.divide(
+                BigDecimal.valueOf(totalParticipantCount), WON_SCALE, RoundingMode.DOWN);
         if (perPersonAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw SettlementErrorCode
-                    .INVALID_SETTLEMENT_AMOUNT
-                    .toException();
+            throw SettlementErrorCode.INVALID_SETTLEMENT_AMOUNT.toException();
         }
-
         return perPersonAmount;
     }
 }

--- a/src/main/resources/db/03_contractchange.sql
+++ b/src/main/resources/db/03_contractchange.sql
@@ -40,7 +40,7 @@ ALTER TABLE loan_contract_change_request
     MODIFY COLUMN new_repayment_type VARCHAR(30) NULL;
 
 ALTER TABLE loan_contract_change_request
-    ADD COLUMN requester_signature VARCHAR(255) NULL AFTER return_reason;
+    ADD COLUMN IF NOT EXISTS requester_signature VARCHAR(255) NULL AFTER return_reason;
 
 ALTER TABLE loan_contract_change_request
 DROP CONSTRAINT IF EXISTS status;

--- a/src/main/resources/db/payment.sql
+++ b/src/main/resources/db/payment.sql
@@ -50,3 +50,24 @@ CREATE TABLE IF NOT EXISTS payment_record (
 ) ENGINE=InnoDB
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;
+
+SET @constraint_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'settlement'
+      AND CONSTRAINT_NAME = 'chk_recurring_fields'
+);
+
+SET @sql = IF(@constraint_exists = 0,
+              'ALTER TABLE settlement ADD CONSTRAINT chk_recurring_fields
+                  CHECK (
+                      settlement_type != ''RECURRING''
+                      OR (recurring_settlement_id IS NOT NULL AND cycle_date IS NOT NULL)
+                  )',
+              'SELECT ''chk_recurring_fields already exists'' AS message'
+           );
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/payment.sql
+++ b/src/main/resources/db/payment.sql
@@ -17,6 +17,23 @@ CREATE TABLE IF NOT EXISTS payment_obligation (
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;
 
+SET @constraint_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'payment_obligation'
+      AND INDEX_NAME = 'uq_payment_obligation_participant'
+);
+
+SET @sql = IF(@constraint_exists = 0,
+              'ALTER TABLE payment_obligation ADD CONSTRAINT uq_payment_obligation_participant UNIQUE (participant_id)',
+              'SELECT ''uq_payment_obligation_participant already exists'' AS message'
+           );
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 CREATE TABLE IF NOT EXISTS payment_record (
     payment_record_id BIGINT NOT NULL AUTO_INCREMENT,
     bank_transaction_id BIGINT NOT NULL,

--- a/src/main/resources/db/payment.sql
+++ b/src/main/resources/db/payment.sql
@@ -17,23 +17,6 @@ CREATE TABLE IF NOT EXISTS payment_obligation (
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;
 
-SET @constraint_exists = (
-    SELECT COUNT(*)
-    FROM information_schema.STATISTICS
-    WHERE TABLE_SCHEMA = DATABASE()
-      AND TABLE_NAME = 'payment_obligation'
-      AND INDEX_NAME = 'uq_payment_obligation_participant'
-);
-
-SET @sql = IF(@constraint_exists = 0,
-              'ALTER TABLE payment_obligation ADD CONSTRAINT uq_payment_obligation_participant UNIQUE (participant_id)',
-              'SELECT ''uq_payment_obligation_participant already exists'' AS message'
-           );
-
-PREPARE stmt FROM @sql;
-EXECUTE stmt;
-DEALLOCATE PREPARE stmt;
-
 CREATE TABLE IF NOT EXISTS payment_record (
     payment_record_id BIGINT NOT NULL AUTO_INCREMENT,
     bank_transaction_id BIGINT NOT NULL,

--- a/src/main/resources/db/settlement.sql
+++ b/src/main/resources/db/settlement.sql
@@ -38,3 +38,20 @@ CREATE TABLE IF NOT EXISTS settlement (
 ENGINE = InnoDB
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;
+
+SET @constraint_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'settlement'
+      AND INDEX_NAME = 'uq_settlement_recurring_cycle'
+);
+
+SET @sql = IF(@constraint_exists = 0,
+    'ALTER TABLE settlement ADD CONSTRAINT uq_settlement_recurring_cycle UNIQUE (recurring_settlement_id, cycle_date)',
+    'SELECT ''uq_settlement_recurring_cycle already exists'' AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/settlement.sql
+++ b/src/main/resources/db/settlement.sql
@@ -39,19 +39,20 @@ ENGINE = InnoDB
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;
 
-SET @constraint_exists = (
-    SELECT COUNT(*)
-    FROM information_schema.STATISTICS
-    WHERE TABLE_SCHEMA = DATABASE()
-      AND TABLE_NAME = 'settlement'
-      AND INDEX_NAME = 'uq_settlement_recurring_cycle'
+SET @col_exists = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'settlement' AND COLUMN_NAME = 'recurring_settlement_id'
 );
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE settlement ADD COLUMN recurring_settlement_id BIGINT NULL',
+    'SELECT ''recurring_settlement_id already exists'' AS message');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-SET @sql = IF(@constraint_exists = 0,
-    'ALTER TABLE settlement ADD CONSTRAINT uq_settlement_recurring_cycle UNIQUE (recurring_settlement_id, cycle_date)',
-    'SELECT ''uq_settlement_recurring_cycle already exists'' AS message'
+SET @col_exists = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'settlement' AND COLUMN_NAME = 'cycle_date'
 );
-
-PREPARE stmt FROM @sql;
-EXECUTE stmt;
-DEALLOCATE PREPARE stmt;
+SET @sql = IF(@col_exists = 0,
+    'ALTER TABLE settlement ADD COLUMN cycle_date DATE NULL',
+    'SELECT ''cycle_date already exists'' AS message');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -157,4 +157,11 @@
         #{obligationStatus}
         )
     </insert>
+
+    <select id="findByParticipantId" resultMap="PaymentObligationResultMap">
+        SELECT payment_obligation_id, participant_id, expected_amount,
+        payment_status, review_status, obligation_status
+        FROM payment_obligation
+        WHERE participant_id = #{participantId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -157,7 +157,9 @@
         #{obligationStatus}
         )
     </insert>
-
+    
+    <!-- 주의: obligation_status='ACTIVE'는 "정산이 진행 중"이 아니라 "이 obligation이 취소/제외되지 않음"을 의미.
+         정산 종료 여부는 상위 settlement.settlement_status로 별도 판단해야 함. -->
     <select id="findByParticipantIds" resultMap="PaymentObligationResultMap">
         SELECT po.payment_obligation_id, po.participant_id, po.expected_amount,
         po.payment_status, po.review_status, po.obligation_status

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -167,4 +167,21 @@
         ORDER BY payment_obligation_id DESC
         LIMIT 1
     </select>
+
+    <select id="findByParticipantIds" resultMap="PaymentObligationResultMap">
+        SELECT po.payment_obligation_id, po.participant_id, po.expected_amount,
+        po.payment_status, po.review_status, po.obligation_status
+        FROM payment_obligation po
+        INNER JOIN (
+        SELECT participant_id, MAX(payment_obligation_id) AS latest_id
+        FROM payment_obligation
+        WHERE participant_id IN
+        <foreach item="id" collection="participantIds" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        AND obligation_status = 'ACTIVE'
+        GROUP BY participant_id
+        ) latest ON latest.participant_id = po.participant_id
+        AND latest.latest_id = po.payment_obligation_id
+    </select>
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -163,5 +163,7 @@
         payment_status, review_status, obligation_status
         FROM payment_obligation
         WHERE participant_id = #{participantId}
+        ORDER BY payment_obligation_id DESC
+        LIMIT 1
     </select>
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -163,6 +163,7 @@
         payment_status, review_status, obligation_status
         FROM payment_obligation
         WHERE participant_id = #{participantId}
+        AND obligation_status = 'ACTIVE'
         ORDER BY payment_obligation_id DESC
         LIMIT 1
     </select>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -158,16 +158,6 @@
         )
     </insert>
 
-    <select id="findByParticipantId" resultMap="PaymentObligationResultMap">
-        SELECT payment_obligation_id, participant_id, expected_amount,
-        payment_status, review_status, obligation_status
-        FROM payment_obligation
-        WHERE participant_id = #{participantId}
-        AND obligation_status = 'ACTIVE'
-        ORDER BY payment_obligation_id DESC
-        LIMIT 1
-    </select>
-
     <select id="findByParticipantIds" resultMap="PaymentObligationResultMap">
         SELECT po.payment_obligation_id, po.participant_id, po.expected_amount,
         po.payment_status, po.review_status, po.obligation_status

--- a/src/main/resources/mapper/settlement/RecurringSettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/RecurringSettlementMapper.xml
@@ -16,11 +16,15 @@
     </resultMap>
 
     <select id="findActiveInRange" resultMap="RecurringSettlementResultMap">
-        SELECT recurring_settlement_id, owner_id, settlement_category, title,
-               split_type, total_amount, cycle_rule, start_date, end_date, created_at
-        FROM recurring_settlement
-        WHERE start_date &lt;= #{baseDate}
-          AND (end_date IS NULL OR end_date &gt;= #{baseDate})
+        SELECT rs.recurring_settlement_id, rs.owner_id, rs.settlement_category, rs.title,
+               rs.split_type, rs.total_amount, rs.cycle_rule, rs.start_date, rs.end_date, rs.created_at
+        FROM recurring_settlement rs
+        WHERE rs.start_date &lt;= #{baseDate}
+          AND NOT EXISTS (
+            SELECT 1 FROM settlement s
+            WHERE s.recurring_settlement_id = rs.recurring_settlement_id
+              AND s.cycle_date &gt;= COALESCE(rs.end_date, #{baseDate})
+        )
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/settlement/RecurringSettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/RecurringSettlementMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper">
+
+    <resultMap id="RecurringSettlementResultMap" type="org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO">
+        <id property="recurringSettlementId" column="recurring_settlement_id"/>
+        <result property="ownerId" column="owner_id"/>
+        <result property="settlementCategory" column="settlement_category"/>
+        <result property="title" column="title"/>
+        <result property="splitType" column="split_type"/>
+        <result property="totalAmount" column="total_amount"/>
+        <result property="cycleRule" column="cycle_rule"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <select id="findActiveInRange" resultMap="RecurringSettlementResultMap">
+        SELECT recurring_settlement_id, owner_id, settlement_category, title,
+               split_type, total_amount, cycle_rule, start_date, end_date, created_at
+        FROM recurring_settlement
+        WHERE start_date &lt;= #{baseDate}
+          AND (end_date IS NULL OR end_date &gt;= #{baseDate})
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -185,4 +185,20 @@
 
     </select>
 
+    <select id="countByRecurringId" resultType="int">
+        SELECT COUNT(*)
+        FROM settlement
+        WHERE recurring_settlement_id = #{recurringSettlementId}
+    </select>
+
+    <select id="findLatestByRecurringIdForUpdate" resultMap="settlementResultMap">
+        SELECT settlement_id, recurring_settlement_id, owner_id, settlement_type, settlement_status,
+        settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at
+        FROM settlement
+        WHERE recurring_settlement_id = #{recurringSettlementId}
+        ORDER BY cycle_date DESC
+        LIMIT 1
+        FOR UPDATE
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -56,6 +56,15 @@
         )
     </insert>
 
+    <select id="findLatestByRecurringId" resultMap="settlementResultMap">
+        SELECT settlement_id, recurring_settlement_id, owner_id, settlement_type, settlement_status,
+        settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at, status
+        FROM settlement
+        WHERE recurring_settlement_id = #{recurringSettlementId}
+        ORDER BY cycle_date DESC
+        LIMIT 1
+    </select>
+
     <select id="findById" resultMap="settlementResultMap">
         SELECT
         settlement_id,

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -193,7 +193,7 @@
 
     <select id="findLatestByRecurringIdForUpdate" resultMap="settlementResultMap">
         SELECT settlement_id, recurring_settlement_id, owner_id, settlement_type, settlement_status,
-        settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at
+        settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at, status
         FROM settlement
         WHERE recurring_settlement_id = #{recurringSettlementId}
         ORDER BY cycle_date DESC

--- a/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
@@ -5,6 +5,15 @@
 
 <mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper">
 
+    <resultMap id="SettlementParticipantResultMap" type="org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO">
+        <id property="participantId" column="participant_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="settlementId" column="settlement_id"/>
+        <result property="participantRole" column="participant_role"/>
+        <result property="participantStatus" column="participant_status"/>
+        <result property="joinedAt" column="joined_at"/>
+    </resultMap>
+
     <insert id="insert"
             parameterType="org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO"
             useGeneratedKeys="true"
@@ -26,6 +35,12 @@
         )
 
     </insert>
+
+    <select id="findBySettlementId" resultMap="SettlementParticipantResultMap">
+        SELECT participant_id, user_id, settlement_id, participant_role, participant_status, joined_at
+        FROM settlement_participant
+        WHERE settlement_id = #{settlementId}
+    </select>
 
     <select id="existsActiveParticipant"
             resultType="boolean">

--- a/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
@@ -36,12 +36,6 @@
 
     </insert>
 
-    <select id="findBySettlementId" resultMap="SettlementParticipantResultMap">
-        SELECT participant_id, user_id, settlement_id, participant_role, participant_status, joined_at
-        FROM settlement_participant
-        WHERE settlement_id = #{settlementId}
-    </select>
-
     <select id="existsActiveParticipant"
             resultType="boolean">
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -26,7 +26,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -43,6 +42,10 @@ class RecurringSettlementCycleGeneratorTest {
     private RecurringSettlementCycleGenerator sut; // system under test
 
     private RecurringSettlementDTO recurring(CycleRule cycleRule) {
+        return recurring(cycleRule, LocalDate.of(2026, 1, 1));
+    }
+
+    private RecurringSettlementDTO recurring(CycleRule cycleRule, LocalDate startDate) {
         return RecurringSettlementDTO.builder()
                 .recurringSettlementId(1L)
                 .ownerId(100L)
@@ -51,7 +54,7 @@ class RecurringSettlementCycleGeneratorTest {
                 .splitType(SplitType.EQUAL)
                 .totalAmount(BigDecimal.valueOf(300000))
                 .cycleRule(cycleRule)
-                .startDate(LocalDate.of(2026, 1, 1))
+                .startDate(startDate)
                 .endDate(null)
                 .build();
     }
@@ -123,7 +126,7 @@ class RecurringSettlementCycleGeneratorTest {
     }
 
     @Nested
-    @DisplayName("CycleRule별 생성일 도래 판정")
+    @DisplayName("CycleRule별 생성일 도래 판정 (말일 앵커링 포함)")
     class DueDateJudgement {
 
         @Test
@@ -137,11 +140,7 @@ class RecurringSettlementCycleGeneratorTest {
             when(paymentObligationMapper.findByParticipantId(1L))
                     .thenReturn(Optional.of(PaymentObligationDTO.builder()
                             .expectedAmount(BigDecimal.valueOf(150000)).build()));
-            when(settlementMapper.insertSettlement(any())).thenAnswer(inv -> {
-                SettlementDTO s = inv.getArgument(0);
-                s.setSettlementId(20L); // setter 없으면 @Builder.Default 등으로 대체 필요
-                return 1;
-            });
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
 
             sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
@@ -150,23 +149,11 @@ class RecurringSettlementCycleGeneratorTest {
         }
 
         @Test
-        @DisplayName("MONTHLY - 같은 일자가 아니면 도래하지 않은 것으로 본다")
-        void monthlyNotDueOnDifferentDay() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
+        @DisplayName("MONTHLY - 1/31 시작, 직전 회차 1/31 → 2월은 말일인 28일에 도래한다")
+        void monthlyClampsToLastDayOfShortMonth() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
             when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 1)));
-
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)); // 1일이 아니라 2일
-
-            verify(settlementMapper, never()).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("MONTHLY - 같은 일자, 한 달 이상 지났으면 도래한 것으로 본다")
-        void monthlyDueOnSameDayNextMonth() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 1)));
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 31)));
             when(participantMapper.findBySettlementId(10L))
                     .thenReturn(List.of(activeParticipant(1L, 100L)));
             when(paymentObligationMapper.findByParticipantId(1L))
@@ -175,9 +162,85 @@ class RecurringSettlementCycleGeneratorTest {
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
 
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 1));
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 28));
 
             verify(settlementMapper).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("MONTHLY - 목표일(2/28) 이전이면 아직 도래하지 않은 것으로 본다")
+        void monthlyNotDueBeforeClampedTarget() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 31)));
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 27));
+
+            verify(settlementMapper, never()).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("MONTHLY - 2월에 28일로 클램프된 뒤에도, 3월엔 원래 anchor인 31일로 복귀한다")
+        void monthlyAnchorRecoversAfterClamp() {
+            // 직전 회차가 2/28(클램프된 값)이어도, anchor는 startDate의 31일을 계속 유지해야 함
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 28)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(paymentObligationMapper.findByParticipantId(1L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 3, 31));
+
+            verify(settlementMapper).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("MONTHLY - anchor 복귀 목표일(3/31) 이전인 3/30에는 아직 도래하지 않은 것으로 본다")
+        void monthlyNotDueBeforeAnchorRecovery() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 28)));
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 3, 30));
+
+            verify(settlementMapper, never()).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("YEARLY - 2/29 시작, 평년엔 2/28로 클램프되어 도래한다")
+        void yearlyClampsToFeb28InNonLeapYear() {
+            // 2024는 윤년, 2025는 평년
+            RecurringSettlementDTO recurring = recurring(CycleRule.YEARLY, LocalDate.of(2024, 2, 29));
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2024, 2, 29)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(paymentObligationMapper.findByParticipantId(1L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+
+            sut.generateNextCycle(recurring, LocalDate.of(2025, 2, 28));
+
+            verify(settlementMapper).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("YEARLY - 평년에 2/28로 클램프된 뒤, 다음 윤년엔 원래 anchor인 2/29로 복귀한다")
+        void yearlyAnchorRecoversOnNextLeapYear() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.YEARLY, LocalDate.of(2024, 2, 29));
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2027, 2, 28))); // 평년 회차
+
+            // 2028은 윤년 - 아직 2/28이면 도래 전
+            sut.generateNextCycle(recurring, LocalDate.of(2028, 2, 28));
+            verify(settlementMapper, never()).insertSettlement(any());
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -1,0 +1,258 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.exception.PaymentErrorCode;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
+import org.teamsai.saibackend.domain.settlement.type.*;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecurringSettlementCycleGeneratorTest {
+
+    @Mock private SettlementMapper settlementMapper;
+    @Mock private SettlementParticipantMapper participantMapper;
+    @Mock private PaymentObligationMapper paymentObligationMapper;
+    @Mock private SettlementPaymentService settlementPaymentService;
+
+    @InjectMocks
+    private RecurringSettlementCycleGenerator sut; // system under test
+
+    private RecurringSettlementDTO recurring(CycleRule cycleRule) {
+        return RecurringSettlementDTO.builder()
+                .recurringSettlementId(1L)
+                .ownerId(100L)
+                .settlementCategory("월세")
+                .title("자취방 월세")
+                .splitType(SplitType.EQUAL)
+                .totalAmount(BigDecimal.valueOf(300000))
+                .cycleRule(cycleRule)
+                .startDate(LocalDate.of(2026, 1, 1))
+                .endDate(null)
+                .build();
+    }
+
+    private SettlementDTO latestSettlement(LocalDate cycleDate) {
+        return SettlementDTO.builder()
+                .settlementId(10L)
+                .recurringSettlementId(1L)
+                .cycleDate(cycleDate)
+                .build();
+    }
+
+    private SettlementParticipantDTO activeParticipant(Long participantId, Long userId) {
+        return SettlementParticipantDTO.builder()
+                .participantId(participantId)
+                .userId(userId)
+                .settlementId(10L)
+                .participantRole(SettlementParticipantRole.MEMBER)
+                .participantStatus(SettlementParticipantStatus.ACTIVE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("직전 회차/참여자 존재 여부에 따른 스킵 처리")
+    class SkipCases {
+
+        @Test
+        @DisplayName("직전 회차가 없으면 생성하지 않고 조용히 종료한다")
+        void skipWhenNoLatestSettlement() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
+            when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(null);
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 1));
+
+            verify(settlementMapper, never()).insertSettlement(any());
+            verify(participantMapper, never()).insert(any());
+        }
+
+        @Test
+        @DisplayName("오늘이 생성 주기가 아니면 생성하지 않는다")
+        void skipWhenNotDueToday() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+
+            // 같은 달 15일 - 아직 다음 회차 도래 전
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 15));
+
+            verify(settlementMapper, never()).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("ACTIVE 참여자가 없으면 생성하지 않는다")
+        void skipWhenNoActiveParticipants() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    SettlementParticipantDTO.builder()
+                            .participantId(1L)
+                            .participantStatus(SettlementParticipantStatus.LEFT)
+                            .build()
+            ));
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
+
+            verify(settlementMapper, never()).insertSettlement(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("CycleRule별 생성일 도래 판정")
+    class DueDateJudgement {
+
+        @Test
+        @DisplayName("DAILY - 직전 회차와 날짜가 다르면 도래한 것으로 본다")
+        void dailyIsDueWhenDateDiffers() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(paymentObligationMapper.findByParticipantId(1L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(settlementMapper.insertSettlement(any())).thenAnswer(inv -> {
+                SettlementDTO s = inv.getArgument(0);
+                s.setSettlementId(20L); // setter 없으면 @Builder.Default 등으로 대체 필요
+                return 1;
+            });
+            when(participantMapper.insert(any())).thenReturn(1);
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
+
+            verify(settlementMapper).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("MONTHLY - 같은 일자가 아니면 도래하지 않은 것으로 본다")
+        void monthlyNotDueOnDifferentDay() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 1)));
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)); // 1일이 아니라 2일
+
+            verify(settlementMapper, never()).insertSettlement(any());
+        }
+
+        @Test
+        @DisplayName("MONTHLY - 같은 일자, 한 달 이상 지났으면 도래한 것으로 본다")
+        void monthlyDueOnSameDayNextMonth() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 1)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(paymentObligationMapper.findByParticipantId(1L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 1));
+
+            verify(settlementMapper).insertSettlement(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 생성 시 참여자/납부의무 복사")
+    class HappyPath {
+
+        @Test
+        @DisplayName("ACTIVE 참여자만 복사하고, 각 참여자의 직전 회차 expectedAmount로 납부의무를 생성한다")
+        void copiesOnlyActiveParticipantsWithObligation() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L),
+                    activeParticipant(2L, 200L),
+                    SettlementParticipantDTO.builder()
+                            .participantId(3L).userId(300L)
+                            .participantStatus(SettlementParticipantStatus.REMOVED)
+                            .build()
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            when(paymentObligationMapper.findByParticipantId(1L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(paymentObligationMapper.findByParticipantId(2L))
+                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
+                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+
+            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
+
+            // REMOVED(participantId=3)는 복사 대상에서 제외되어 2번만 insert
+            verify(participantMapper, times(2)).insert(any());
+            verify(settlementPaymentService, times(2)).createObligation(any(), eq(BigDecimal.valueOf(150000)));
+            verify(paymentObligationMapper, never()).findByParticipantId(3L);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 상황")
+    class ExceptionCases {
+
+        @Test
+        @DisplayName("Settlement insert 실패 시 SETTLEMENT_CREATE_FAILED 예외를 던진다")
+        void throwsWhenSettlementInsertFails() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(settlementMapper.insertSettlement(any())).thenReturn(0); // 실패
+
+            assertThatThrownBy(() -> sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)))
+                    .isInstanceOf(DomainException.class)
+                    .extracting(e -> ((DomainException) e).getErrorCode())
+                    .isEqualTo(SettlementErrorCode.SETTLEMENT_CREATE_FAILED);
+        }
+
+        @Test
+        @DisplayName("직전 회차 납부의무가 없으면 PAYMENT_OBLIGATION_NOT_FOUND 예외를 던진다")
+        void throwsWhenPreviousObligationMissing() {
+            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
+            when(settlementMapper.findLatestByRecurringId(1L))
+                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+            when(participantMapper.findBySettlementId(10L))
+                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            when(paymentObligationMapper.findByParticipantId(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)))
+                    .isInstanceOf(DomainException.class)
+                    .extracting(e -> ((DomainException) e).getErrorCode())
+                    .isEqualTo(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -145,7 +146,7 @@ class RecurringSettlementCycleGeneratorTest {
     class EqualSplitRecalculation {
 
         @Test
-        @DisplayName("EQUAL이면 직전 회차 금액이 아니라 현재 ACTIVE 참여자 수 기준으로 재계산한다")
+        @DisplayName("EQUAL이면 직전 회차 금액이 아니라 현재 ACTIVE 참여자 수(전체 인원) 기준으로 재계산한다")
         void recalculatesEqualAmountByCurrentActiveCount() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
@@ -155,13 +156,13 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(settlementAmountCalculator.calculateEqualAmount(BigDecimal.valueOf(300000), 1))
+            when(settlementAmountCalculator.calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1))
                     .thenReturn(BigDecimal.valueOf(300000)); // 1명이면 전액
 
             SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
             assertThat(result).isNotNull();
-            verify(settlementAmountCalculator).calculateEqualAmount(BigDecimal.valueOf(300000), 1);
+            verify(settlementAmountCalculator).calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1);
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(300000)));
             // EQUAL이면 직전 obligation을 조회할 필요가 없어야 함
             verify(paymentObligationMapper, never()).findByParticipantId(any());
@@ -186,7 +187,7 @@ class RecurringSettlementCycleGeneratorTest {
 
             assertThat(result).isNotNull();
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
-            verify(settlementAmountCalculator, never()).calculateEqualAmount(any(), anyInt());
+            verify(settlementAmountCalculator, never()).calculateEqualAmountForTotalCount(any(), anyInt());
         }
 
         @Test
@@ -229,7 +230,7 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(settlementAmountCalculator.calculateEqualAmount(BigDecimal.valueOf(300000), 2))
+            when(settlementAmountCalculator.calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 2))
                     .thenReturn(BigDecimal.valueOf(150000));
 
             SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -17,8 +17,7 @@ import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
-import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
-import org.teamsai.saibackend.domain.settlement.service.SettlementAmountCalculator;
+import org.teamsai.saibackend.domain.settlement.service.*;
 import org.teamsai.saibackend.domain.settlement.type.*;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -46,13 +45,17 @@ class RecurringSettlementCycleGeneratorTest {
     private RecurringSettlementCycleGenerator sut;
 
     private RecurringSettlementDTO recurring(SplitType splitType) {
+        return recurring(splitType, BigDecimal.valueOf(300000));
+    }
+
+    private RecurringSettlementDTO recurring(SplitType splitType, BigDecimal totalAmount) {
         return RecurringSettlementDTO.builder()
                 .recurringSettlementId(1L)
                 .ownerId(100L)
                 .settlementCategory("월세")
                 .title("자취방 월세")
                 .splitType(splitType)
-                .totalAmount(BigDecimal.valueOf(300000))
+                .totalAmount(totalAmount)
                 .cycleRule(CycleRule.MONTHLY)
                 .startDate(LocalDate.of(2026, 1, 31))
                 .endDate(null)
@@ -90,8 +93,8 @@ class RecurringSettlementCycleGeneratorTest {
     class LockValidation {
 
         @Test
-        @DisplayName("락 획득 시점의 직전 회차가 넘겨받은 previousSettlement와 다르면 null을 반환하고 아무것도 생성하지 않는다")
-        void returnsNullWhenConcurrentGenerationDetected() {
+        @DisplayName("락 획득 시점의 직전 회차가 넘겨받은 previousSettlement와 다르면 CONCURRENTLY_SKIPPED를 반환하고 아무것도 생성하지 않는다")
+        void returnsConcurrentlySkippedWhenConcurrentGenerationDetected() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
 
@@ -103,23 +106,24 @@ class RecurringSettlementCycleGeneratorTest {
             when(settlementMapper.findLatestByRecurringIdForUpdate(1L))
                     .thenReturn(alreadyCreatedByOther);
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNull();
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CONCURRENTLY_SKIPPED);
+            assertThat(outcome.settlement()).isNull();
             verify(settlementMapper, never()).insertSettlement(any());
             verify(participantMapper, never()).findBySettlementId(any());
         }
 
         @Test
-        @DisplayName("락 획득 시점의 직전 회차가 null이면 null을 반환한다")
-        void returnsNullWhenLockedLatestIsNull() {
+        @DisplayName("락 획득 시점의 직전 회차가 null이면 CONCURRENTLY_SKIPPED를 반환한다")
+        void returnsConcurrentlySkippedWhenLockedLatestIsNull() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
             when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(null);
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNull();
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CONCURRENTLY_SKIPPED);
             verify(settlementMapper, never()).insertSettlement(any());
         }
     }
@@ -129,8 +133,8 @@ class RecurringSettlementCycleGeneratorTest {
     class ActiveParticipantCheck {
 
         @Test
-        @DisplayName("ACTIVE 참여자가 없으면 null을 반환하고 생성하지 않는다")
-        void returnsNullWhenNoActiveParticipants() {
+        @DisplayName("ACTIVE 참여자가 없으면 NO_ACTIVE_PARTICIPANT를 반환하고 생성하지 않는다")
+        void returnsNoActiveParticipantWhenNoneExist() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
             when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
@@ -141,19 +145,20 @@ class RecurringSettlementCycleGeneratorTest {
                             .build()
             ));
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNull();
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.NO_ACTIVE_PARTICIPANT);
+            assertThat(outcome.settlement()).isNull();
             verify(settlementMapper, never()).insertSettlement(any());
         }
     }
 
     @Nested
-    @DisplayName("EQUAL 분할 재계산")
+    @DisplayName("EQUAL 분할 재계산 (나머지 배정 포함)")
     class EqualSplitRecalculation {
 
         @Test
-        @DisplayName("EQUAL이면 직전 회차 금액이 아니라 현재 ACTIVE 참여자 수(전체 인원) 기준으로 재계산한다")
+        @DisplayName("EQUAL이면 직전 회차 금액이 아니라 현재 ACTIVE 참여자 수 기준으로 분배 리스트를 요청한다")
         void recalculatesEqualAmountByCurrentActiveCount() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
@@ -163,16 +168,44 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(settlementAmountCalculator.calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1))
-                    .thenReturn(BigDecimal.valueOf(300000));
+            when(settlementAmountCalculator.distributeEqualAmounts(BigDecimal.valueOf(300000), 1))
+                    .thenReturn(List.of(BigDecimal.valueOf(300000)));
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNotNull();
-            verify(settlementAmountCalculator).calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1);
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CREATED);
+            assertThat(outcome.settlement()).isNotNull();
+            verify(settlementAmountCalculator).distributeEqualAmounts(BigDecimal.valueOf(300000), 1);
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(300000)));
-            // EQUAL이면 배치 조회 자체를 안 해야 함 (N+1 제거 후에도 EQUAL 경로는 조회 불필요)
             verify(paymentObligationMapper, never()).findByParticipantIds(any());
+        }
+
+        @Test
+        @DisplayName("나머지가 발생하면 분배 리스트가 순서대로 참여자에게 배정된다 (3명, 10000원 -> 3333/3333/3334)")
+        void assignsRemainderToLastParticipantAmount() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL, BigDecimal.valueOf(10000));
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L),
+                    activeParticipant(2L, 200L),
+                    activeParticipant(3L, 300L)
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            when(settlementAmountCalculator.distributeEqualAmounts(BigDecimal.valueOf(10000), 3))
+                    .thenReturn(List.of(
+                            BigDecimal.valueOf(3333),
+                            BigDecimal.valueOf(3333),
+                            BigDecimal.valueOf(3334)
+                    ));
+
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CREATED);
+
+            verify(settlementPaymentService, times(2)).createObligation(any(), eq(BigDecimal.valueOf(3333)));
+            verify(settlementPaymentService, times(1)).createObligation(any(), eq(BigDecimal.valueOf(3334)));
         }
 
         @Test
@@ -189,31 +222,12 @@ class RecurringSettlementCycleGeneratorTest {
             when(paymentObligationMapper.findByParticipantIds(List.of(1L)))
                     .thenReturn(List.of(obligation(500L, 1L, BigDecimal.valueOf(150000))));
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNotNull();
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CREATED);
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
-            verify(settlementAmountCalculator, never()).calculateEqualAmountForTotalCount(any(), anyInt());
+            verify(settlementAmountCalculator, never()).distributeEqualAmounts(any(), anyInt());
             verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
-        }
-
-        @Test
-        @DisplayName("같은 참여자에게 obligation이 여러 건 있어도, 쿼리는 이미 최신 것 하나만 반환한다고 가정하고 그 값을 사용한다")
-        void usesTheSingleObligationReturnedByQuery() {
-            RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
-            SettlementDTO previous = previousSettlement();
-            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
-            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
-                    activeParticipant(1L, 100L)
-            ));
-            when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
-            when(paymentObligationMapper.findByParticipantIds(List.of(1L)))
-                    .thenReturn(List.of(obligation(600L, 1L, BigDecimal.valueOf(150000))));
-
-            sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
-
-            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
         }
 
         @Test
@@ -226,7 +240,7 @@ class RecurringSettlementCycleGeneratorTest {
                     activeParticipant(1L, 100L)
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
+            // when(participantMapper.insert(any())).thenReturn(1);  ← 이 줄 삭제
             when(paymentObligationMapper.findByParticipantIds(List.of(1L))).thenReturn(List.of());
 
             assertThatThrownBy(() -> sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28)))
@@ -241,8 +255,8 @@ class RecurringSettlementCycleGeneratorTest {
     class HappyPath {
 
         @Test
-        @DisplayName("ACTIVE 참여자만 복사하고 생성된 SettlementDTO를 반환한다")
-        void copiesOnlyActiveParticipantsAndReturnsCreatedSettlement() {
+        @DisplayName("ACTIVE 참여자만 복사하고, 분배된 금액이 순서대로 배정되며, CREATED 결과와 생성된 SettlementDTO를 반환한다")
+        void copiesOnlyActiveParticipantsWithDistributedAmounts() {
             RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
             SettlementDTO previous = previousSettlement();
             when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
@@ -256,14 +270,15 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(settlementAmountCalculator.calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 2))
-                    .thenReturn(BigDecimal.valueOf(150000));
+            when(settlementAmountCalculator.distributeEqualAmounts(BigDecimal.valueOf(300000), 2))
+                    .thenReturn(List.of(BigDecimal.valueOf(150000), BigDecimal.valueOf(150000)));
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNotNull();
-            assertThat(result.getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
-            verify(participantMapper, times(2)).insert(any()); // REMOVED는 제외되어 2명만
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CREATED);
+            assertThat(outcome.settlement()).isNotNull();
+            assertThat(outcome.settlement().getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
+            verify(participantMapper, times(2)).insert(any());
             verify(settlementPaymentService, times(2)).createObligation(any(), eq(BigDecimal.valueOf(150000)));
         }
 
@@ -287,9 +302,9 @@ class RecurringSettlementCycleGeneratorTest {
                             obligation(502L, 3L, BigDecimal.valueOf(80000))
                     ));
 
-            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+            CycleGenerationOutcome outcome = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            assertThat(result).isNotNull();
+            assertThat(outcome.result()).isEqualTo(CycleGenerationResult.CREATED);
             verify(participantMapper, times(3)).insert(any());
             verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(100000)));

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -25,7 +25,6 @@ import org.teamsai.saibackend.global.exception.DomainException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -78,6 +77,14 @@ class RecurringSettlementCycleGeneratorTest {
                 .build();
     }
 
+    private PaymentObligationDTO obligation(Long obligationId, Long participantId, BigDecimal expectedAmount) {
+        return PaymentObligationDTO.builder()
+                .paymentObligationId(obligationId)
+                .participantId(participantId)
+                .expectedAmount(expectedAmount)
+                .build();
+    }
+
     @Nested
     @DisplayName("동시성 락 검증")
     class LockValidation {
@@ -89,7 +96,7 @@ class RecurringSettlementCycleGeneratorTest {
             SettlementDTO previous = previousSettlement();
 
             SettlementDTO alreadyCreatedByOther = SettlementDTO.builder()
-                    .settlementId(11L) // previous.getSettlementId()=10L과 다름
+                    .settlementId(11L)
                     .recurringSettlementId(1L)
                     .cycleDate(LocalDate.of(2026, 2, 28))
                     .build();
@@ -152,24 +159,24 @@ class RecurringSettlementCycleGeneratorTest {
             SettlementDTO previous = previousSettlement();
             when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
             when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
-                    activeParticipant(1L, 100L) // 참여자 1명만 남음 (탈퇴로 인원 감소)
+                    activeParticipant(1L, 100L)
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
             when(settlementAmountCalculator.calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1))
-                    .thenReturn(BigDecimal.valueOf(300000)); // 1명이면 전액
+                    .thenReturn(BigDecimal.valueOf(300000));
 
             SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
             assertThat(result).isNotNull();
             verify(settlementAmountCalculator).calculateEqualAmountForTotalCount(BigDecimal.valueOf(300000), 1);
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(300000)));
-            // EQUAL이면 직전 obligation을 조회할 필요가 없어야 함
-            verify(paymentObligationMapper, never()).findByParticipantId(any());
+            // EQUAL이면 배치 조회 자체를 안 해야 함 (N+1 제거 후에도 EQUAL 경로는 조회 불필요)
+            verify(paymentObligationMapper, never()).findByParticipantIds(any());
         }
 
         @Test
-        @DisplayName("EQUAL이 아니면 직전 회차의 expectedAmount를 그대로 유지한다")
+        @DisplayName("EQUAL이 아니면 참여자ID 목록으로 한 번에 조회한 뒤 직전 회차의 expectedAmount를 그대로 유지한다")
         void keepsPreviousAmountWhenNotEqual() {
             RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
             SettlementDTO previous = previousSettlement();
@@ -179,15 +186,38 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(paymentObligationMapper.findByParticipantId(1L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(paymentObligationMapper.findByParticipantIds(List.of(1L)))
+                    .thenReturn(List.of(obligation(500L, 1L, BigDecimal.valueOf(150000))));
 
             SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
             assertThat(result).isNotNull();
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
             verify(settlementAmountCalculator, never()).calculateEqualAmountForTotalCount(any(), anyInt());
+            // N+1 제거 확인: 단건 조회(findByParticipantId)는 더 이상 호출되지 않아야 함
+            verify(paymentObligationMapper, never()).findByParticipantId(any());
+            // 배치 조회는 정확히 1번만 호출되어야 함 (참여자 수와 무관하게)
+            verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
+        }
+
+        @Test
+        @DisplayName("같은 참여자에게 obligation이 여러 건 있어도, 쿼리는 이미 최신 것 하나만 반환한다고 가정하고 그 값을 사용한다")
+        void usesTheSingleObligationReturnedByQuery() {
+            RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L)
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            // "최신 것 고르기"는 이제 SQL 책임이므로, Mock은 이미 걸러진 결과 1건만 반환
+            when(paymentObligationMapper.findByParticipantIds(List.of(1L)))
+                    .thenReturn(List.of(obligation(600L, 1L, BigDecimal.valueOf(150000))));
+
+            sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
         }
 
         @Test
@@ -201,7 +231,7 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(paymentObligationMapper.findByParticipantId(1L)).thenReturn(Optional.empty());
+            when(paymentObligationMapper.findByParticipantIds(List.of(1L))).thenReturn(List.of());
 
             assertThatThrownBy(() -> sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28)))
                     .isInstanceOf(DomainException.class)
@@ -239,6 +269,38 @@ class RecurringSettlementCycleGeneratorTest {
             assertThat(result.getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
             verify(participantMapper, times(2)).insert(any()); // REMOVED는 제외되어 2명만
             verify(settlementPaymentService, times(2)).createObligation(any(), eq(BigDecimal.valueOf(150000)));
+        }
+
+        @Test
+        @DisplayName("CUSTOM 참여자 복수 명에 대해 배치 조회가 정확히 1번만 호출된다 (N+1 검증)")
+        void batchQueriesObligationsOnceForMultipleParticipants() {
+            RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L),
+                    activeParticipant(2L, 200L),
+                    activeParticipant(3L, 300L)
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            when(paymentObligationMapper.findByParticipantIds(List.of(1L, 2L, 3L)))
+                    .thenReturn(List.of(
+                            obligation(500L, 1L, BigDecimal.valueOf(100000)),
+                            obligation(501L, 2L, BigDecimal.valueOf(120000)),
+                            obligation(502L, 3L, BigDecimal.valueOf(80000))
+                    ));
+
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            assertThat(result).isNotNull();
+            verify(participantMapper, times(3)).insert(any());
+            // 참여자가 3명이어도 obligation 조회는 딱 1번만 (N+1이 아니라 배치 조회임을 검증)
+            verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
+            verify(paymentObligationMapper, never()).findByParticipantId(any());
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(100000)));
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(120000)));
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(80000)));
         }
 
         @Test

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -18,6 +18,7 @@ import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
 import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
+import org.teamsai.saibackend.domain.settlement.service.SettlementAmountCalculator;
 import org.teamsai.saibackend.domain.settlement.type.*;
 import org.teamsai.saibackend.global.exception.DomainException;
 
@@ -26,8 +27,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,33 +40,30 @@ class RecurringSettlementCycleGeneratorTest {
     @Mock private SettlementParticipantMapper participantMapper;
     @Mock private PaymentObligationMapper paymentObligationMapper;
     @Mock private SettlementPaymentService settlementPaymentService;
+    @Mock private SettlementAmountCalculator settlementAmountCalculator;
 
     @InjectMocks
-    private RecurringSettlementCycleGenerator sut; // system under test
+    private RecurringSettlementCycleGenerator sut;
 
-    private RecurringSettlementDTO recurring(CycleRule cycleRule) {
-        return recurring(cycleRule, LocalDate.of(2026, 1, 1));
-    }
-
-    private RecurringSettlementDTO recurring(CycleRule cycleRule, LocalDate startDate) {
+    private RecurringSettlementDTO recurring(SplitType splitType) {
         return RecurringSettlementDTO.builder()
                 .recurringSettlementId(1L)
                 .ownerId(100L)
                 .settlementCategory("월세")
                 .title("자취방 월세")
-                .splitType(SplitType.EQUAL)
+                .splitType(splitType)
                 .totalAmount(BigDecimal.valueOf(300000))
-                .cycleRule(cycleRule)
-                .startDate(startDate)
+                .cycleRule(CycleRule.MONTHLY)
+                .startDate(LocalDate.of(2026, 1, 31))
                 .endDate(null)
                 .build();
     }
 
-    private SettlementDTO latestSettlement(LocalDate cycleDate) {
+    private SettlementDTO previousSettlement() {
         return SettlementDTO.builder()
                 .settlementId(10L)
                 .recurringSettlementId(1L)
-                .cycleDate(cycleDate)
+                .cycleDate(LocalDate.of(2026, 1, 31))
                 .build();
     }
 
@@ -78,40 +78,54 @@ class RecurringSettlementCycleGeneratorTest {
     }
 
     @Nested
-    @DisplayName("직전 회차/참여자 존재 여부에 따른 스킵 처리")
-    class SkipCases {
+    @DisplayName("동시성 락 검증")
+    class LockValidation {
 
         @Test
-        @DisplayName("직전 회차가 없으면 생성하지 않고 조용히 종료한다")
-        void skipWhenNoLatestSettlement() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
-            when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(null);
+        @DisplayName("락 획득 시점의 직전 회차가 넘겨받은 previousSettlement와 다르면 null을 반환하고 아무것도 생성하지 않는다")
+        void returnsNullWhenConcurrentGenerationDetected() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
 
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 1));
+            SettlementDTO alreadyCreatedByOther = SettlementDTO.builder()
+                    .settlementId(11L) // previous.getSettlementId()=10L과 다름
+                    .recurringSettlementId(1L)
+                    .cycleDate(LocalDate.of(2026, 2, 28))
+                    .build();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L))
+                    .thenReturn(alreadyCreatedByOther);
 
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            assertThat(result).isNull();
             verify(settlementMapper, never()).insertSettlement(any());
-            verify(participantMapper, never()).insert(any());
+            verify(participantMapper, never()).findBySettlementId(any());
         }
 
         @Test
-        @DisplayName("오늘이 생성 주기가 아니면 생성하지 않는다")
-        void skipWhenNotDueToday() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+        @DisplayName("락 획득 시점의 직전 회차가 null이면 null을 반환한다")
+        void returnsNullWhenLockedLatestIsNull() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(null);
 
-            // 같은 달 15일 - 아직 다음 회차 도래 전
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 15));
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
+            assertThat(result).isNull();
             verify(settlementMapper, never()).insertSettlement(any());
         }
+    }
+
+    @Nested
+    @DisplayName("ACTIVE 참여자 존재 여부")
+    class ActiveParticipantCheck {
 
         @Test
-        @DisplayName("ACTIVE 참여자가 없으면 생성하지 않는다")
-        void skipWhenNoActiveParticipants() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+        @DisplayName("ACTIVE 참여자가 없으면 null을 반환하고 생성하지 않는다")
+        void returnsNullWhenNoActiveParticipants() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
             when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
                     SettlementParticipantDTO.builder()
                             .participantId(1L)
@@ -119,141 +133,92 @@ class RecurringSettlementCycleGeneratorTest {
                             .build()
             ));
 
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
+            assertThat(result).isNull();
             verify(settlementMapper, never()).insertSettlement(any());
         }
     }
 
     @Nested
-    @DisplayName("CycleRule별 생성일 도래 판정 (말일 앵커링 포함)")
-    class DueDateJudgement {
+    @DisplayName("EQUAL 분할 재계산")
+    class EqualSplitRecalculation {
 
         @Test
-        @DisplayName("DAILY - 직전 회차와 날짜가 다르면 도래한 것으로 본다")
-        void dailyIsDueWhenDateDiffers() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
+        @DisplayName("EQUAL이면 직전 회차 금액이 아니라 현재 ACTIVE 참여자 수 기준으로 재계산한다")
+        void recalculatesEqualAmountByCurrentActiveCount() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L) // 참여자 1명만 남음 (탈퇴로 인원 감소)
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
+            when(settlementAmountCalculator.calculateEqualAmount(BigDecimal.valueOf(300000), 1))
+                    .thenReturn(BigDecimal.valueOf(300000)); // 1명이면 전액
+
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            assertThat(result).isNotNull();
+            verify(settlementAmountCalculator).calculateEqualAmount(BigDecimal.valueOf(300000), 1);
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(300000)));
+            // EQUAL이면 직전 obligation을 조회할 필요가 없어야 함
+            verify(paymentObligationMapper, never()).findByParticipantId(any());
+        }
+
+        @Test
+        @DisplayName("EQUAL이 아니면 직전 회차의 expectedAmount를 그대로 유지한다")
+        void keepsPreviousAmountWhenNotEqual() {
+            RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L)
+            ));
+            when(settlementMapper.insertSettlement(any())).thenReturn(1);
+            when(participantMapper.insert(any())).thenReturn(1);
             when(paymentObligationMapper.findByParticipantId(1L))
                     .thenReturn(Optional.of(PaymentObligationDTO.builder()
                             .expectedAmount(BigDecimal.valueOf(150000)).build()));
+
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
+
+            assertThat(result).isNotNull();
+            verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
+            verify(settlementAmountCalculator, never()).calculateEqualAmount(any(), anyInt());
+        }
+
+        @Test
+        @DisplayName("CUSTOM인데 직전 회차 납부의무가 없으면 PAYMENT_OBLIGATION_NOT_FOUND 예외를 던진다")
+        void throwsWhenCustomAndPreviousObligationMissing() {
+            RecurringSettlementDTO recurring = recurring(SplitType.CUSTOM);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
+                    activeParticipant(1L, 100L)
+            ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
+            when(paymentObligationMapper.findByParticipantId(1L)).thenReturn(Optional.empty());
 
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
-
-            verify(settlementMapper).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("MONTHLY - 1/31 시작, 직전 회차 1/31 → 2월은 말일인 28일에 도래한다")
-        void monthlyClampsToLastDayOfShortMonth() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 31)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
-            when(paymentObligationMapper.findByParticipantId(1L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
-            when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
-
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 28));
-
-            verify(settlementMapper).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("MONTHLY - 목표일(2/28) 이전이면 아직 도래하지 않은 것으로 본다")
-        void monthlyNotDueBeforeClampedTarget() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 1, 31)));
-
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 27));
-
-            verify(settlementMapper, never()).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("MONTHLY - 2월에 28일로 클램프된 뒤에도, 3월엔 원래 anchor인 31일로 복귀한다")
-        void monthlyAnchorRecoversAfterClamp() {
-            // 직전 회차가 2/28(클램프된 값)이어도, anchor는 startDate의 31일을 계속 유지해야 함
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 28)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
-            when(paymentObligationMapper.findByParticipantId(1L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
-            when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
-
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 3, 31));
-
-            verify(settlementMapper).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("MONTHLY - anchor 복귀 목표일(3/31) 이전인 3/30에는 아직 도래하지 않은 것으로 본다")
-        void monthlyNotDueBeforeAnchorRecovery() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.MONTHLY, LocalDate.of(2026, 1, 31));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 28)));
-
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 3, 30));
-
-            verify(settlementMapper, never()).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("YEARLY - 2/29 시작, 평년엔 2/28로 클램프되어 도래한다")
-        void yearlyClampsToFeb28InNonLeapYear() {
-            // 2024는 윤년, 2025는 평년
-            RecurringSettlementDTO recurring = recurring(CycleRule.YEARLY, LocalDate.of(2024, 2, 29));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2024, 2, 29)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
-            when(paymentObligationMapper.findByParticipantId(1L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
-            when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
-
-            sut.generateNextCycle(recurring, LocalDate.of(2025, 2, 28));
-
-            verify(settlementMapper).insertSettlement(any());
-        }
-
-        @Test
-        @DisplayName("YEARLY - 평년에 2/28로 클램프된 뒤, 다음 윤년엔 원래 anchor인 2/29로 복귀한다")
-        void yearlyAnchorRecoversOnNextLeapYear() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.YEARLY, LocalDate.of(2024, 2, 29));
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2027, 2, 28))); // 평년 회차
-
-            // 2028은 윤년 - 아직 2/28이면 도래 전
-            sut.generateNextCycle(recurring, LocalDate.of(2028, 2, 28));
-            verify(settlementMapper, never()).insertSettlement(any());
+            assertThatThrownBy(() -> sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28)))
+                    .isInstanceOf(DomainException.class)
+                    .extracting(e -> ((DomainException) e).getErrorCode())
+                    .isEqualTo(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND);
         }
     }
 
     @Nested
-    @DisplayName("정상 생성 시 참여자/납부의무 복사")
+    @DisplayName("정상 생성 시 참여자 복사")
     class HappyPath {
 
         @Test
-        @DisplayName("ACTIVE 참여자만 복사하고, 각 참여자의 직전 회차 expectedAmount로 납부의무를 생성한다")
-        void copiesOnlyActiveParticipantsWithObligation() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
+        @DisplayName("ACTIVE 참여자만 복사하고 생성된 SettlementDTO를 반환한다")
+        void copiesOnlyActiveParticipantsAndReturnsCreatedSettlement() {
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
             when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(
                     activeParticipant(1L, 100L),
                     activeParticipant(2L, 200L),
@@ -264,58 +229,77 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            when(paymentObligationMapper.findByParticipantId(1L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
-            when(paymentObligationMapper.findByParticipantId(2L))
-                    .thenReturn(Optional.of(PaymentObligationDTO.builder()
-                            .expectedAmount(BigDecimal.valueOf(150000)).build()));
+            when(settlementAmountCalculator.calculateEqualAmount(BigDecimal.valueOf(300000), 2))
+                    .thenReturn(BigDecimal.valueOf(150000));
 
-            sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2));
+            SettlementDTO result = sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28));
 
-            // REMOVED(participantId=3)는 복사 대상에서 제외되어 2번만 insert
-            verify(participantMapper, times(2)).insert(any());
+            assertThat(result).isNotNull();
+            assertThat(result.getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
+            verify(participantMapper, times(2)).insert(any()); // REMOVED는 제외되어 2명만
             verify(settlementPaymentService, times(2)).createObligation(any(), eq(BigDecimal.valueOf(150000)));
-            verify(paymentObligationMapper, never()).findByParticipantId(3L);
         }
-    }
-
-    @Nested
-    @DisplayName("예외 상황")
-    class ExceptionCases {
 
         @Test
         @DisplayName("Settlement insert 실패 시 SETTLEMENT_CREATE_FAILED 예외를 던진다")
         void throwsWhenSettlementInsertFails() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
-            when(settlementMapper.insertSettlement(any())).thenReturn(0); // 실패
+            RecurringSettlementDTO recurring = recurring(SplitType.EQUAL);
+            SettlementDTO previous = previousSettlement();
+            when(settlementMapper.findLatestByRecurringIdForUpdate(1L)).thenReturn(previous);
+            when(participantMapper.findBySettlementId(10L)).thenReturn(List.of(activeParticipant(1L, 100L)));
+            when(settlementMapper.insertSettlement(any())).thenReturn(0);
 
-            assertThatThrownBy(() -> sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)))
+            assertThatThrownBy(() -> sut.generateOneCycle(recurring, previous, LocalDate.of(2026, 2, 28)))
                     .isInstanceOf(DomainException.class)
                     .extracting(e -> ((DomainException) e).getErrorCode())
                     .isEqualTo(SettlementErrorCode.SETTLEMENT_CREATE_FAILED);
         }
+    }
+
+    @Nested
+    @DisplayName("회차 목표일 계산 (월말/윤년 앵커링)")
+    class NthCycleDateCalculation {
 
         @Test
-        @DisplayName("직전 회차 납부의무가 없으면 PAYMENT_OBLIGATION_NOT_FOUND 예외를 던진다")
-        void throwsWhenPreviousObligationMissing() {
-            RecurringSettlementDTO recurring = recurring(CycleRule.DAILY);
-            when(settlementMapper.findLatestByRecurringId(1L))
-                    .thenReturn(latestSettlement(LocalDate.of(2026, 2, 1)));
-            when(participantMapper.findBySettlementId(10L))
-                    .thenReturn(List.of(activeParticipant(1L, 100L)));
-            when(settlementMapper.insertSettlement(any())).thenReturn(1);
-            when(participantMapper.insert(any())).thenReturn(1);
-            when(paymentObligationMapper.findByParticipantId(1L)).thenReturn(Optional.empty());
+        @DisplayName("MONTHLY - 1/31 시작, 1번째 회차는 2월 말일(28일)로 클램프된다")
+        void monthlyClampsToLastDayOfShortMonth() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2026, 1, 31), CycleRule.MONTHLY, 1);
+            assertThat(result).isEqualTo(LocalDate.of(2026, 2, 28));
+        }
 
-            assertThatThrownBy(() -> sut.generateNextCycle(recurring, LocalDate.of(2026, 2, 2)))
-                    .isInstanceOf(DomainException.class)
-                    .extracting(e -> ((DomainException) e).getErrorCode())
-                    .isEqualTo(PaymentErrorCode.PAYMENT_OBLIGATION_NOT_FOUND);
+        @Test
+        @DisplayName("MONTHLY - 2번째 회차는 anchor인 31일로 복귀한다 (2월 클램프에 영향받지 않음)")
+        void monthlyAnchorRecoversOnNextMonth() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2026, 1, 31), CycleRule.MONTHLY, 2);
+            assertThat(result).isEqualTo(LocalDate.of(2026, 3, 31));
+        }
+
+        @Test
+        @DisplayName("YEARLY - 2/29 시작, 평년(1번째)엔 2/28로 클램프된다")
+        void yearlyClampsToFeb28InNonLeapYear() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2024, 2, 29), CycleRule.YEARLY, 1);
+            assertThat(result).isEqualTo(LocalDate.of(2025, 2, 28));
+        }
+
+        @Test
+        @DisplayName("YEARLY - 다음 윤년(4번째)엔 anchor인 2/29로 복귀한다")
+        void yearlyAnchorRecoversOnNextLeapYear() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2024, 2, 29), CycleRule.YEARLY, 4);
+            assertThat(result).isEqualTo(LocalDate.of(2028, 2, 29));
+        }
+
+        @Test
+        @DisplayName("WEEKLY - n주 뒤 날짜를 정확히 계산한다 (드리프트 없음)")
+        void weeklyAddsExactWeeksFromStartDate() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2026, 1, 5), CycleRule.WEEKLY, 3);
+            assertThat(result).isEqualTo(LocalDate.of(2026, 1, 26));
+        }
+
+        @Test
+        @DisplayName("DAILY - n일 뒤 날짜를 정확히 계산한다")
+        void dailyAddsExactDaysFromStartDate() {
+            LocalDate result = sut.calculateNthCycleDate(LocalDate.of(2026, 1, 1), CycleRule.DAILY, 5);
+            assertThat(result).isEqualTo(LocalDate.of(2026, 1, 6));
         }
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementCycleGeneratorTest.java
@@ -194,9 +194,6 @@ class RecurringSettlementCycleGeneratorTest {
             assertThat(result).isNotNull();
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(150000)));
             verify(settlementAmountCalculator, never()).calculateEqualAmountForTotalCount(any(), anyInt());
-            // N+1 제거 확인: 단건 조회(findByParticipantId)는 더 이상 호출되지 않아야 함
-            verify(paymentObligationMapper, never()).findByParticipantId(any());
-            // 배치 조회는 정확히 1번만 호출되어야 함 (참여자 수와 무관하게)
             verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
         }
 
@@ -211,7 +208,6 @@ class RecurringSettlementCycleGeneratorTest {
             ));
             when(settlementMapper.insertSettlement(any())).thenReturn(1);
             when(participantMapper.insert(any())).thenReturn(1);
-            // "최신 것 고르기"는 이제 SQL 책임이므로, Mock은 이미 걸러진 결과 1건만 반환
             when(paymentObligationMapper.findByParticipantIds(List.of(1L)))
                     .thenReturn(List.of(obligation(600L, 1L, BigDecimal.valueOf(150000))));
 
@@ -295,9 +291,7 @@ class RecurringSettlementCycleGeneratorTest {
 
             assertThat(result).isNotNull();
             verify(participantMapper, times(3)).insert(any());
-            // 참여자가 3명이어도 obligation 조회는 딱 1번만 (N+1이 아니라 배치 조회임을 검증)
             verify(paymentObligationMapper, times(1)).findByParticipantIds(any());
-            verify(paymentObligationMapper, never()).findByParticipantId(any());
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(100000)));
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(120000)));
             verify(settlementPaymentService).createObligation(any(), eq(BigDecimal.valueOf(80000)));

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -260,6 +261,21 @@ class RecurringSettlementGenerationServiceIntegrationTest {
             );
 
             assertThat(count).isEqualTo(1); // 두 번 호출해도 1건만 존재
+        }
+
+        @Test
+        @DisplayName("RECURRING 타입인데 recurring_settlement_id 또는 cycle_date가 NULL이면 CHECK 제약 위반으로 insert가 거부된다")
+        void rejectsRecurringSettlementWithMissingRequiredFields() {
+            assertThatThrownBy(() -> jdbcTemplate.update(
+                    """
+                    INSERT INTO settlement (
+                        settlement_id, owner_id, settlement_type, settlement_status,
+                        settlement_category, title, split_type, total_amount, cycle_date, created_at
+                    )
+                    VALUES (?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '위반 테스트', 'EQUAL', 150000, NULL, NOW())
+                    """,
+                    99901L, 99001L
+            )).isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
 import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementGenerationService;
+import org.teamsai.saibackend.domain.settlement.type.SplitType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -135,6 +136,65 @@ class RecurringSettlementGenerationServiceIntegrationTest {
     }
 
     @Nested
+    @DisplayName("CUSTOM 분할 시 재청구 이력 중 최신 obligation 사용")
+    class LatestObligationAmongMultipleRecords {
+
+        @Test
+        @DisplayName("한 참여자에게 obligation이 여러 건(재청구 이력) 있으면, ID가 가장 큰 최신 것의 금액으로 다음 회차가 생성된다")
+        void usesLatestObligationAmountWhenMultipleExistForSameParticipant() {
+            Long ownerId = 75001L;
+            Long userA = 75002L;
+            Long recurringId = 75101L;
+            Long settlement1Id = 75201L;
+            Long participant1Id = 75301L;
+
+            insertUser(ownerId, "채무자 관리자");
+            insertUser(userA, "참여자 A");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31), SplitType.CUSTOM);
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31), SplitType.CUSTOM);
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+
+            // 재청구 이력: 오래된 obligation(취소/제외 처리됐다고 가정)과 최신 obligation이 공존
+            insertObligation(85001L, participant1Id, "100000.00", "EXCLUDED");
+            insertObligation(85002L, participant1Id, "150000.00", "ACTIVE"); // 더 최근에 생성된, ID가 더 큰 것
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28));
+
+            var latest = settlementMapper.findLatestByRecurringId(recurringId);
+            assertThat(latest).isNotNull();
+            assertThat(latest.getSettlementId()).isNotEqualTo(settlement1Id);
+
+            Map<Long, BigDecimal> obligationByUserId = fetchObligationAmountsByUser(latest.getSettlementId());
+            assertThat(obligationByUserId.get(userA)).isEqualByComparingTo(new BigDecimal("150000"));
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태인 obligation이 여러 건이어도, 그중 ID가 가장 큰(가장 최근) 것을 사용한다")
+        void usesHighestIdAmongMultipleActiveObligations() {
+            Long ownerId = 76001L;
+            Long userA = 76002L;
+            Long recurringId = 76101L;
+            Long settlement1Id = 76201L;
+            Long participant1Id = 76301L;
+
+            insertUser(ownerId, "채무자 관리자");
+            insertUser(userA, "참여자 A");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31), SplitType.CUSTOM);
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31), SplitType.CUSTOM);
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+
+            insertObligation(86001L, participant1Id, "80000.00", "ACTIVE");
+            insertObligation(86002L, participant1Id, "200000.00", "ACTIVE"); // ID가 더 큼
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28));
+
+            var latest = settlementMapper.findLatestByRecurringId(recurringId);
+            Map<Long, BigDecimal> obligationByUserId = fetchObligationAmountsByUser(latest.getSettlementId());
+            assertThat(obligationByUserId.get(userA)).isEqualByComparingTo(new BigDecimal("200000"));
+        }
+    }
+
+    @Nested
     @DisplayName("밀린 회차 캐치업")
     class CatchUpMultipleCycles {
 
@@ -228,32 +288,15 @@ class RecurringSettlementGenerationServiceIntegrationTest {
     }
 
     private void insertRecurringSettlement(Long recurringSettlementId, Long ownerId, LocalDate startDate) {
-        jdbcTemplate.update(
-                """
-                INSERT INTO recurring_settlement (
-                    recurring_settlement_id, owner_id, settlement_category, title,
-                    split_type, total_amount, cycle_rule, start_date, end_date, created_at
-                )
-                VALUES (?, ?, '월세', '자취방 월세', 'EQUAL', 300000, 'MONTHLY', ?, NULL, NOW())
-                """,
-                recurringSettlementId, ownerId, startDate
-        );
+        insertRecurringSettlement(recurringSettlementId, ownerId, startDate, SplitType.EQUAL);
     }
 
-    private void insertSettlementInstance(
-            Long settlementId, Long recurringSettlementId, Long ownerId, LocalDate cycleDate
-    ) {
-        jdbcTemplate.update(
-                """
-                INSERT INTO settlement (
-                    settlement_id, recurring_settlement_id, owner_id, settlement_type,
-                    settlement_status, settlement_category, title, split_type,
-                    total_amount, due_date, cycle_date, created_at
-                )
-                VALUES (?, ?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '자취방 월세', 'EQUAL', 300000, NULL, ?, NOW())
-                """,
-                settlementId, recurringSettlementId, ownerId, cycleDate
-        );
+    private void insertSettlementInstance(Long settlementId, Long recurringSettlementId, Long ownerId, LocalDate cycleDate) {
+        insertSettlementInstance(settlementId, recurringSettlementId, ownerId, cycleDate, SplitType.EQUAL);
+    }
+
+    private void insertObligation(Long obligationId, Long participantId, String expectedAmount) {
+        insertObligation(obligationId, participantId, expectedAmount, "ACTIVE");
     }
 
     private void insertParticipant(Long participantId, Long settlementId, Long userId, String status) {
@@ -268,16 +311,45 @@ class RecurringSettlementGenerationServiceIntegrationTest {
         );
     }
 
-    private void insertObligation(Long obligationId, Long participantId, String expectedAmount) {
+    private void insertRecurringSettlement(Long recurringSettlementId, Long ownerId, LocalDate startDate, SplitType splitType) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO recurring_settlement (
+                    recurring_settlement_id, owner_id, settlement_category, title,
+                    split_type, total_amount, cycle_rule, start_date, end_date, created_at
+                )
+                VALUES (?, ?, '차용금', '월 상환액', ?, 300000, 'MONTHLY', ?, NULL, NOW())
+                """,
+                recurringSettlementId, ownerId, splitType.name(), startDate
+        );
+    }
+
+    private void insertSettlementInstance(
+            Long settlementId, Long recurringSettlementId, Long ownerId, LocalDate cycleDate, SplitType splitType
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id, recurring_settlement_id, owner_id, settlement_type,
+                    settlement_status, settlement_category, title, split_type,
+                    total_amount, due_date, cycle_date, created_at
+                )
+                VALUES (?, ?, ?, 'RECURRING', 'IN_PROGRESS', '차용금', '월 상환액', ?, 300000, NULL, ?, NOW())
+                """,
+                settlementId, recurringSettlementId, ownerId, splitType.name(), cycleDate
+        );
+    }
+
+    private void insertObligation(Long obligationId, Long participantId, String expectedAmount, String obligationStatus) {
         jdbcTemplate.update(
                 """
                 INSERT INTO payment_obligation (
                     payment_obligation_id, participant_id, expected_amount,
                     payment_status, review_status, obligation_status
                 )
-                VALUES (?, ?, ?, 'UNPAID', 'NORMAL', 'ACTIVE')
+                VALUES (?, ?, ?, 'UNPAID', 'NORMAL', ?)
                 """,
-                obligationId, participantId, new BigDecimal(expectedAmount)
+                obligationId, participantId, new BigDecimal(expectedAmount), obligationStatus
         );
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceIntegrationTest.java
@@ -1,0 +1,283 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementGenerationService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("dev")
+@Sql(scripts = {
+        "/db/user.sql",
+        "/db/settlement.sql",
+        "/db/settlement_participant.sql",
+        "/db/payment.sql"
+})
+@DisplayName("RecurringSettlementGenerationService 엔드투엔드 통합 테스트")
+class RecurringSettlementGenerationServiceIntegrationTest {
+
+    @Autowired
+    private RecurringSettlementGenerationService generationService;
+
+    @Autowired
+    private SettlementMapper settlementMapper;
+
+    @Autowired
+    private SettlementParticipantMapper participantMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM payment_obligation WHERE participant_id >= 70000");
+        jdbcTemplate.update("DELETE FROM settlement_participant WHERE participant_id >= 70000");
+        jdbcTemplate.update("DELETE FROM settlement WHERE settlement_id >= 70000");
+        jdbcTemplate.update("DELETE FROM recurring_settlement WHERE recurring_settlement_id >= 70000");
+        jdbcTemplate.update("DELETE FROM users WHERE user_id >= 70000");
+    }
+
+    @Nested
+    @DisplayName("정상 시나리오 - 2회차 생성")
+    class NormalGeneration {
+
+        @Test
+        @DisplayName("참여자 2명이 있는 1회차에서 다음 회차를 생성하면, 동일한 참여자 2명이 복사되고 동일 금액이 유지된다")
+        void generatesNextCycleWithSameParticipantsAndAmounts() {
+            Long ownerId = 71001L;
+            Long userA = 71002L;
+            Long userB = 71003L;
+            Long recurringId = 71101L;
+            Long settlement1Id = 71201L;
+            Long participant1Id = 71301L;
+            Long participant2Id = 71302L;
+
+            insertUser(ownerId, "월세 관리자");
+            insertUser(userA, "참여자 A");
+            insertUser(userB, "참여자 B");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+            insertParticipant(participant2Id, settlement1Id, userB, "ACTIVE");
+            insertObligation(81001L, participant1Id, "150000.00");
+            insertObligation(81002L, participant2Id, "150000.00");
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28));
+
+            var latest = settlementMapper.findLatestByRecurringId(recurringId);
+            assertThat(latest).isNotNull();
+            assertThat(latest.getSettlementId()).isNotEqualTo(settlement1Id);
+            assertThat(latest.getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
+
+            var newParticipants = participantMapper.findBySettlementId(latest.getSettlementId());
+            assertThat(newParticipants).hasSize(2);
+
+            Map<Long, BigDecimal> obligationByUserId = fetchObligationAmountsByUser(latest.getSettlementId());
+            assertThat(obligationByUserId.get(userA)).isEqualByComparingTo(new BigDecimal("150000"));
+            assertThat(obligationByUserId.get(userB)).isEqualByComparingTo(new BigDecimal("150000"));
+        }
+    }
+
+    @Nested
+    @DisplayName("참여자 탈퇴 시 EQUAL 재계산")
+    class EqualRecalculationOnParticipantLeft {
+
+        @Test
+        @DisplayName("2명 중 1명이 REMOVED되면, 새 회차엔 남은 1명만 복사되고 전액(30만원)으로 재계산된다")
+        void recalculatesFullAmountWhenOneParticipantRemoved() {
+            Long ownerId = 72001L;
+            Long userA = 72002L;
+            Long userB = 72003L;
+            Long recurringId = 72101L;
+            Long settlement1Id = 72201L;
+            Long participant1Id = 72301L;
+            Long participant2Id = 72302L;
+
+            insertUser(ownerId, "월세 관리자");
+            insertUser(userA, "남는 참여자");
+            insertUser(userB, "탈퇴한 참여자");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+            insertParticipant(participant2Id, settlement1Id, userB, "REMOVED"); // 이미 탈퇴 상태
+            insertObligation(82001L, participant1Id, "150000.00");
+            insertObligation(82002L, participant2Id, "150000.00");
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28));
+
+            var latest = settlementMapper.findLatestByRecurringId(recurringId);
+            var newParticipants = participantMapper.findBySettlementId(latest.getSettlementId());
+
+            assertThat(newParticipants).hasSize(1);
+
+            Map<Long, BigDecimal> obligationByUserId = fetchObligationAmountsByUser(latest.getSettlementId());
+            assertThat(obligationByUserId.get(userA)).isEqualByComparingTo(new BigDecimal("300000"));
+            assertThat(obligationByUserId).doesNotContainKey(userB);
+        }
+    }
+
+    @Nested
+    @DisplayName("밀린 회차 캐치업")
+    class CatchUpMultipleCycles {
+
+        @Test
+        @DisplayName("배치가 두 달 밀린 상태에서 한 번 호출하면, 2회차와 3회차가 순차적으로 모두 생성된다")
+        void catchesUpMultipleMissedCycles() {
+            Long ownerId = 73001L;
+            Long userA = 73002L;
+            Long recurringId = 73101L;
+            Long settlement1Id = 73201L;
+            Long participant1Id = 73301L;
+
+            insertUser(ownerId, "월세 관리자");
+            insertUser(userA, "참여자 A");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+            insertObligation(83001L, participant1Id, "300000.00");
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 3, 31));
+
+            List<LocalDate> cycleDates = jdbcTemplate.queryForList(
+                    "SELECT cycle_date FROM settlement WHERE recurring_settlement_id = ? ORDER BY cycle_date",
+                    LocalDate.class,
+                    recurringId
+            );
+
+            assertThat(cycleDates).containsExactly(
+                    LocalDate.of(2026, 1, 31),
+                    LocalDate.of(2026, 2, 28), // 말일 클램프
+                    LocalDate.of(2026, 3, 31)  // anchor 복귀
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 - 중복 실행 방지")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 오늘자 회차가 존재하는 상태에서 같은 baseDate로 다시 호출해도 중복 생성되지 않는다")
+        void doesNotDuplicateWhenAlreadyGeneratedForBaseDate() {
+            Long ownerId = 74001L;
+            Long userA = 74002L;
+            Long recurringId = 74101L;
+            Long settlement1Id = 74201L;
+            Long participant1Id = 74301L;
+
+            insertUser(ownerId, "월세 관리자");
+            insertUser(userA, "참여자 A");
+            insertRecurringSettlement(recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertSettlementInstance(settlement1Id, recurringId, ownerId, LocalDate.of(2026, 1, 31));
+            insertParticipant(participant1Id, settlement1Id, userA, "ACTIVE");
+            insertObligation(84001L, participant1Id, "300000.00");
+
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28));
+            generationService.generateTodaySettlements(LocalDate.of(2026, 2, 28)); // 같은 날짜로 재호출
+
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM settlement WHERE recurring_settlement_id = ? AND cycle_date = ?",
+                    Integer.class,
+                    recurringId, LocalDate.of(2026, 2, 28)
+            );
+
+            assertThat(count).isEqualTo(1); // 두 번 호출해도 1건만 존재
+        }
+    }
+
+    private Map<Long, BigDecimal> fetchObligationAmountsByUser(Long settlementId) {
+        return jdbcTemplate.query(
+                """
+                SELECT sp.user_id AS user_id, po.expected_amount AS expected_amount
+                FROM settlement_participant sp
+                JOIN payment_obligation po ON po.participant_id = sp.participant_id
+                WHERE sp.settlement_id = ?
+                """,
+                (rs, rowNum) -> Map.entry(rs.getLong("user_id"), rs.getBigDecimal("expected_amount")),
+                settlementId
+        ).stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void insertUser(Long userId, String name) {
+        String unique = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                """
+                INSERT INTO users (user_id, user_token, email, password, name, birth_date)
+                VALUES (?, ?, ?, ?, ?, '2000-01-01')
+                """,
+                userId, unique, unique + "@example.com", "password", name
+        );
+    }
+
+    private void insertRecurringSettlement(Long recurringSettlementId, Long ownerId, LocalDate startDate) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO recurring_settlement (
+                    recurring_settlement_id, owner_id, settlement_category, title,
+                    split_type, total_amount, cycle_rule, start_date, end_date, created_at
+                )
+                VALUES (?, ?, '월세', '자취방 월세', 'EQUAL', 300000, 'MONTHLY', ?, NULL, NOW())
+                """,
+                recurringSettlementId, ownerId, startDate
+        );
+    }
+
+    private void insertSettlementInstance(
+            Long settlementId, Long recurringSettlementId, Long ownerId, LocalDate cycleDate
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id, recurring_settlement_id, owner_id, settlement_type,
+                    settlement_status, settlement_category, title, split_type,
+                    total_amount, due_date, cycle_date, created_at
+                )
+                VALUES (?, ?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '자취방 월세', 'EQUAL', 300000, NULL, ?, NOW())
+                """,
+                settlementId, recurringSettlementId, ownerId, cycleDate
+        );
+    }
+
+    private void insertParticipant(Long participantId, Long settlementId, Long userId, String status) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement_participant (
+                    participant_id, settlement_id, user_id, participant_role, participant_status, joined_at
+                )
+                VALUES (?, ?, ?, 'MEMBER', ?, NOW())
+                """,
+                participantId, settlementId, userId, status
+        );
+    }
+
+    private void insertObligation(Long obligationId, Long participantId, String expectedAmount) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO payment_obligation (
+                    payment_obligation_id, participant_id, expected_amount,
+                    payment_status, review_status, obligation_status
+                )
+                VALUES (?, ?, ?, 'UNPAID', 'NORMAL', 'ACTIVE')
+                """,
+                obligationId, participantId, new BigDecimal(expectedAmount)
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
@@ -186,6 +186,8 @@ class RecurringSettlementGenerationServiceTest {
 
         when(cycleGenerator.calculateNthCycleDate(any(), any(), eq(1)))
                 .thenReturn(LocalDate.of(2026, 2, 28));
+        when(cycleGenerator.calculateNthCycleDate(any(), any(), eq(2)))
+                .thenReturn(LocalDate.of(2026, 3, 31));
 
         when(cycleGenerator.generateOneCycle(eq(r1), eq(latest1), any()))
                 .thenThrow(new IllegalStateException("r1 실패"));
@@ -195,6 +197,7 @@ class RecurringSettlementGenerationServiceTest {
         sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator).generateOneCycle(eq(r1), eq(latest1), any());
-        verify(cycleGenerator).generateOneCycle(eq(r2), eq(latest2), any()); // r1 실패와 무관하게 호출됨
+        verify(cycleGenerator).generateOneCycle(eq(r2), eq(latest2), any());
+        verify(cycleGenerator, times(1)).generateOneCycle(eq(r2), any(), any());
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
@@ -1,0 +1,69 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementGenerationService;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecurringSettlementGenerationServiceTest {
+
+    @Mock private RecurringSettlementMapper recurringSettlementMapper;
+    @Mock private RecurringSettlementCycleGenerator cycleGenerator;
+
+    @InjectMocks
+    private RecurringSettlementGenerationService sut;
+
+    @Test
+    @DisplayName("조회된 대상 각각에 대해 회차 생성을 시도한다")
+    void invokesCycleGeneratorForEachCandidate() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 2);
+        RecurringSettlementDTO r1 = RecurringSettlementDTO.builder().recurringSettlementId(1L).build();
+        RecurringSettlementDTO r2 = RecurringSettlementDTO.builder().recurringSettlementId(2L).build();
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1, r2));
+
+        sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator).generateNextCycle(r1, baseDate);
+        verify(cycleGenerator).generateNextCycle(r2, baseDate);
+    }
+
+    @Test
+    @DisplayName("한 건이 예외를 던져도 나머지 대상은 계속 처리된다")
+    void continuesProcessingWhenOneFails() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 2);
+        RecurringSettlementDTO r1 = RecurringSettlementDTO.builder().recurringSettlementId(1L).build();
+        RecurringSettlementDTO r2 = RecurringSettlementDTO.builder().recurringSettlementId(2L).build();
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1, r2));
+        doThrow(new IllegalStateException("boom"))
+                .when(cycleGenerator).generateNextCycle(eq(r1), eq(baseDate));
+
+        sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator).generateNextCycle(r2, baseDate);
+    }
+
+    @Test
+    @DisplayName("대상이 없으면 아무것도 호출하지 않는다")
+    void doesNothingWhenNoCandidates() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 2);
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of());
+
+        sut.generateTodaySettlements(baseDate);
+
+        verifyNoInteractions(cycleGenerator);
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
@@ -7,9 +7,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
 import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementGenerationService;
+import org.teamsai.saibackend.domain.settlement.type.CycleRule;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -22,48 +25,176 @@ import static org.mockito.Mockito.*;
 class RecurringSettlementGenerationServiceTest {
 
     @Mock private RecurringSettlementMapper recurringSettlementMapper;
+    @Mock private SettlementMapper settlementMapper;
     @Mock private RecurringSettlementCycleGenerator cycleGenerator;
 
     @InjectMocks
     private RecurringSettlementGenerationService sut;
 
-    @Test
-    @DisplayName("조회된 대상 각각에 대해 회차 생성을 시도한다")
-    void invokesCycleGeneratorForEachCandidate() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 2);
-        RecurringSettlementDTO r1 = RecurringSettlementDTO.builder().recurringSettlementId(1L).build();
-        RecurringSettlementDTO r2 = RecurringSettlementDTO.builder().recurringSettlementId(2L).build();
-        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1, r2));
+    private RecurringSettlementDTO recurring(Long id, LocalDate startDate) {
+        return RecurringSettlementDTO.builder()
+                .recurringSettlementId(id)
+                .cycleRule(CycleRule.MONTHLY)
+                .startDate(startDate)
+                .build();
+    }
 
-        sut.generateTodaySettlements(baseDate);
-
-        verify(cycleGenerator).generateNextCycle(r1, baseDate);
-        verify(cycleGenerator).generateNextCycle(r2, baseDate);
+    private SettlementDTO settlement(Long id, Long recurringId, LocalDate cycleDate) {
+        return SettlementDTO.builder()
+                .settlementId(id)
+                .recurringSettlementId(recurringId)
+                .cycleDate(cycleDate)
+                .build();
     }
 
     @Test
-    @DisplayName("한 건이 예외를 던져도 나머지 대상은 계속 처리된다")
-    void continuesProcessingWhenOneFails() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 2);
-        RecurringSettlementDTO r1 = RecurringSettlementDTO.builder().recurringSettlementId(1L).build();
-        RecurringSettlementDTO r2 = RecurringSettlementDTO.builder().recurringSettlementId(2L).build();
-        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1, r2));
-        doThrow(new IllegalStateException("boom"))
-                .when(cycleGenerator).generateNextCycle(eq(r1), eq(baseDate));
+    @DisplayName("직전 회차가 없으면 캐치업을 시도하지 않는다")
+    void skipsWhenNoLatestSettlement() {
+        LocalDate baseDate = LocalDate.of(2026, 3, 1);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(null);
 
         sut.generateTodaySettlements(baseDate);
 
-        verify(cycleGenerator).generateNextCycle(r2, baseDate);
+        verify(cycleGenerator, never()).generateOneCycle(any(), any(), any());
     }
 
     @Test
-    @DisplayName("대상이 없으면 아무것도 호출하지 않는다")
-    void doesNothingWhenNoCandidates() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 2);
-        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of());
+    @DisplayName("도래한 회차가 하나면 정확히 1번만 생성을 시도한다")
+    void generatesExactlyOneCycleWhenOnlyOneIsDue() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 28);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO latest = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO created = settlement(11L, 1L, LocalDate.of(2026, 2, 28));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(latest);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1); // 이미 1회차 존재
+
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
+                .thenReturn(LocalDate.of(2026, 2, 28)); // baseDate와 같음 -> 도래
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
+                .thenReturn(LocalDate.of(2026, 3, 31)); // baseDate 이후 -> 미도래, 루프 종료
+
+        when(cycleGenerator.generateOneCycle(r1, latest, LocalDate.of(2026, 2, 28)))
+                .thenReturn(created);
 
         sut.generateTodaySettlements(baseDate);
 
-        verifyNoInteractions(cycleGenerator);
+        verify(cycleGenerator, times(1)).generateOneCycle(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("배치가 밀려 여러 회차가 도래했으면 baseDate까지 연속으로 캐치업한다")
+    void catchesUpMultipleOverdueCycles() {
+        LocalDate baseDate = LocalDate.of(2026, 4, 15); // 2, 3, 4월 회차가 밀린 상태
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle2 = settlement(11L, 1L, LocalDate.of(2026, 2, 28));
+        SettlementDTO cycle3 = settlement(12L, 1L, LocalDate.of(2026, 3, 31));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(cycle1);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
+                .thenReturn(LocalDate.of(2026, 2, 28));
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
+                .thenReturn(LocalDate.of(2026, 3, 31));
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 3))
+                .thenReturn(LocalDate.of(2026, 4, 30)); // baseDate(4/15) 이후 -> 루프 종료
+
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(cycle2);
+        when(cycleGenerator.generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31))).thenReturn(cycle3);
+
+        sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator).generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28));
+        verify(cycleGenerator).generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31));
+        verify(cycleGenerator, times(2)).generateOneCycle(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("캐치업 도중 한 회차가 실패하면, 이미 성공한 이전 회차는 유지하고 그 이후 회차는 이번 배치에서 중단한다 (부분 커밋)")
+    void stopsCatchUpOnFailureButKeepsPreviouslySucceededCycles() {
+        LocalDate baseDate = LocalDate.of(2026, 4, 15);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle2 = settlement(11L, 1L, LocalDate.of(2026, 2, 28));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(cycle1);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
+                .thenReturn(LocalDate.of(2026, 2, 28));
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
+                .thenReturn(LocalDate.of(2026, 3, 31));
+
+        // 1번째 회차는 성공(이미 별도 트랜잭션에서 커밋된 것으로 간주)
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(cycle2);
+        // 2번째 회차에서 예외 발생
+        when(cycleGenerator.generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31)))
+                .thenThrow(new IllegalStateException("insert 실패"));
+
+        sut.generateTodaySettlements(baseDate);
+
+        // 1번째는 시도됨(=커밋됨), 2번째도 시도됐지만 실패, 3번째는 시도조차 안 됨(루프 중단)
+        verify(cycleGenerator).generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28));
+        verify(cycleGenerator).generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31));
+        verify(cycleGenerator, times(2)).generateOneCycle(any(), any(), any());
+        // calculateNthCycleDate(n=3)까지는 호출되지 않아야 함 (예외 이후 즉시 중단)
+        verify(cycleGenerator, never()).calculateNthCycleDate(any(), any(), eq(3));
+    }
+
+    @Test
+    @DisplayName("generateOneCycle이 null을 반환하면(동시성 충돌 또는 참여자 없음) 캐치업을 중단한다")
+    void stopsCatchUpWhenGenerateOneCycleReturnsNull() {
+        LocalDate baseDate = LocalDate.of(2026, 3, 1);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(cycle1);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
+                .thenReturn(LocalDate.of(2026, 2, 28));
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(null);
+
+        sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator, times(1)).generateOneCycle(any(), any(), any());
+        verify(cycleGenerator, never()).calculateNthCycleDate(any(), any(), eq(2));
+    }
+
+    @Test
+    @DisplayName("한 recurring 건이 실패해도 다른 recurring 건 처리는 계속된다")
+    void continuesOtherRecurringsWhenOneFails() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 28);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        RecurringSettlementDTO r2 = recurring(2L, LocalDate.of(2026, 1, 31));
+        SettlementDTO latest1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO latest2 = settlement(20L, 2L, LocalDate.of(2026, 1, 31));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1, r2));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(latest1);
+        when(settlementMapper.findLatestByRecurringId(2L)).thenReturn(latest2);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+        when(settlementMapper.countByRecurringId(2L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(any(), any(), eq(1)))
+                .thenReturn(LocalDate.of(2026, 2, 28));
+
+        when(cycleGenerator.generateOneCycle(eq(r1), eq(latest1), any()))
+                .thenThrow(new IllegalStateException("r1 실패"));
+        when(cycleGenerator.generateOneCycle(eq(r2), eq(latest2), any()))
+                .thenReturn(settlement(21L, 2L, LocalDate.of(2026, 2, 28)));
+
+        sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator).generateOneCycle(eq(r1), eq(latest1), any());
+        verify(cycleGenerator).generateOneCycle(eq(r2), eq(latest2), any()); // r1 실패와 무관하게 호출됨
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementGenerationServiceTest.java
@@ -10,15 +10,14 @@ import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementMapper;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
-import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementCycleGenerator;
-import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementGenerationService;
+import org.teamsai.saibackend.domain.settlement.service.*;
 import org.teamsai.saibackend.domain.settlement.type.CycleRule;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,10 +31,15 @@ class RecurringSettlementGenerationServiceTest {
     private RecurringSettlementGenerationService sut;
 
     private RecurringSettlementDTO recurring(Long id, LocalDate startDate) {
+        return recurring(id, startDate, null);
+    }
+
+    private RecurringSettlementDTO recurring(Long id, LocalDate startDate, LocalDate endDate) {
         return RecurringSettlementDTO.builder()
                 .recurringSettlementId(id)
                 .cycleRule(CycleRule.MONTHLY)
                 .startDate(startDate)
+                .endDate(endDate)
                 .build();
     }
 
@@ -55,9 +59,11 @@ class RecurringSettlementGenerationServiceTest {
         when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
         when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(null);
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator, never()).generateOneCycle(any(), any(), any());
+        assertThat(result.succeeded()).isEqualTo(1); // 직전 회차 없음도 정상 종료로 집계됨
+        assertThat(result.failed()).isEqualTo(0);
     }
 
     @Test
@@ -70,25 +76,26 @@ class RecurringSettlementGenerationServiceTest {
 
         when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
         when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(latest);
-        when(settlementMapper.countByRecurringId(1L)).thenReturn(1); // 이미 1회차 존재
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
 
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
-                .thenReturn(LocalDate.of(2026, 2, 28)); // baseDate와 같음 -> 도래
+                .thenReturn(LocalDate.of(2026, 2, 28));
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
-                .thenReturn(LocalDate.of(2026, 3, 31)); // baseDate 이후 -> 미도래, 루프 종료
+                .thenReturn(LocalDate.of(2026, 3, 31));
 
         when(cycleGenerator.generateOneCycle(r1, latest, LocalDate.of(2026, 2, 28)))
-                .thenReturn(created);
+                .thenReturn(CycleGenerationOutcome.created(created));
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator, times(1)).generateOneCycle(any(), any(), any());
+        assertThat(result.succeeded()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("배치가 밀려 여러 회차가 도래했으면 baseDate까지 연속으로 캐치업한다")
     void catchesUpMultipleOverdueCycles() {
-        LocalDate baseDate = LocalDate.of(2026, 4, 15); // 2, 3, 4월 회차가 밀린 상태
+        LocalDate baseDate = LocalDate.of(2026, 4, 15);
         RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
         SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
         SettlementDTO cycle2 = settlement(11L, 1L, LocalDate.of(2026, 2, 28));
@@ -103,21 +110,24 @@ class RecurringSettlementGenerationServiceTest {
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
                 .thenReturn(LocalDate.of(2026, 3, 31));
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 3))
-                .thenReturn(LocalDate.of(2026, 4, 30)); // baseDate(4/15) 이후 -> 루프 종료
+                .thenReturn(LocalDate.of(2026, 4, 30));
 
-        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(cycle2);
-        when(cycleGenerator.generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31))).thenReturn(cycle3);
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28)))
+                .thenReturn(CycleGenerationOutcome.created(cycle2));
+        when(cycleGenerator.generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31)))
+                .thenReturn(CycleGenerationOutcome.created(cycle3));
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator).generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28));
         verify(cycleGenerator).generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31));
         verify(cycleGenerator, times(2)).generateOneCycle(any(), any(), any());
+        assertThat(result.succeeded()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("캐치업 도중 한 회차가 실패하면, 이미 성공한 이전 회차는 유지하고 그 이후 회차는 이번 배치에서 중단한다 (부분 커밋)")
-    void stopsCatchUpOnFailureButKeepsPreviouslySucceededCycles() {
+    @DisplayName("캐치업 도중 한 회차가 실패하면, 이미 성공한 이전 회차는 유지하고 그 이후 회차는 이번 배치에서 중단하며 실패로 집계된다")
+    void stopsCatchUpOnFailureAndCountsAsFailed() {
         LocalDate baseDate = LocalDate.of(2026, 4, 15);
         RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
         SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
@@ -132,25 +142,25 @@ class RecurringSettlementGenerationServiceTest {
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 2))
                 .thenReturn(LocalDate.of(2026, 3, 31));
 
-        // 1번째 회차는 성공(이미 별도 트랜잭션에서 커밋된 것으로 간주)
-        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(cycle2);
-        // 2번째 회차에서 예외 발생
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28)))
+                .thenReturn(CycleGenerationOutcome.created(cycle2));
         when(cycleGenerator.generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31)))
                 .thenThrow(new IllegalStateException("insert 실패"));
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
-        // 1번째는 시도됨(=커밋됨), 2번째도 시도됐지만 실패, 3번째는 시도조차 안 됨(루프 중단)
         verify(cycleGenerator).generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28));
         verify(cycleGenerator).generateOneCycle(r1, cycle2, LocalDate.of(2026, 3, 31));
         verify(cycleGenerator, times(2)).generateOneCycle(any(), any(), any());
-        // calculateNthCycleDate(n=3)까지는 호출되지 않아야 함 (예외 이후 즉시 중단)
         verify(cycleGenerator, never()).calculateNthCycleDate(any(), any(), eq(3));
+
+        assertThat(result.failed()).isEqualTo(1);
+        assertThat(result.failedRecurringIds()).containsExactly(1L);
     }
 
     @Test
-    @DisplayName("generateOneCycle이 null을 반환하면(동시성 충돌 또는 참여자 없음) 캐치업을 중단한다")
-    void stopsCatchUpWhenGenerateOneCycleReturnsNull() {
+    @DisplayName("동시성 충돌로 CONCURRENTLY_SKIPPED가 반환되면 캐치업을 중단하되 실패로 집계하지 않는다")
+    void stopsCatchUpWhenConcurrentlySkipped() {
         LocalDate baseDate = LocalDate.of(2026, 3, 1);
         RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
         SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
@@ -161,16 +171,43 @@ class RecurringSettlementGenerationServiceTest {
 
         when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
                 .thenReturn(LocalDate.of(2026, 2, 28));
-        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28))).thenReturn(null);
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28)))
+                .thenReturn(CycleGenerationOutcome.concurrentlySkipped());
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator, times(1)).generateOneCycle(any(), any(), any());
         verify(cycleGenerator, never()).calculateNthCycleDate(any(), any(), eq(2));
+        assertThat(result.succeeded()).isEqualTo(1);
+        assertThat(result.failed()).isEqualTo(0);
     }
 
     @Test
-    @DisplayName("한 recurring 건이 실패해도 다른 recurring 건 처리는 계속된다")
+    @DisplayName("ACTIVE 참여자가 없어 NO_ACTIVE_PARTICIPANT가 반환되면 캐치업을 중단하되 실패로 집계하지 않는다")
+    void stopsCatchUpWhenNoActiveParticipant() {
+        LocalDate baseDate = LocalDate.of(2026, 3, 1);
+        RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
+        SettlementDTO cycle1 = settlement(10L, 1L, LocalDate.of(2026, 1, 31));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(r1));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(cycle1);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(r1.getStartDate(), CycleRule.MONTHLY, 1))
+                .thenReturn(LocalDate.of(2026, 2, 28));
+        when(cycleGenerator.generateOneCycle(r1, cycle1, LocalDate.of(2026, 2, 28)))
+                .thenReturn(CycleGenerationOutcome.noActiveParticipant());
+
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator, times(1)).generateOneCycle(any(), any(), any());
+        verify(cycleGenerator, never()).calculateNthCycleDate(any(), any(), eq(2));
+        assertThat(result.succeeded()).isEqualTo(1);
+        assertThat(result.failed()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("한 recurring 건이 실패해도 다른 recurring 건 처리는 계속되고, 결과에 실패/성공이 각각 집계된다")
     void continuesOtherRecurringsWhenOneFails() {
         LocalDate baseDate = LocalDate.of(2026, 2, 28);
         RecurringSettlementDTO r1 = recurring(1L, LocalDate.of(2026, 1, 31));
@@ -192,12 +229,83 @@ class RecurringSettlementGenerationServiceTest {
         when(cycleGenerator.generateOneCycle(eq(r1), eq(latest1), any()))
                 .thenThrow(new IllegalStateException("r1 실패"));
         when(cycleGenerator.generateOneCycle(eq(r2), eq(latest2), any()))
-                .thenReturn(settlement(21L, 2L, LocalDate.of(2026, 2, 28)));
+                .thenReturn(CycleGenerationOutcome.created(settlement(21L, 2L, LocalDate.of(2026, 2, 28))));
 
-        sut.generateTodaySettlements(baseDate);
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
 
         verify(cycleGenerator).generateOneCycle(eq(r1), eq(latest1), any());
         verify(cycleGenerator).generateOneCycle(eq(r2), eq(latest2), any());
         verify(cycleGenerator, times(1)).generateOneCycle(eq(r2), any(), any());
+
+        assertThat(result.totalCandidates()).isEqualTo(2);
+        assertThat(result.succeeded()).isEqualTo(1);
+        assertThat(result.failed()).isEqualTo(1);
+        assertThat(result.failedRecurringIds()).containsExactly(1L);
+    }
+
+    @Test
+    @DisplayName("종료일이 지난 정기정산도 종료일까지 미생성 회차가 있으면 계속 조회 대상이 된다")
+    void includesEndedRecurringSettlementWithUngeneratedCyclesUpToEndDate() {
+        LocalDate baseDate = LocalDate.of(2026, 8, 17);
+        RecurringSettlementDTO recurring = recurring(1L, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 8, 15));
+        SettlementDTO lastGenerated = settlement(10L, 1L, LocalDate.of(2026, 8, 13));
+        SettlementDTO generated = settlement(11L, 1L, LocalDate.of(2026, 8, 14));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(recurring));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(lastGenerated);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(13);
+
+        when(cycleGenerator.calculateNthCycleDate(recurring.getStartDate(), recurring.getCycleRule(), 13))
+                .thenReturn(LocalDate.of(2026, 8, 14));
+        when(cycleGenerator.calculateNthCycleDate(recurring.getStartDate(), recurring.getCycleRule(), 14))
+                .thenReturn(LocalDate.of(2026, 8, 15));
+        when(cycleGenerator.calculateNthCycleDate(recurring.getStartDate(), recurring.getCycleRule(), 15))
+                .thenReturn(LocalDate.of(2026, 8, 16));
+
+        when(cycleGenerator.generateOneCycle(recurring, lastGenerated, LocalDate.of(2026, 8, 14)))
+                .thenReturn(CycleGenerationOutcome.created(generated));
+        when(cycleGenerator.generateOneCycle(eq(recurring), eq(generated), any()))
+                .thenReturn(CycleGenerationOutcome.created(settlement(12L, 1L, LocalDate.of(2026, 8, 15))));
+
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator).generateOneCycle(recurring, lastGenerated, LocalDate.of(2026, 8, 14));
+        verify(cycleGenerator).generateOneCycle(eq(recurring), eq(generated), eq(LocalDate.of(2026, 8, 15)));
+        verify(cycleGenerator, never()).generateOneCycle(any(), any(), eq(LocalDate.of(2026, 8, 16)));
+        assertThat(result.succeeded()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("한 정기정산의 캐치업이 상한(31회)에 도달하면 그 지점에서 멈추고 다른 정기정산 처리로 넘어간다")
+    void stopsAtCatchUpLimitAndProcessesOtherRecurrings() {
+        LocalDate baseDate = LocalDate.of(2026, 12, 31);
+        RecurringSettlementDTO heavilyDelayed = recurring(1L, LocalDate.of(2026, 1, 1));
+        RecurringSettlementDTO normal = recurring(2L, LocalDate.of(2026, 12, 30));
+
+        SettlementDTO delayedLast = settlement(10L, 1L, LocalDate.of(2026, 1, 1));
+        SettlementDTO normalLast = settlement(20L, 2L, LocalDate.of(2026, 12, 30));
+
+        when(recurringSettlementMapper.findActiveInRange(baseDate)).thenReturn(List.of(heavilyDelayed, normal));
+        when(settlementMapper.findLatestByRecurringId(1L)).thenReturn(delayedLast);
+        when(settlementMapper.findLatestByRecurringId(2L)).thenReturn(normalLast);
+        when(settlementMapper.countByRecurringId(1L)).thenReturn(1);
+        when(settlementMapper.countByRecurringId(2L)).thenReturn(1);
+
+        when(cycleGenerator.calculateNthCycleDate(eq(heavilyDelayed.getStartDate()), any(), anyInt()))
+                .thenReturn(LocalDate.of(2026, 1, 2));
+        when(cycleGenerator.generateOneCycle(eq(heavilyDelayed), any(), any()))
+                .thenReturn(CycleGenerationOutcome.created(settlement(99L, 1L, LocalDate.of(2026, 1, 2))));
+
+        when(cycleGenerator.calculateNthCycleDate(eq(normal.getStartDate()), any(), eq(1)))
+                .thenReturn(LocalDate.of(2026, 12, 31));
+        when(cycleGenerator.calculateNthCycleDate(eq(normal.getStartDate()), any(), eq(2)))
+                .thenReturn(LocalDate.of(2027, 1, 30));
+        when(cycleGenerator.generateOneCycle(eq(normal), eq(normalLast), any()))
+                .thenReturn(CycleGenerationOutcome.created(settlement(21L, 2L, LocalDate.of(2026, 12, 31))));
+        RecurringSettlementBatchResult result = sut.generateTodaySettlements(baseDate);
+
+        verify(cycleGenerator, times(31)).generateOneCycle(eq(heavilyDelayed), any(), any());
+        verify(cycleGenerator).generateOneCycle(eq(normal), eq(normalLast), any());
+        assertThat(result.succeeded()).isEqualTo(2); // 둘 다 "실패"는 아니므로 성공 집계
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAmountCalculatorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementAmountCalculatorTest.java
@@ -155,6 +155,134 @@ class SettlementAmountCalculatorTest {
         );
     }
 
+    @Test
+    @DisplayName(
+            "인원수가 0이면 ArithmeticException이 아니라 도메인 예외가 발생한다"
+    )
+    void calculateEqualAmountFailsWhenParticipantCountIsZero() {
+        // calculateEqualAmount(totalAmount, 0)은 내부적으로 calculateEqualAmountForTotalCount(totalAmount, 1)이 되어
+        // 정상 계산되므로, 0 이하 검증은 calculateEqualAmountForTotalCount를 직접 호출해서 확인한다
+        assertSettlementExceptionThrownBy(
+                () ->
+                        settlementAmountCalculator
+                                .calculateEqualAmountForTotalCount(
+                                        new BigDecimal("300000"),
+                                        0
+                                ),
+                SettlementErrorCode
+                        .INVALID_SETTLEMENT_AMOUNT
+        );
+    }
+
+    @Test
+    @DisplayName(
+            "인원수가 음수이면 도메인 예외가 발생한다"
+    )
+    void calculateEqualAmountForTotalCountFailsWhenParticipantCountIsNegative() {
+        assertSettlementExceptionThrownBy(
+                () ->
+                        settlementAmountCalculator
+                                .calculateEqualAmountForTotalCount(
+                                        new BigDecimal("300000"),
+                                        -1
+                                ),
+                SettlementErrorCode
+                        .INVALID_SETTLEMENT_AMOUNT
+        );
+    }
+
+    @Test
+    @DisplayName(
+            "총금액을 전체 인원으로 균등 분배하되, 나머지 없이 정확히 나누어떨어지면 모두 동일한 금액이다"
+    )
+    void distributeEqualAmountsSuccessWhenDivisible() {
+        BigDecimal totalAmount = new BigDecimal("300000");
+        int totalParticipantCount = 3;
+
+        java.util.List<BigDecimal> result =
+                settlementAmountCalculator.distributeEqualAmounts(
+                        totalAmount,
+                        totalParticipantCount
+                );
+
+        assertThat(result).hasSize(3);
+        assertThat(result).allSatisfy(amount ->
+                assertThat(amount).isEqualByComparingTo("100000"));
+    }
+
+    @Test
+    @DisplayName(
+            "총금액이 인원수로 나누어떨어지지 않으면 나머지를 마지막 참여자에게 배정하여 합계를 총금액과 일치시킨다"
+    )
+    void distributeEqualAmountsAssignsRemainderToLastParticipant() {
+        BigDecimal totalAmount = new BigDecimal("10000");
+        int totalParticipantCount = 3;
+
+        java.util.List<BigDecimal> result =
+                settlementAmountCalculator.distributeEqualAmounts(
+                        totalAmount,
+                        totalParticipantCount
+                );
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualByComparingTo("3333");
+        assertThat(result.get(1)).isEqualByComparingTo("3333");
+        assertThat(result.get(2)).isEqualByComparingTo("3334");
+
+        BigDecimal sum = result.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(sum).isEqualByComparingTo(totalAmount);
+    }
+
+    @Test
+    @DisplayName(
+            "1명에게 분배하면 전액이 그대로 배정된다"
+    )
+    void distributeEqualAmountsAssignsFullAmountToSingleParticipant() {
+        BigDecimal totalAmount = new BigDecimal("150000");
+
+        java.util.List<BigDecimal> result =
+                settlementAmountCalculator.distributeEqualAmounts(
+                        totalAmount,
+                        1
+                );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isEqualByComparingTo(totalAmount);
+    }
+
+    @Test
+    @DisplayName(
+            "distributeEqualAmounts도 총금액이 0이면 예외가 발생한다"
+    )
+    void distributeEqualAmountsFailsWhenTotalAmountIsZero() {
+        assertSettlementExceptionThrownBy(
+                () ->
+                        settlementAmountCalculator
+                                .distributeEqualAmounts(
+                                        BigDecimal.ZERO,
+                                        3
+                                ),
+                SettlementErrorCode
+                        .INVALID_SETTLEMENT_AMOUNT
+        );
+    }
+
+    @Test
+    @DisplayName(
+            "distributeEqualAmounts도 인원수가 0 이하이면 도메인 예외가 발생한다"
+    )
+    void distributeEqualAmountsFailsWhenParticipantCountIsZeroOrLess() {
+        assertSettlementExceptionThrownBy(
+                () ->
+                        settlementAmountCalculator
+                                .distributeEqualAmounts(
+                                        new BigDecimal("300000"),
+                                        0
+                                ),
+                SettlementErrorCode
+                        .INVALID_SETTLEMENT_AMOUNT
+        );
+    }
 
     private void assertSettlementExceptionThrownBy(
             Runnable operation,

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementMapperTest.java
@@ -9,9 +9,16 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+import org.teamsai.saibackend.domain.settlement.type.SplitType;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -40,277 +47,182 @@ class SettlementMapperTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-
     @Test
     @Transactional
     @DisplayName("본인이 생성한 정산은 OWNER로 조회한다")
     void findAllByUserIdReturnsOwnerSettlement() {
+        insertUser(USER_ID, "조회 사용자");
+        insertSettlement(9711L, USER_ID, "내가 만든 정산");
 
-        insertUser(
-                USER_ID,
-                "조회 사용자"
-        );
-
-        insertSettlement(
-                9711L,
-                USER_ID,
-                "내가 만든 정산"
-        );
-
-
-        List<SettlementListResponse> result =
-                settlementMapper.findAllByUserId(
-                        USER_ID
-                );
-
+        List<SettlementListResponse> result = settlementMapper.findAllByUserId(USER_ID);
 
         assertThat(result)
-                .extracting(
-                        SettlementListResponse::settlementId,
-                        SettlementListResponse::role
-                )
-                .contains(
-                        tuple(
-                                9711L,
-                                "OWNER"
-                        )
-                );
+                .extracting(SettlementListResponse::settlementId, SettlementListResponse::role)
+                .contains(tuple(9711L, "OWNER"));
     }
-
 
     @Test
     @Transactional
     @DisplayName("ACTIVE 참여자는 정산을 MEMBER로 조회한다")
     void findAllByUserIdReturnsActiveMemberSettlement() {
+        insertUser(USER_ID, "참여자");
+        insertUser(OTHER_USER_ID, "정산 생성자");
+        insertSettlement(9721L, OTHER_USER_ID, "참여 중인 정산");
+        insertParticipant(9741L, 9721L, USER_ID, "ACTIVE");
 
-        insertUser(
-                USER_ID,
-                "참여자"
-        );
-
-        insertUser(
-                OTHER_USER_ID,
-                "정산 생성자"
-        );
-
-        insertSettlement(
-                9721L,
-                OTHER_USER_ID,
-                "참여 중인 정산"
-        );
-
-        insertParticipant(
-                9741L,
-                9721L,
-                USER_ID,
-                "ACTIVE"
-        );
-
-
-        List<SettlementListResponse> result =
-                settlementMapper.findAllByUserId(
-                        USER_ID
-                );
-
+        List<SettlementListResponse> result = settlementMapper.findAllByUserId(USER_ID);
 
         assertThat(result)
-                .extracting(
-                        SettlementListResponse::settlementId,
-                        SettlementListResponse::role
-                )
-                .contains(
-                        tuple(
-                                9721L,
-                                "MEMBER"
-                        )
-                );
+                .extracting(SettlementListResponse::settlementId, SettlementListResponse::role)
+                .contains(tuple(9721L, "MEMBER"));
     }
-
 
     @Test
     @Transactional
     @DisplayName("ACTIVE가 아닌 참여자는 MEMBER 목록에서 제외한다")
     void findAllByUserIdExcludesInactiveParticipant() {
+        insertUser(USER_ID, "참여자");
+        insertUser(OTHER_USER_ID, "정산 생성자");
+        insertSettlement(9781L, OTHER_USER_ID, "비활성 참여 정산");
+        insertParticipant(9801L, 9781L, USER_ID, "REMOVED");
 
-        insertUser(
-                USER_ID,
-                "참여자"
-        );
-
-        insertUser(
-                OTHER_USER_ID,
-                "정산 생성자"
-        );
-
-        insertSettlement(
-                9781L,
-                OTHER_USER_ID,
-                "비활성 참여 정산"
-        );
-
-        insertParticipant(
-                9801L,
-                9781L,
-                USER_ID,
-                "REMOVED"
-        );
-
-
-        List<SettlementListResponse> result =
-                settlementMapper.findAllByUserId(
-                        USER_ID
-                );
-
+        List<SettlementListResponse> result = settlementMapper.findAllByUserId(USER_ID);
 
         assertThat(result)
-                .extracting(
-                        SettlementListResponse::settlementId
-                )
-                .doesNotContain(
-                        9781L
-                );
+                .extracting(SettlementListResponse::settlementId)
+                .doesNotContain(9781L);
     }
-
 
     @Test
     @Transactional
     @DisplayName("정산과 관계없는 사용자의 목록에는 정산이 포함되지 않는다")
     void findAllByUserIdExcludesUnrelatedSettlement() {
+        insertUser(USER_ID, "조회 사용자");
+        insertUser(OTHER_USER_ID, "정산 생성자");
+        insertSettlement(9811L, OTHER_USER_ID, "관계없는 정산");
 
-        insertUser(
-                USER_ID,
-                "조회 사용자"
-        );
-
-        insertUser(
-                OTHER_USER_ID,
-                "정산 생성자"
-        );
-
-        insertSettlement(
-                9811L,
-                OTHER_USER_ID,
-                "관계없는 정산"
-        );
-
-
-        List<SettlementListResponse> result =
-                settlementMapper.findAllByUserId(
-                        USER_ID
-                );
-
+        List<SettlementListResponse> result = settlementMapper.findAllByUserId(USER_ID);
 
         assertThat(result)
-                .extracting(
-                        SettlementListResponse::settlementId
-                )
-                .doesNotContain(
-                        9811L
-                );
+                .extracting(SettlementListResponse::settlementId)
+                .doesNotContain(9811L);
     }
 
+    @Test
+    @Transactional
+    @DisplayName("recurringSettlementId로 가장 최근 회차(cycleDate 기준)를 조회한다")
+    void findLatestByRecurringId_returnsMostRecentCycle() {
+        insertUser(9901L, "정기정산 소유자");
+        insertRecurringSettlement(9911L, 9901L, LocalDate.of(2026, 1, 31));
+        insertRecurringSettlementInstance(9921L, 9911L, 9901L, LocalDate.of(2026, 1, 31));
+        insertRecurringSettlementInstance(9922L, 9911L, 9901L, LocalDate.of(2026, 2, 28));
+        insertRecurringSettlementInstance(9923L, 9911L, 9901L, LocalDate.of(2025, 12, 31)); // 더 과거 회차
 
-    private void insertUser(
-            Long userId,
-            String name
-    ) {
+        SettlementDTO result = settlementMapper.findLatestByRecurringId(9911L);
 
-        String unique =
-                UUID.randomUUID().toString();
+        assertThat(result).isNotNull();
+        assertThat(result.getSettlementId()).isEqualTo(9922L);
+        assertThat(result.getCycleDate()).isEqualTo(LocalDate.of(2026, 2, 28));
+    }
 
+    @Test
+    @Transactional
+    @DisplayName("해당 recurringSettlementId로 생성된 회차가 없으면 null을 반환한다")
+    void findLatestByRecurringId_returnsNullWhenNoSettlement() {
+        SettlementDTO result = settlementMapper.findLatestByRecurringId(999999L);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Settlement를 저장하면 DTO에 생성된 settlementId가 채워진다")
+    void insertSettlement_fillsGeneratedId() {
+        insertUser(9901L, "정기정산 소유자");
+        insertRecurringSettlement(9911L, 9901L, LocalDate.of(2026, 1, 31));
+
+        SettlementDTO newSettlement = SettlementDTO.builder()
+                .recurringSettlementId(9911L)
+                .ownerId(9901L)
+                .settlementType(SettlementType.RECURRING)
+                .settlementStatus(SettlementStatus.IN_PROGRESS)
+                .settlementCategory("월세")
+                .title("자취방 월세")
+                .splitType(SplitType.EQUAL)
+                .totalAmount(new BigDecimal("300000"))
+                .cycleDate(LocalDate.of(2026, 3, 31))
+                .dueDate(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        int inserted = settlementMapper.insertSettlement(newSettlement);
+
+        assertThat(inserted).isEqualTo(1);
+        assertThat(newSettlement.getSettlementId()).isNotNull();
+    }
+
+    private void insertUser(Long userId, String name) {
+        String unique = UUID.randomUUID().toString();
         jdbcTemplate.update(
                 """
-                INSERT INTO users (
-                    user_id,
-                    user_token,
-                    email,
-                    password,
-                    name,
-                    birth_date
-                )
-                VALUES (
-                    ?, ?, ?, ?, ?, '2000-01-01'
-                )
+                INSERT INTO users (user_id, user_token, email, password, name, birth_date)
+                VALUES (?, ?, ?, ?, ?, '2000-01-01')
                 """,
-                userId,
-                unique,
-                unique + "@example.com",
-                "password",
-                name
+                userId, unique, unique + "@example.com", "password", name
         );
     }
 
-
-    private void insertSettlement(
-            Long settlementId,
-            Long ownerId,
-            String title
-    ) {
-
+    private void insertSettlement(Long settlementId, Long ownerId, String title) {
         jdbcTemplate.update(
                 """
                 INSERT INTO settlement (
-                    settlement_id,
-                    owner_id,
-                    settlement_type,
-                    settlement_status,
-                    settlement_category,
-                    title,
-                    split_type,
-                    due_date,
-                    total_amount,
-                    created_at
+                    settlement_id, owner_id, settlement_type, settlement_status,
+                    settlement_category, title, split_type, due_date, total_amount, created_at
                 )
-                VALUES (
-                    ?,
-                    ?,
-                    'SHARED',
-                    'IN_PROGRESS',
-                    'FOOD',
-                    ?,
-                    'EQUAL',
-                    '2099-12-31',
-                    100000.00,
-                    NOW()
-                )
+                VALUES (?, ?, 'SHARED', 'IN_PROGRESS', 'FOOD', ?, 'EQUAL', '2099-12-31', 100000.00, NOW())
                 """,
-                settlementId,
-                ownerId,
-                title
+                settlementId, ownerId, title
         );
     }
 
-
-    private void insertParticipant(
-            Long participantId,
-            Long settlementId,
-            Long userId,
-            String participantStatus
-    ) {
-
+    private void insertParticipant(Long participantId, Long settlementId, Long userId, String participantStatus) {
         jdbcTemplate.update(
                 """
                 INSERT INTO settlement_participant (
-                    participant_id,
-                    settlement_id,
-                    user_id,
-                    participant_role,
-                    participant_status,
-                    joined_at
+                    participant_id, settlement_id, user_id, participant_role, participant_status, joined_at
                 )
-                VALUES (
-                    ?,
-                    ?,
-                    ?,
-                    'MEMBER',
-                    ?,
-                    NOW()
-                )
+                VALUES (?, ?, ?, 'MEMBER', ?, NOW())
                 """,
-                participantId,
-                settlementId,
-                userId,
-                participantStatus
+                participantId, settlementId, userId, participantStatus
+        );
+    }
+
+    private void insertRecurringSettlement(Long recurringSettlementId, Long ownerId, LocalDate startDate) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO recurring_settlement (
+                    recurring_settlement_id, owner_id, settlement_category, title,
+                    split_type, total_amount, cycle_rule, start_date, end_date, created_at
+                )
+                VALUES (?, ?, '월세', '자취방 월세', 'EQUAL', 300000, 'MONTHLY', ?, NULL, NOW())
+                """,
+                recurringSettlementId, ownerId, startDate
+        );
+    }
+
+    private void insertRecurringSettlementInstance(
+            Long settlementId, Long recurringSettlementId, Long ownerId, LocalDate cycleDate
+    ) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id, recurring_settlement_id, owner_id, settlement_type,
+                    settlement_status, settlement_category, title, split_type,
+                    total_amount, due_date, cycle_date, created_at
+                )
+                VALUES (?, ?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '자취방 월세', 'EQUAL', 300000, NULL, ?, NOW())
+                """,
+                settlementId, recurringSettlementId, ownerId, cycleDate
         );
     }
 }


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #141 

## 🛠 작업 사항

- `RecurringSettlementGenerationService`: 부분 커밋
- `RecurringSettlementCycleGenerator`: 회차 1건 생성
- `SettlementAmountCalculator`:  `calculateEqualAmountForTotalCount` 오버로드 추가

## ✅ 테스트

- [ x ] 로컬 서버 테스트 완료
- [ x ] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 이 PR은 자동 생성 **도메인 로직**만 다룹니다. 이 서비스를 언제,어떻게 트리거할지는 별도 이슈에서 다룹니다.
- 현재 `generateTodaySettlements()`를 호출하는 진입점은 없습니다.

---