### PR TITLE
feat(#145): 연체 상태 갱신

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/payment/dto/PaymentObligationDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/dto/PaymentObligationDTO.java
@@ -9,6 +9,7 @@ import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
 import org.teamsai.saibackend.domain.payment.type.ReviewStatus;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -22,4 +23,5 @@ public class PaymentObligationDTO {
     private PaymentStatus paymentStatus;
     private ReviewStatus reviewStatus;
     private ObligationStatus obligationStatus;
+    private LocalDateTime overdueSince;
 }

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -2,7 +2,6 @@ package org.teamsai.saibackend.domain.payment.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.cglib.core.Local;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
 import org.teamsai.saibackend.domain.payment.type.PaymentStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -2,6 +2,7 @@ package org.teamsai.saibackend.domain.payment.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.cglib.core.Local;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
 import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
@@ -28,5 +29,10 @@ public interface PaymentObligationMapper {
 
     int insert(PaymentObligationDTO paymentObligation);
 
+    List<PaymentObligationDTO> findUnpaidByParticipantIds(@Param("participantIds") List<Long> participantIds);
+
+    int updateOverdueSince(@Param("paymentObligationId") Long paymentObligationId, @Param("overdueSince")LocalDateTime overdueSince);
+
+    int clearOverdueSince(@Param("paymentObligationId") Long paymentObligationId);
 }
 

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -30,8 +30,6 @@ public interface PaymentObligationMapper {
 
     List<PaymentObligationDTO> findUnpaidByParticipantIds(@Param("participantIds") List<Long> participantIds);
 
-    int updateOverdueSince(@Param("paymentObligationId") Long paymentObligationId, @Param("overdueSince")LocalDateTime overdueSince);
-
     int updateOverdueSinceBulk(@Param("paymentObligationIds") List<Long> paymentObligationIds,
                                @Param("overdueSince") LocalDateTime overdueSince);
 

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -32,6 +32,9 @@ public interface PaymentObligationMapper {
 
     int updateOverdueSince(@Param("paymentObligationId") Long paymentObligationId, @Param("overdueSince")LocalDateTime overdueSince);
 
+    int updateOverdueSinceBulk(@Param("paymentObligationIds") List<Long> paymentObligationIds,
+                               @Param("overdueSince") LocalDateTime overdueSince);
+
     int clearOverdueSince(@Param("paymentObligationId") Long paymentObligationId);
 }
 

--- a/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
@@ -80,6 +80,10 @@ public class SettlementPaymentService {
         if (updatedCount != 1) {
             throw PaymentErrorCode.PAYMENT_STATUS_UPDATE_FAILED.toException();
         }
+
+        if (newPaymentStatus == PaymentStatus.PAID) {
+            paymentObligationMapper.clearOverdueSince(paymentObligationId);
+        }
     }
 
     public Long createObligation(Long participantId, BigDecimal expectedAmount){

--- a/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/service/SettlementPaymentService.java
@@ -1,6 +1,7 @@
 package org.teamsai.saibackend.domain.payment.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
@@ -10,6 +11,7 @@ import org.teamsai.saibackend.domain.payment.type.*;
 
 import java.math.BigDecimal;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SettlementPaymentService {
@@ -82,7 +84,10 @@ public class SettlementPaymentService {
         }
 
         if (newPaymentStatus == PaymentStatus.PAID) {
-            paymentObligationMapper.clearOverdueSince(paymentObligationId);
+            int clearedCount = paymentObligationMapper.clearOverdueSince(paymentObligationId);
+            if (clearedCount == 0) {
+                log.debug("연체 해제 스킵 (원래 연체 상태가 아니었음) paymentObligationId={}", paymentObligationId);
+            }
         }
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -33,6 +33,8 @@ public interface SettlementMapper {
             @Param("settlementId") Long settlementId,
             @Param("userId") Long userId
     );
+    
+    int countInProgressSettlements();
 
-    List<SettlementDTO> findInProgressSettlements();
+    List<SettlementDTO> findInProgressSettlements(@Param("offset") int offset, @Param("limit") int limit);
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementMapper.java
@@ -34,4 +34,5 @@ public interface SettlementMapper {
             @Param("userId") Long userId
     );
 
+    List<SettlementDTO> findInProgressSettlements();
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/SettlementParticipantMapper.java
@@ -2,7 +2,10 @@ package org.teamsai.saibackend.domain.settlement.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+
+import java.util.List;
 
 @Mapper
 public interface  SettlementParticipantMapper {
@@ -12,4 +15,5 @@ public interface  SettlementParticipantMapper {
             @Param("settlementId") Long settlementId,
             @Param("userId") Long userId
     );
+    List<SettlementParticipantDTO> findBySettlementId(@Param("settlementId") Long settlementId);
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
@@ -1,6 +1,5 @@
 package org.teamsai.saibackend.domain.settlement.service;
 
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Component;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
@@ -17,7 +16,7 @@ public class OverdueCriteria {
         return referenceDate != null && referenceDate.isBefore(baseDate);
     }
 
-    private LocalDate resolveReferenceDate(SettlementDTO settlement){
+    public LocalDate resolveReferenceDate(SettlementDTO settlement){
         return switch (settlement.getSettlementType()){
             case SHARED -> settlement.getDueDate();
             case RECURRING -> settlement.getCycleDate();

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
@@ -8,16 +8,15 @@ import java.time.LocalDate;
 
 @Component
 public class OverdueCriteria {
-    public boolean isOverdue(SettlementDTO settlement, LocalDate baseDate) {
+    public boolean isOverdue(SettlementDTO settlement, LocalDate baseDate, LocalDate referenceDate) {
         if (settlement.getSettlementStatus() != SettlementStatus.IN_PROGRESS) {
             return false;
         }
-        LocalDate referenceDate = resolveReferenceDate(settlement);
         return referenceDate != null && referenceDate.isBefore(baseDate);
     }
 
-    public LocalDate resolveReferenceDate(SettlementDTO settlement){
-        return switch (settlement.getSettlementType()){
+    public LocalDate resolveReferenceDate(SettlementDTO settlement) {
+        return switch (settlement.getSettlementType()) {
             case SHARED -> settlement.getDueDate();
             case RECURRING -> settlement.getCycleDate();
         };

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
@@ -3,12 +3,16 @@ package org.teamsai.saibackend.domain.settlement.service;
 import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Component;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
 
 import java.time.LocalDate;
 
 @Component
 public class OverdueCriteria {
-    public boolean isOverdue(SettlementDTO settlement, LocalDate baseDate){
+    public boolean isOverdue(SettlementDTO settlement, LocalDate baseDate) {
+        if (settlement.getSettlementStatus() != SettlementStatus.IN_PROGRESS) {
+            return false;
+        }
         LocalDate referenceDate = resolveReferenceDate(settlement);
         return referenceDate != null && referenceDate.isBefore(baseDate);
     }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueCriteria.java
@@ -1,0 +1,22 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import org.springframework.cglib.core.Local;
+import org.springframework.stereotype.Component;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+
+import java.time.LocalDate;
+
+@Component
+public class OverdueCriteria {
+    public boolean isOverdue(SettlementDTO settlement, LocalDate baseDate){
+        LocalDate referenceDate = resolveReferenceDate(settlement);
+        return referenceDate != null && referenceDate.isBefore(baseDate);
+    }
+
+    private LocalDate resolveReferenceDate(SettlementDTO settlement){
+        return switch (settlement.getSettlementType()){
+            case SHARED -> settlement.getDueDate();
+            case RECURRING -> settlement.getCycleDate();
+        };
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
@@ -1,0 +1,59 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OverdueSettlementService {
+    private final OverdueCriteria overdueCriteria;
+    private final SettlementMapper settlementMapper;
+    private final SettlementParticipantMapper participantMapper;
+    private final PaymentObligationMapper paymentObligationMapper;
+
+    @Transactional
+    public void updateOverdueStatus(LocalDate baseDate){
+        List<SettlementDTO> inProgressSettlements = settlementMapper.findInProgressSettlements();
+
+        for(SettlementDTO settlement : inProgressSettlements){
+            if(!overdueCriteria.isOverdue(settlement,baseDate)){
+                continue;
+            }
+            markOverdueForSettlement(settlement,baseDate);
+        }
+    }
+
+    private void markOverdueForSettlement(SettlementDTO settlement, LocalDate baseDate){
+        List<Long> activeParticipantIds = participantMapper.findBySettlementId(settlement.getSettlementId())
+                .stream()
+                .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
+                .map(SettlementParticipantDTO::getParticipantId)
+                .toList();
+
+        if(activeParticipantIds.isEmpty()){
+            return;
+        }
+
+        List<PaymentObligationDTO> unpaidObligations = paymentObligationMapper.findUnpaidByParticipantIds(activeParticipantIds);
+
+        LocalDateTime overdueSince = baseDate.atStartOfDay();
+
+        for(PaymentObligationDTO obligation : unpaidObligations){
+            paymentObligationMapper.updateOverdueSince(obligation.getPaymentObligationId(), overdueSince);
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
@@ -1,6 +1,7 @@
 package org.teamsai.saibackend.domain.settlement.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
@@ -8,6 +9,7 @@ import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OverdueSettlementService {
@@ -28,8 +30,14 @@ public class OverdueSettlementService {
             }
 
             for (SettlementDTO settlement : page) {
-                if (overdueCriteria.isOverdue(settlement, baseDate)) {
+                if (!overdueCriteria.isOverdue(settlement, baseDate)) {
+                    continue;
+                }
+                try {
                     overdueSettlementUpdater.updateOverdueForSettlement(settlement, baseDate);
+                } catch (Exception e) {
+                    log.error("연체 상태 갱신 실패, 다음 배치에서 재시도 예정 settlementId={}",
+                            settlement.getSettlementId(), e);
                 }
             }
 

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
@@ -21,7 +21,11 @@ public class OverdueSettlementService {
     private final OverdueSettlementUpdater overdueSettlementUpdater;
 
     public void updateOverdueStatus(LocalDate baseDate) {
+        int totalCount = settlementMapper.countInProgressSettlements();
+        log.info("연체 상태 갱신 배치 시작, 대상 정산 총 {}건, baseDate={}", totalCount, baseDate);
+
         int offset = 0;
+        int processedCount = 0;
 
         while (true) {
             List<SettlementDTO> page = settlementMapper.findInProgressSettlements(offset, PAGE_SIZE);
@@ -41,10 +45,13 @@ public class OverdueSettlementService {
                 }
             }
 
+            processedCount += page.size();
             if (page.size() < PAGE_SIZE) {
                 break;
             }
             offset += PAGE_SIZE;
         }
+
+        log.info("연체 상태 갱신 배치 종료, 처리 대상 조회 완료 {}건 (총 {}건 중)", processedCount, totalCount);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
@@ -1,59 +1,42 @@
 package org.teamsai.saibackend.domain.settlement.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
-import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
-import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
-import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
-import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OverdueSettlementService {
+
+    private static final int PAGE_SIZE = 200;
+
     private final OverdueCriteria overdueCriteria;
     private final SettlementMapper settlementMapper;
-    private final SettlementParticipantMapper participantMapper;
-    private final PaymentObligationMapper paymentObligationMapper;
+    private final OverdueSettlementUpdater overdueSettlementUpdater;
 
-    @Transactional
-    public void updateOverdueStatus(LocalDate baseDate){
-        List<SettlementDTO> inProgressSettlements = settlementMapper.findInProgressSettlements();
+    public void updateOverdueStatus(LocalDate baseDate) {
+        int offset = 0;
 
-        for(SettlementDTO settlement : inProgressSettlements){
-            if(!overdueCriteria.isOverdue(settlement,baseDate)){
-                continue;
+        while (true) {
+            List<SettlementDTO> page = settlementMapper.findInProgressSettlements(offset, PAGE_SIZE);
+            if (page.isEmpty()) {
+                break;
             }
-            markOverdueForSettlement(settlement,baseDate);
-        }
-    }
 
-    private void markOverdueForSettlement(SettlementDTO settlement, LocalDate baseDate){
-        List<Long> activeParticipantIds = participantMapper.findBySettlementId(settlement.getSettlementId())
-                .stream()
-                .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
-                .map(SettlementParticipantDTO::getParticipantId)
-                .toList();
+            for (SettlementDTO settlement : page) {
+                if (overdueCriteria.isOverdue(settlement, baseDate)) {
+                    overdueSettlementUpdater.updateOverdueForSettlement(settlement, baseDate);
+                }
+            }
 
-        if(activeParticipantIds.isEmpty()){
-            return;
-        }
-
-        List<PaymentObligationDTO> unpaidObligations = paymentObligationMapper.findUnpaidByParticipantIds(activeParticipantIds);
-
-        LocalDateTime overdueSince = baseDate.atStartOfDay();
-
-        for(PaymentObligationDTO obligation : unpaidObligations){
-            paymentObligationMapper.updateOverdueSince(obligation.getPaymentObligationId(), overdueSince);
+            if (page.size() < PAGE_SIZE) {
+                break;
+            }
+            offset += PAGE_SIZE;
         }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementService.java
@@ -34,11 +34,12 @@ public class OverdueSettlementService {
             }
 
             for (SettlementDTO settlement : page) {
-                if (!overdueCriteria.isOverdue(settlement, baseDate)) {
+                LocalDate referenceDate = overdueCriteria.resolveReferenceDate(settlement);
+                if (!overdueCriteria.isOverdue(settlement, baseDate, referenceDate)) {
                     continue;
                 }
                 try {
-                    overdueSettlementUpdater.updateOverdueForSettlement(settlement, baseDate);
+                    overdueSettlementUpdater.updateOverdueForSettlement(settlement, referenceDate);
                 } catch (Exception e) {
                     log.error("연체 상태 갱신 실패, 다음 배치에서 재시도 예정 settlementId={}",
                             settlement.getSettlementId(), e);

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class OverdueSettlementUpdater {
-    
+
     private final SettlementParticipantMapper participantMapper;
     private final PaymentObligationMapper paymentObligationMapper;
 
@@ -44,14 +44,15 @@ public class OverdueSettlementUpdater {
         }
 
         LocalDateTime overdueSince = referenceDate.atStartOfDay();
+        List<Long> obligationIds = unpaidObligations.stream()
+                .map(PaymentObligationDTO::getPaymentObligationId)
+                .toList();
 
-        for (PaymentObligationDTO obligation : unpaidObligations) {
-            int updatedCount = paymentObligationMapper.updateOverdueSince(
-                    obligation.getPaymentObligationId(), overdueSince);
-            if (updatedCount == 0) {
-                log.info("연체 처리 스킵 (이미 완납 등으로 조건 불일치) paymentObligationId={}",
-                        obligation.getPaymentObligationId());
-            }
+        int updatedCount = paymentObligationMapper.updateOverdueSinceBulk(obligationIds, overdueSince);
+
+        if (updatedCount < obligationIds.size()) {
+            log.info("일부 연체 처리 스킵됨 (이미 완납 등으로 조건 불일치) settlementId={}, 대상={}건, 실제갱신={}건",
+                    settlement.getSettlementId(), obligationIds.size(), updatedCount);
         }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
@@ -1,6 +1,7 @@
 package org.teamsai.saibackend.domain.settlement.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +16,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OverdueSettlementUpdater {
 
+    private final OverdueCriteria overdueCriteria;
     private final SettlementParticipantMapper participantMapper;
     private final PaymentObligationMapper paymentObligationMapper;
 
@@ -37,10 +40,21 @@ public class OverdueSettlementUpdater {
         List<PaymentObligationDTO> unpaidObligations =
                 paymentObligationMapper.findUnpaidByParticipantIds(activeParticipantIds);
 
-        LocalDateTime overdueSince = baseDate.atStartOfDay();
+        if (unpaidObligations.isEmpty()) {
+            return;
+        }
+
+
+        LocalDate referenceDate = overdueCriteria.resolveReferenceDate(settlement);
+        LocalDateTime overdueSince = referenceDate.atStartOfDay();
 
         for (PaymentObligationDTO obligation : unpaidObligations) {
-            paymentObligationMapper.updateOverdueSince(obligation.getPaymentObligationId(), overdueSince);
+            int updatedCount = paymentObligationMapper.updateOverdueSince(
+                    obligation.getPaymentObligationId(), overdueSince);
+            if (updatedCount == 0) {
+                log.info("연체 처리 스킵 (이미 완납 등으로 조건 불일치) paymentObligationId={}",
+                        obligation.getPaymentObligationId());
+            }
         }
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
@@ -1,0 +1,46 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OverdueSettlementUpdater {
+
+    private final SettlementParticipantMapper participantMapper;
+    private final PaymentObligationMapper paymentObligationMapper;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateOverdueForSettlement(SettlementDTO settlement, LocalDate baseDate) {
+        List<Long> activeParticipantIds = participantMapper.findBySettlementId(settlement.getSettlementId())
+                .stream()
+                .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
+                .map(SettlementParticipantDTO::getParticipantId)
+                .toList();
+
+        if (activeParticipantIds.isEmpty()) {
+            return;
+        }
+
+        List<PaymentObligationDTO> unpaidObligations =
+                paymentObligationMapper.findUnpaidByParticipantIds(activeParticipantIds);
+
+        LocalDateTime overdueSince = baseDate.atStartOfDay();
+
+        for (PaymentObligationDTO obligation : unpaidObligations) {
+            paymentObligationMapper.updateOverdueSince(obligation.getPaymentObligationId(), overdueSince);
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
@@ -20,13 +20,12 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class OverdueSettlementUpdater {
-
-    private final OverdueCriteria overdueCriteria;
+    
     private final SettlementParticipantMapper participantMapper;
     private final PaymentObligationMapper paymentObligationMapper;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateOverdueForSettlement(SettlementDTO settlement, LocalDate baseDate) {
+    public void updateOverdueForSettlement(SettlementDTO settlement, LocalDate referenceDate) {
         List<Long> activeParticipantIds = participantMapper.findBySettlementId(settlement.getSettlementId())
                 .stream()
                 .filter(p -> p.getParticipantStatus() == SettlementParticipantStatus.ACTIVE)
@@ -44,8 +43,6 @@ public class OverdueSettlementUpdater {
             return;
         }
 
-
-        LocalDate referenceDate = overdueCriteria.resolveReferenceDate(settlement);
         LocalDateTime overdueSince = referenceDate.atStartOfDay();
 
         for (PaymentObligationDTO obligation : unpaidObligations) {

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/OverdueSettlementUpdater.java
@@ -43,7 +43,7 @@ public class OverdueSettlementUpdater {
             return;
         }
 
-        LocalDateTime overdueSince = referenceDate.atStartOfDay();
+        LocalDateTime overdueSince = referenceDate.plusDays(1).atStartOfDay();
         List<Long> obligationIds = unpaidObligations.stream()
                 .map(PaymentObligationDTO::getPaymentObligationId)
                 .toList();

--- a/src/main/resources/db/03_contractchange.sql
+++ b/src/main/resources/db/03_contractchange.sql
@@ -40,7 +40,7 @@ ALTER TABLE loan_contract_change_request
     MODIFY COLUMN new_repayment_type VARCHAR(30) NULL;
 
 ALTER TABLE loan_contract_change_request
-    ADD COLUMN requester_signature VARCHAR(255) NULL AFTER return_reason;
+    ADD COLUMN IF NOT EXISTS requester_signature VARCHAR(255) NULL AFTER return_reason;
 
 ALTER TABLE loan_contract_change_request
 DROP CONSTRAINT IF EXISTS status;

--- a/src/main/resources/db/payment.sql
+++ b/src/main/resources/db/payment.sql
@@ -17,6 +17,24 @@ CREATE TABLE IF NOT EXISTS payment_obligation (
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;
 
+SET @index_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'payment_obligation'
+      AND INDEX_NAME = 'idx_payment_obligation_participant_status'
+);
+
+SET @sql = IF(@index_exists = 0,
+              'CREATE INDEX idx_payment_obligation_participant_status
+                  ON payment_obligation (participant_id, obligation_status, payment_status)',
+              'SELECT ''idx_payment_obligation_participant_status already exists'' AS message'
+           );
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 ALTER TABLE payment_obligation ADD COLUMN IF NOT EXISTS overdue_since DATETIME NULL;
 
     CREATE TABLE IF NOT EXISTS payment_record (

--- a/src/main/resources/db/payment.sql
+++ b/src/main/resources/db/payment.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS payment_obligation (
 DEFAULT CHARSET=utf8mb4
 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS payment_record (
+ALTER TABLE payment_obligation ADD COLUMN IF NOT EXISTS overdue_since DATETIME NULL;
+
+    CREATE TABLE IF NOT EXISTS payment_record (
     payment_record_id BIGINT NOT NULL AUTO_INCREMENT,
     bank_transaction_id BIGINT NOT NULL,
 

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -179,6 +179,7 @@
         WHERE payment_obligation_id = #{paymentObligationId}
         AND payment_status != 'PAID'
         AND overdue_since IS NULL
+        AND obligation_status = 'ACTIVE'
     </update>
 
     <update id="clearOverdueSince">

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -187,4 +187,16 @@
         SET overdue_since = NULL
         WHERE payment_obligation_id = #{paymentObligationId}
     </update>
+
+    <update id="updateOverdueSinceBulk">
+        UPDATE payment_obligation
+        SET overdue_since = #{overdueSince}
+        WHERE payment_obligation_id IN
+        <foreach item="id" collection="paymentObligationIds" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        AND payment_status != 'PAID'
+        AND overdue_since IS NULL
+        AND obligation_status = 'ACTIVE'
+    </update>
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -39,7 +39,8 @@
         expected_amount,
         payment_status,
         review_status,
-        obligation_status
+        obligation_status,
+        overdue_since
         FROM payment_obligation
         WHERE payment_obligation_id = #{paymentObligationId}
         FOR UPDATE
@@ -176,6 +177,8 @@
         UPDATE payment_obligation
         SET overdue_since = #{overdueSince}
         WHERE payment_obligation_id = #{paymentObligationId}
+        AND payment_status != 'PAID'
+        AND overdue_since IS NULL
     </update>
 
     <update id="clearOverdueSince">

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -13,6 +13,7 @@
         <result property="paymentStatus" column="payment_status"/>
         <result property="reviewStatus" column="review_status"/>
         <result property="obligationStatus" column="obligation_status"/>
+        <result property="overdueSince" column="overdue_since"/>
     </resultMap>
     <resultMap id="MatchingCandidateResultMap"
                type="org.teamsai.saibackend.domain.matching.model.MatchingCandidate">
@@ -157,4 +158,29 @@
         #{obligationStatus}
         )
     </insert>
+
+    <select id="findUnpaidByParticipantIds" resultMap="PaymentObligationResultMap">
+        SELECT payment_obligation_id, participant_id, expected_amount,
+        payment_status, review_status, obligation_status, overdue_since
+        FROM payment_obligation
+        WHERE participant_id IN
+        <foreach item="id" collection="participantIds" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        AND payment_status != 'PAID'
+        AND obligation_status = 'ACTIVE'
+        AND overdue_since IS NULL
+    </select>
+
+    <update id="updateOverdueSince">
+        UPDATE payment_obligation
+        SET overdue_since = #{overdueSince}
+        WHERE payment_obligation_id = #{paymentObligationId}
+    </update>
+
+    <update id="clearOverdueSince">
+        UPDATE payment_obligation
+        SET overdue_since = NULL
+        WHERE payment_obligation_id = #{paymentObligationId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -173,15 +173,6 @@
         AND overdue_since IS NULL
     </select>
 
-    <update id="updateOverdueSince">
-        UPDATE payment_obligation
-        SET overdue_since = #{overdueSince}
-        WHERE payment_obligation_id = #{paymentObligationId}
-        AND payment_status != 'PAID'
-        AND overdue_since IS NULL
-        AND obligation_status = 'ACTIVE'
-    </update>
-
     <update id="clearOverdueSince">
         UPDATE payment_obligation
         SET overdue_since = NULL

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -176,11 +176,19 @@
 
     </select>
 
+    <select id="countInProgressSettlements" resultType="int">
+        SELECT COUNT(*)
+        FROM settlement
+        WHERE settlement_status = 'IN_PROGRESS'
+    </select>
+
     <select id="findInProgressSettlements" resultMap="settlementResultMap">
         SELECT settlement_id, recurring_settlement_id, owner_id, settlement_type, settlement_status,
         settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at
         FROM settlement
         WHERE settlement_status = 'IN_PROGRESS'
+        ORDER BY settlement_id
+        LIMIT #{limit} OFFSET #{offset}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -176,4 +176,11 @@
 
     </select>
 
+    <select id="findInProgressSettlements" resultMap="settlementResultMap">
+        SELECT settlement_id, recurring_settlement_id, owner_id, settlement_type, settlement_status,
+        settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at, closed_at
+        FROM settlement
+        WHERE settlement_status = 'IN_PROGRESS'
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementParticipantMapper.xml
@@ -5,6 +5,15 @@
 
 <mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper">
 
+    <resultMap id="SettlementParticipantResultMap" type="org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO">
+        <id property="participantId" column="participant_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="settlementId" column="settlement_id"/>
+        <result property="participantRole" column="participant_role"/>
+        <result property="participantStatus" column="participant_status"/>
+        <result property="joinedAt" column="joined_at"/>
+    </resultMap>
+
     <insert id="insert"
             parameterType="org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO"
             useGeneratedKeys="true"
@@ -40,5 +49,10 @@
 
     </select>
 
+    <select id="findBySettlementId" resultMap="SettlementParticipantResultMap">
+        SELECT participant_id, user_id, settlement_id, participant_role, participant_status, joined_at
+        FROM settlement_participant
+        WHERE settlement_id = #{settlementId}
+    </select>
 
 </mapper>

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
@@ -1,0 +1,117 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OverdueCriteriaTest {
+
+    private final OverdueCriteria sut = new OverdueCriteria();
+
+    @Nested
+    @DisplayName("SHARED 타입 - dueDate 기준")
+    class SharedType {
+
+        @Test
+        @DisplayName("dueDate가 baseDate보다 이전이면 연체다")
+        void overdueWhenDueDateBeforeBaseDate() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.SHARED)
+                    .settlementStatus(SettlementStatus.IN_PROGRESS)
+                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 11));
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("dueDate와 baseDate가 같으면 아직 연체가 아니다")
+        void notOverdueWhenDueDateEqualsBaseDate() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.SHARED)
+                    .settlementStatus(SettlementStatus.IN_PROGRESS)
+                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 10));
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("dueDate가 baseDate보다 이후면 연체가 아니다")
+        void notOverdueWhenDueDateAfterBaseDate() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.SHARED)
+                    .settlementStatus(SettlementStatus.IN_PROGRESS)
+                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 9));
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("RECURRING 타입 - cycleDate 기준")
+    class RecurringType {
+
+        @Test
+        @DisplayName("cycleDate가 baseDate보다 이전이면 연체다")
+        void overdueWhenCycleDateBeforeBaseDate() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.RECURRING)
+                    .settlementStatus(SettlementStatus.IN_PROGRESS)
+                    .cycleDate(LocalDate.of(2026, 1, 31))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1));
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("SHARED와 달리 dueDate가 null이어도 cycleDate로 정상 판정한다")
+        void ignoresNullDueDateForRecurringType() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.RECURRING)
+                    .settlementStatus(SettlementStatus.IN_PROGRESS)
+                    .dueDate(null)
+                    .cycleDate(LocalDate.of(2026, 1, 31))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1));
+
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("settlementStatus 필터링")
+    class SettlementStatusFiltering {
+
+        @Test
+        @DisplayName("CLOSED 상태면 기한이 지났어도 연체가 아니다")
+        void notOverdueWhenClosed() {
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.SHARED)
+                    .settlementStatus(SettlementStatus.CLOSED)
+                    .dueDate(LocalDate.of(2020, 1, 1))
+                    .build();
+
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 1));
+
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
@@ -23,13 +23,14 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("dueDate가 baseDate보다 이전이면 연체다")
         void overdueWhenDueDateBeforeBaseDate() {
+            LocalDate dueDate = LocalDate.of(2026, 1, 10);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.SHARED)
                     .settlementStatus(SettlementStatus.IN_PROGRESS)
-                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .dueDate(dueDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 11));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 11), dueDate);
 
             assertThat(result).isTrue();
         }
@@ -37,13 +38,14 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("dueDate와 baseDate가 같으면 아직 연체가 아니다")
         void notOverdueWhenDueDateEqualsBaseDate() {
+            LocalDate dueDate = LocalDate.of(2026, 1, 10);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.SHARED)
                     .settlementStatus(SettlementStatus.IN_PROGRESS)
-                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .dueDate(dueDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 10));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 10), dueDate);
 
             assertThat(result).isFalse();
         }
@@ -51,13 +53,14 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("dueDate가 baseDate보다 이후면 연체가 아니다")
         void notOverdueWhenDueDateAfterBaseDate() {
+            LocalDate dueDate = LocalDate.of(2026, 1, 10);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.SHARED)
                     .settlementStatus(SettlementStatus.IN_PROGRESS)
-                    .dueDate(LocalDate.of(2026, 1, 10))
+                    .dueDate(dueDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 9));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 9), dueDate);
 
             assertThat(result).isFalse();
         }
@@ -70,13 +73,14 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("cycleDate가 baseDate보다 이전이면 연체다")
         void overdueWhenCycleDateBeforeBaseDate() {
+            LocalDate cycleDate = LocalDate.of(2026, 1, 31);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.RECURRING)
                     .settlementStatus(SettlementStatus.IN_PROGRESS)
-                    .cycleDate(LocalDate.of(2026, 1, 31))
+                    .cycleDate(cycleDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1), cycleDate);
 
             assertThat(result).isTrue();
         }
@@ -84,14 +88,15 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("SHARED와 달리 dueDate가 null이어도 cycleDate로 정상 판정한다")
         void ignoresNullDueDateForRecurringType() {
+            LocalDate cycleDate = LocalDate.of(2026, 1, 31);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.RECURRING)
                     .settlementStatus(SettlementStatus.IN_PROGRESS)
                     .dueDate(null)
-                    .cycleDate(LocalDate.of(2026, 1, 31))
+                    .cycleDate(cycleDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 2, 1), cycleDate);
 
             assertThat(result).isTrue();
         }
@@ -104,15 +109,49 @@ class OverdueCriteriaTest {
         @Test
         @DisplayName("CLOSED 상태면 기한이 지났어도 연체가 아니다")
         void notOverdueWhenClosed() {
+            LocalDate dueDate = LocalDate.of(2020, 1, 1);
             SettlementDTO settlement = SettlementDTO.builder()
                     .settlementType(SettlementType.SHARED)
                     .settlementStatus(SettlementStatus.CLOSED)
-                    .dueDate(LocalDate.of(2020, 1, 1))
+                    .dueDate(dueDate)
                     .build();
 
-            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 1));
+            boolean result = sut.isOverdue(settlement, LocalDate.of(2026, 1, 1), dueDate);
 
             assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveReferenceDate")
+    class ResolveReferenceDate {
+
+        @Test
+        @DisplayName("SHARED 타입이면 dueDate를 반환한다")
+        void returnsDueDateForShared() {
+            LocalDate dueDate = LocalDate.of(2026, 1, 10);
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.SHARED)
+                    .dueDate(dueDate)
+                    .build();
+
+            LocalDate result = sut.resolveReferenceDate(settlement);
+
+            assertThat(result).isEqualTo(dueDate);
+        }
+
+        @Test
+        @DisplayName("RECURRING 타입이면 cycleDate를 반환한다")
+        void returnsCycleDateForRecurring() {
+            LocalDate cycleDate = LocalDate.of(2026, 1, 31);
+            SettlementDTO settlement = SettlementDTO.builder()
+                    .settlementType(SettlementType.RECURRING)
+                    .cycleDate(cycleDate)
+                    .build();
+
+            LocalDate result = sut.resolveReferenceDate(settlement);
+
+            assertThat(result).isEqualTo(cycleDate);
         }
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueCriteriaTest.java
@@ -1,9 +1,10 @@
-package org.teamsai.saibackend.domain.settlement.service;
+package org.teamsai.saibackend.domain.settlement;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.service.OverdueCriteria;
 import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
 import org.teamsai.saibackend.domain.settlement.type.SettlementType;
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -1,0 +1,269 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.teamsai.saibackend.domain.payment.service.SettlementPaymentService;
+import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("dev")
+@Sql(scripts = {
+        "/db/user.sql",
+        "/db/settlement.sql",
+        "/db/settlement_participant.sql",
+        "/db/payment.sql"
+})
+@DisplayName("OverdueSettlementService 엔드투엔드 통합 테스트")
+class OverdueSettlementServiceIntegrationTest {
+
+    @Autowired
+    private OverdueSettlementService overdueSettlementService;
+
+    @Autowired
+    private SettlementPaymentService settlementPaymentService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM payment_record WHERE payment_record_id >= 90000");
+        jdbcTemplate.update("DELETE FROM bank_transaction WHERE bank_transaction_id >= 90000");
+        jdbcTemplate.update("DELETE FROM linked_bank_account WHERE linked_account_id >= 90000");
+        jdbcTemplate.update("DELETE FROM payment_obligation WHERE payment_obligation_id >= 90000");
+        jdbcTemplate.update("DELETE FROM settlement_participant WHERE participant_id >= 90000");
+        jdbcTemplate.update("DELETE FROM settlement WHERE settlement_id >= 90000");
+        jdbcTemplate.update("DELETE FROM users WHERE user_id >= 90000");
+    }
+
+    @Nested
+    @DisplayName("SHARED 정산 연체 판정")
+    class SharedSettlementOverdue {
+
+        @Test
+        @DisplayName("dueDate가 지난 IN_PROGRESS 정산의 미납 obligation에 overdueSince가 채워진다")
+        void marksOverdueWhenDueDatePassed() {
+            insertUser(91001L, "채권자");
+            insertUser(91002L, "채무자");
+            insertSharedSettlement(91101L, 91001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(91201L, 91101L, 91002L, "ACTIVE");
+            insertObligation(91301L, 91201L, "UNPAID");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+
+            LocalDateTime overdueSince = fetchOverdueSince(91301L);
+            assertThat(overdueSince).isEqualTo(LocalDate.of(2026, 1, 11).atStartOfDay());
+        }
+
+        @Test
+        @DisplayName("dueDate가 아직 안 지났으면 overdueSince가 채워지지 않는다")
+        void doesNotMarkWhenNotYetDue() {
+            insertUser(91001L, "채권자");
+            insertUser(91002L, "채무자");
+            insertSharedSettlement(91101L, 91001L, LocalDate.of(2026, 2, 28));
+            insertParticipant(91201L, 91101L, 91002L, "ACTIVE");
+            insertObligation(91301L, 91201L, "UNPAID");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+
+            assertThat(fetchOverdueSince(91301L)).isNull();
+        }
+
+        @Test
+        @DisplayName("이미 overdueSince가 채워진 obligation은 재실행해도 시점이 갱신되지 않는다 (멱등성)")
+        void doesNotOverwriteExistingOverdueSince() {
+            insertUser(91001L, "채권자");
+            insertUser(91002L, "채무자");
+            insertSharedSettlement(91101L, 91001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(91201L, 91101L, 91002L, "ACTIVE");
+            insertObligation(91301L, 91201L, "UNPAID");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+            LocalDateTime firstOverdueSince = fetchOverdueSince(91301L);
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15)); // 며칠 뒤 재실행
+            LocalDateTime secondOverdueSince = fetchOverdueSince(91301L);
+
+            assertThat(secondOverdueSince).isEqualTo(firstOverdueSince); // 최초 연체일 그대로 유지
+        }
+    }
+
+    @Nested
+    @DisplayName("RECURRING 정산 연체 판정")
+    class RecurringSettlementOverdue {
+
+        @Test
+        @DisplayName("cycleDate가 지난 RECURRING 정산도 연체로 판정된다 (dueDate는 null)")
+        void marksOverdueForRecurringUsingCycleDate() {
+            insertUser(92001L, "관리자");
+            insertUser(92002L, "참여자");
+            insertRecurringSettlement(92101L, 92001L, LocalDate.of(2026, 1, 31));
+            insertParticipant(92201L, 92101L, 92002L, "ACTIVE");
+            insertObligation(92301L, 92201L, "UNPAID");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 2, 1));
+
+            assertThat(fetchOverdueSince(92301L)).isEqualTo(LocalDate.of(2026, 2, 1).atStartOfDay());
+        }
+    }
+
+    @Nested
+    @DisplayName("완납 시 연체 해제")
+    class ClearOverdueOnFullPayment {
+
+        @Test
+        @DisplayName("연체 상태에서 완납하면 overdueSince가 해제된다")
+        void clearsOverdueSinceWhenFullyPaid() {
+            insertUser(93001L, "채권자");
+            insertUser(93002L, "채무자");
+            insertLinkedAccount(93401L, 93001L);
+            insertSharedSettlement(93101L, 93001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(93201L, 93101L, 93002L, "ACTIVE");
+            insertObligation(93301L, 93201L, "UNPAID", "150000.00");
+            insertBankTransaction(93501L, 93401L, "150000.00");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+            assertThat(fetchOverdueSince(93301L)).isNotNull();
+
+            settlementPaymentService.applyAutoMatchedPayment(93301L, 93501L, new BigDecimal("150000.00"));
+
+            assertThat(fetchOverdueSince(93301L)).isNull();
+        }
+
+        @Test
+        @DisplayName("부분납이면 overdueSince가 해제되지 않는다")
+        void doesNotClearOverdueSinceOnPartialPayment() {
+            insertUser(94001L, "채권자");
+            insertUser(94002L, "채무자");
+            insertLinkedAccount(94401L, 94001L);
+            insertSharedSettlement(94101L, 94001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(94201L, 94101L, 94002L, "ACTIVE");
+            insertObligation(94301L, 94201L, "UNPAID", "150000.00");
+            insertBankTransaction(94501L, 94401L, "50000.00");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+            assertThat(fetchOverdueSince(94301L)).isNotNull();
+
+            settlementPaymentService.applyAutoMatchedPayment(94301L, 94501L, new BigDecimal("50000.00"));
+
+            assertThat(fetchOverdueSince(94301L)).isNotNull();
+        }
+    }
+
+    private LocalDateTime fetchOverdueSince(Long paymentObligationId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT overdue_since FROM payment_obligation WHERE payment_obligation_id = ?",
+                LocalDateTime.class,
+                paymentObligationId
+        );
+    }
+
+    private void insertUser(Long userId, String name) {
+        String unique = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                """
+                INSERT INTO users (user_id, user_token, email, password, name, birth_date)
+                VALUES (?, ?, ?, ?, ?, '2000-01-01')
+                """,
+                userId, unique, unique + "@example.com", "password", name
+        );
+    }
+
+    private void insertSharedSettlement(Long settlementId, Long ownerId, LocalDate dueDate) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id, owner_id, settlement_type, settlement_status,
+                    settlement_category, title, split_type, total_amount, due_date, created_at
+                )
+                VALUES (?, ?, 'SHARED', 'IN_PROGRESS', '식비', '테스트 정산', 'EQUAL', 150000, ?, NOW())
+                """,
+                settlementId, ownerId, dueDate
+        );
+    }
+
+    private void insertRecurringSettlement(Long settlementId, Long ownerId, LocalDate cycleDate) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement (
+                    settlement_id, owner_id, settlement_type, settlement_status,
+                    settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at
+                )
+                VALUES (?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '테스트 정기정산', 'EQUAL', 150000, NULL, ?, NOW())
+                """,
+                settlementId, ownerId, cycleDate
+        );
+    }
+
+    private void insertParticipant(Long participantId, Long settlementId, Long userId, String status) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO settlement_participant (
+                    participant_id, settlement_id, user_id, participant_role, participant_status, joined_at
+                )
+                VALUES (?, ?, ?, 'MEMBER', ?, NOW())
+                """,
+                participantId, settlementId, userId, status
+        );
+    }
+
+    private void insertObligation(Long obligationId, Long participantId, String paymentStatus) {
+        insertObligation(obligationId, participantId, paymentStatus, "150000.00");
+    }
+
+    private void insertObligation(Long obligationId, Long participantId, String paymentStatus, String expectedAmount) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO payment_obligation (
+                    payment_obligation_id, participant_id, expected_amount,
+                    payment_status, review_status, obligation_status
+                )
+                VALUES (?, ?, ?, ?, 'NORMAL', 'ACTIVE')
+                """,
+                obligationId, participantId, new BigDecimal(expectedAmount), paymentStatus
+        );
+    }
+
+    private void insertLinkedAccount(Long linkedAccountId, Long userId) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO linked_bank_account (
+                    linked_account_id, user_id, bank_code, account_number,
+                    account_holder_name, connection_status, account_id
+                )
+                VALUES (?, ?, '001', ?, 'Owner', 'AVAILABLE', ?)
+                """,
+                linkedAccountId, userId, "account-" + linkedAccountId, linkedAccountId
+        );
+    }
+
+    private void insertBankTransaction(Long bankTransactionId, Long linkedAccountId, String amount) {
+        String externalTransactionId = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                """
+                INSERT INTO bank_transaction (
+                    bank_transaction_id, linked_account_id, external_transaction_id,
+                    amount, transaction_type, processing_status, transaction_at, synced_at
+                )
+                VALUES (?, ?, ?, ?, 'DEPOSIT', 'PENDING', NOW(), NOW())
+                """,
+                bankTransactionId, linkedAccountId, externalTransactionId, new BigDecimal(amount)
+        );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -49,6 +49,7 @@ class OverdueSettlementServiceIntegrationTest {
         jdbcTemplate.update("DELETE FROM payment_obligation WHERE payment_obligation_id >= 90000");
         jdbcTemplate.update("DELETE FROM settlement_participant WHERE participant_id >= 90000");
         jdbcTemplate.update("DELETE FROM settlement WHERE settlement_id >= 90000");
+        jdbcTemplate.update("DELETE FROM recurring_settlement WHERE recurring_settlement_id >= 90000"); // 추가
         jdbcTemplate.update("DELETE FROM users WHERE user_id >= 90000");
     }
 
@@ -68,7 +69,7 @@ class OverdueSettlementServiceIntegrationTest {
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
 
             LocalDateTime overdueSince = fetchOverdueSince(91301L);
-            assertThat(overdueSince).isEqualTo(LocalDate.of(2026, 1, 10).atStartOfDay()); // baseDate(1/11)가 아니라 dueDate(1/10)
+            assertThat(overdueSince).isEqualTo(LocalDate.of(2026, 1, 11).atStartOfDay());
         }
 
         @Test
@@ -108,13 +109,13 @@ class OverdueSettlementServiceIntegrationTest {
         void recordsActualDueDateNotBatchExecutionDate() {
             insertUser(99001L, "채권자");
             insertUser(99002L, "채무자");
-            insertSharedSettlement(99101L, 99001L, LocalDate.of(2026, 1, 10)); // 실제 만기일
+            insertSharedSettlement(99101L, 99001L, LocalDate.of(2026, 1, 10));
             insertParticipant(99201L, 99101L, 99002L, "ACTIVE");
             insertObligation(99301L, 99201L, "UNPAID");
 
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15));
 
-            assertThat(fetchOverdueSince(99301L)).isEqualTo(LocalDate.of(2026, 1, 10).atStartOfDay()); // baseDate(1/15)가 아님
+            assertThat(fetchOverdueSince(99301L)).isEqualTo(LocalDate.of(2026, 1, 11).atStartOfDay());
         }
     }
 
@@ -133,7 +134,7 @@ class OverdueSettlementServiceIntegrationTest {
 
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 2, 1));
 
-            assertThat(fetchOverdueSince(92301L)).isEqualTo(LocalDate.of(2026, 1, 31).atStartOfDay()); // baseDate(2/1)가 아니라 cycleDate(1/31)
+            assertThat(fetchOverdueSince(92301L)).isEqualTo(LocalDate.of(2026, 2, 1).atStartOfDay()); // baseDate(2/1)가 아니라 cycleDate(1/31)
         }
     }
 
@@ -322,15 +323,29 @@ class OverdueSettlementServiceIntegrationTest {
     }
 
     private void insertRecurringSettlement(Long settlementId, Long ownerId, LocalDate cycleDate) {
+        Long recurringSettlementId = settlementId; // 편의상 동일 값 사용, 별도 시퀀스 관리 불필요
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO recurring_settlement (
+                    recurring_settlement_id, owner_id, settlement_category, title,
+                    split_type, total_amount, cycle_rule, start_date, end_date, created_at
+                )
+                VALUES (?, ?, '월세', '테스트 정기정산', 'EQUAL', 150000, 'MONTHLY', ?, NULL, NOW())
+                """,
+                recurringSettlementId, ownerId, cycleDate
+        );
+
         jdbcTemplate.update(
                 """
                 INSERT INTO settlement (
-                    settlement_id, owner_id, settlement_type, settlement_status,
-                    settlement_category, title, split_type, total_amount, due_date, cycle_date, created_at
+                    settlement_id, recurring_settlement_id, owner_id, settlement_type,
+                    settlement_status, settlement_category, title, split_type,
+                    total_amount, due_date, cycle_date, created_at
                 )
-                VALUES (?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '테스트 정기정산', 'EQUAL', 150000, NULL, ?, NOW())
+                VALUES (?, ?, ?, 'RECURRING', 'IN_PROGRESS', '월세', '테스트 정기정산', 'EQUAL', 150000, NULL, ?, NOW())
                 """,
-                settlementId, ownerId, cycleDate
+                settlementId, recurringSettlementId, ownerId, cycleDate
         );
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -43,7 +43,7 @@ class OverdueSettlementServiceIntegrationTest {
 
     @AfterEach
     void cleanUp() {
-        jdbcTemplate.update("DELETE FROM payment_record WHERE payment_record_id >= 90000");
+        jdbcTemplate.update("DELETE FROM payment_record WHERE bank_transaction_id >= 90000");
         jdbcTemplate.update("DELETE FROM bank_transaction WHERE bank_transaction_id >= 90000");
         jdbcTemplate.update("DELETE FROM linked_bank_account WHERE linked_account_id >= 90000");
         jdbcTemplate.update("DELETE FROM payment_obligation WHERE payment_obligation_id >= 90000");
@@ -163,6 +163,70 @@ class OverdueSettlementServiceIntegrationTest {
             settlementPaymentService.applyAutoMatchedPayment(94301L, 94501L, new BigDecimal("50000.00"));
 
             assertThat(fetchOverdueSince(94301L)).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("정산 단위 독립 처리 (부분 실패 격리)")
+    class PartialFailureIsolation {
+
+        @Test
+        @DisplayName("한 정산에 문제가 있어도, 다른 정산의 연체 갱신은 정상적으로 처리된다")
+        void continuesOtherSettlementsWhenOneFails() {
+            insertUser(95001L, "채권자");
+            insertUser(95002L, "채무자A");
+            insertUser(95003L, "채무자B");
+
+            // 정상 처리될 정산
+            insertSharedSettlement(95101L, 95001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(95201L, 95101L, 95002L, "ACTIVE");
+            insertObligation(95301L, 95201L, "UNPAID");
+
+            // 참여자가 아예 없어서 스킵되지만, 예외 없이 넘어가는지 확인용 정산
+            insertSharedSettlement(95102L, 95001L, LocalDate.of(2026, 1, 10));
+            // 의도적으로 참여자를 넣지 않음
+
+            // 정상 처리될 또 다른 정산
+            insertSharedSettlement(95103L, 95001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(95202L, 95103L, 95003L, "ACTIVE");
+            insertObligation(95302L, 95202L, "UNPAID");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+
+            assertThat(fetchOverdueSince(95301L)).isNotNull();
+            assertThat(fetchOverdueSince(95302L)).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("페이징 - 다수 정산 처리")
+    class PagingMultipleSettlements {
+
+        @Test
+        @DisplayName("PAGE_SIZE(200)를 넘는 정산이 있어도 모두 처리된다")
+        void processesAllSettlementsAcrossMultiplePages() {
+            insertUser(96001L, "채권자");
+
+            int settlementCount = 210; // PAGE_SIZE(200)를 넘기도록
+            for (int i = 0; i < settlementCount; i++) {
+                long userId = 96100L + i;
+                long settlementId = 96200L + i;
+                long participantId = 96500L + i;
+                long obligationId = 96800L + i;
+
+                insertUser(userId, "참여자" + i);
+                insertSharedSettlement(settlementId, 96001L, LocalDate.of(2026, 1, 10));
+                insertParticipant(participantId, settlementId, userId, "ACTIVE");
+                insertObligation(obligationId, participantId, "UNPAID");
+            }
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+
+            Integer overdueCount = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM payment_obligation WHERE payment_obligation_id BETWEEN 96800 AND 97009 AND overdue_since IS NOT NULL",
+                    Integer.class
+            );
+            assertThat(overdueCount).isEqualTo(settlementCount); // 210건 전부 처리됨
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -68,7 +68,7 @@ class OverdueSettlementServiceIntegrationTest {
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
 
             LocalDateTime overdueSince = fetchOverdueSince(91301L);
-            assertThat(overdueSince).isEqualTo(LocalDate.of(2026, 1, 11).atStartOfDay());
+            assertThat(overdueSince).isEqualTo(LocalDate.of(2026, 1, 10).atStartOfDay()); // baseDate(1/11)가 아니라 dueDate(1/10)
         }
 
         @Test
@@ -102,6 +102,21 @@ class OverdueSettlementServiceIntegrationTest {
 
             assertThat(secondOverdueSince).isEqualTo(firstOverdueSince); // 최초 연체일 그대로 유지
         }
+
+        @Test
+        @DisplayName("배치가 며칠 밀려 실행돼도 overdueSince는 baseDate가 아닌 실제 dueDate로 기록된다")
+        void recordsActualDueDateNotBatchExecutionDate() {
+            insertUser(99001L, "채권자");
+            insertUser(99002L, "채무자");
+            insertSharedSettlement(99101L, 99001L, LocalDate.of(2026, 1, 10)); // 실제 만기일
+            insertParticipant(99201L, 99101L, 99002L, "ACTIVE");
+            insertObligation(99301L, 99201L, "UNPAID");
+
+            // 배치가 5일 밀려서 1/15에 실행됨
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15));
+
+            assertThat(fetchOverdueSince(99301L)).isEqualTo(LocalDate.of(2026, 1, 10).atStartOfDay()); // baseDate(1/15)가 아님
+        }
     }
 
     @Nested
@@ -119,7 +134,7 @@ class OverdueSettlementServiceIntegrationTest {
 
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 2, 1));
 
-            assertThat(fetchOverdueSince(92301L)).isEqualTo(LocalDate.of(2026, 2, 1).atStartOfDay());
+            assertThat(fetchOverdueSince(92301L)).isEqualTo(LocalDate.of(2026, 1, 31).atStartOfDay()); // baseDate(2/1)가 아니라 cycleDate(1/31)
         }
     }
 
@@ -227,6 +242,51 @@ class OverdueSettlementServiceIntegrationTest {
                     Integer.class
             );
             assertThat(overdueCount).isEqualTo(settlementCount); // 210건 전부 처리됨
+        }
+    }
+
+    @Nested
+    @DisplayName("동시성 - 배치와 완납이 겹치는 경우")
+    class ConcurrentPaymentDuringOverdueUpdate {
+
+        @Test
+        @DisplayName("연체 대상 조회 이후 완납 처리된 obligation은 overdueSince로 갱신되지 않는다")
+        void doesNotMarkOverdueWhenAlreadyPaidBeforeUpdate() {
+            insertUser(97001L, "채권자");
+            insertUser(97002L, "채무자");
+            insertLinkedAccount(97401L, 97001L);
+            insertSharedSettlement(97101L, 97001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(97201L, 97101L, 97002L, "ACTIVE");
+            insertObligation(97301L, 97201L, "UNPAID", "150000.00");
+            insertBankTransaction(97501L, 97401L, "150000.00");
+
+            settlementPaymentService.applyAutoMatchedPayment(97301L, 97501L, new BigDecimal("150000.00"));
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+
+            assertThat(fetchOverdueSince(97301L)).isNull();
+        }
+
+        @Test
+        @DisplayName("조건부 UPDATE는 이미 overdueSince가 채워진 건을 다시 덮어쓰지 않는다 (재실행 시 완납된 건 보호)")
+        void conditionalUpdateProtectsAlreadyPaidObligation() {
+            insertUser(98001L, "채권자");
+            insertUser(98002L, "채무자");
+            insertLinkedAccount(98401L, 98001L);
+            insertSharedSettlement(98101L, 98001L, LocalDate.of(2026, 1, 10));
+            insertParticipant(98201L, 98101L, 98002L, "ACTIVE");
+            insertObligation(98301L, 98201L, "UNPAID", "150000.00");
+            insertBankTransaction(98501L, 98401L, "150000.00");
+
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 11));
+            assertThat(fetchOverdueSince(98301L)).isNotNull();
+
+            settlementPaymentService.applyAutoMatchedPayment(98301L, 98501L, new BigDecimal("150000.00"));
+            assertThat(fetchOverdueSince(98301L)).isNull(); // 완납으로 해제됨
+
+            // 배치가 다시 돌아도(예: 재시도), 이미 완납된 건이 연체로 잘못 마킹되면 안 됨
+            overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15));
+            assertThat(fetchOverdueSince(98301L)).isNull(); // 여전히 null 유지
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -112,7 +112,6 @@ class OverdueSettlementServiceIntegrationTest {
             insertParticipant(99201L, 99101L, 99002L, "ACTIVE");
             insertObligation(99301L, 99201L, "UNPAID");
 
-            // 배치가 5일 밀려서 1/15에 실행됨
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15));
 
             assertThat(fetchOverdueSince(99301L)).isEqualTo(LocalDate.of(2026, 1, 10).atStartOfDay()); // baseDate(1/15)가 아님
@@ -284,7 +283,7 @@ class OverdueSettlementServiceIntegrationTest {
             settlementPaymentService.applyAutoMatchedPayment(98301L, 98501L, new BigDecimal("150000.00"));
             assertThat(fetchOverdueSince(98301L)).isNull(); // 완납으로 해제됨
 
-            // 배치가 다시 돌아도(예: 재시도), 이미 완납된 건이 연체로 잘못 마킹되면 안 됨
+            // 배치가 다시 돌아도 이미 완납된 건이 연체로 잘못 마킹되면 안 됨
             overdueSettlementService.updateOverdueStatus(LocalDate.of(2026, 1, 15));
             assertThat(fetchOverdueSince(98301L)).isNull(); // 여전히 null 유지
         }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
@@ -1,0 +1,129 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.OverdueCriteria;
+import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementService;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OverdueSettlementServiceTest {
+
+    @Mock private OverdueCriteria overdueCriteria;
+    @Mock private SettlementMapper settlementMapper;
+    @Mock private SettlementParticipantMapper participantMapper;
+    @Mock private PaymentObligationMapper paymentObligationMapper;
+
+    @InjectMocks
+    private OverdueSettlementService sut;
+
+    private SettlementDTO settlement(Long id, SettlementType type) {
+        return SettlementDTO.builder()
+                .settlementId(id)
+                .settlementType(type)
+                .settlementStatus(SettlementStatus.IN_PROGRESS)
+                .build();
+    }
+
+    private SettlementParticipantDTO participant(Long participantId, SettlementParticipantStatus status) {
+        return SettlementParticipantDTO.builder()
+                .participantId(participantId)
+                .participantStatus(status)
+                .build();
+    }
+
+    @Test
+    @DisplayName("연체로 판정된 정산만 참여자를 조회하고, 판정 안 된 정산은 건드리지 않는다")
+    void onlyProcessesOverdueSettlements() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
+        SettlementDTO notOverdue = settlement(2L, SettlementType.SHARED);
+
+        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue, notOverdue));
+        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
+        when(overdueCriteria.isOverdue(notOverdue, baseDate)).thenReturn(false);
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.ACTIVE)
+        ));
+        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of());
+
+        sut.updateOverdueStatus(baseDate);
+
+        verify(participantMapper).findBySettlementId(1L);
+        verify(participantMapper, never()).findBySettlementId(2L);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 baseDate 자정으로 채운다")
+    void updatesOverdueSinceForUnpaidObligations() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
+
+        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue));
+        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.ACTIVE),
+                participant(102L, SettlementParticipantStatus.LEFT) // 제외되어야 함
+        ));
+        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
+                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
+                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
+        ));
+
+        sut.updateOverdueStatus(baseDate);
+
+        LocalDateTime expectedOverdueSince = baseDate.atStartOfDay();
+        verify(paymentObligationMapper).updateOverdueSince(9001L, expectedOverdueSince);
+        verify(paymentObligationMapper).updateOverdueSince(9002L, expectedOverdueSince);
+        // LEFT 참여자는 findUnpaidByParticipantIds 호출 시 애초에 포함 안 됨
+        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
+    }
+
+    @Test
+    @DisplayName("ACTIVE 참여자가 없으면 obligation 조회 자체를 하지 않는다")
+    void skipsWhenNoActiveParticipants() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
+
+        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue));
+        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.LEFT)
+        ));
+
+        sut.updateOverdueStatus(baseDate);
+
+        verify(paymentObligationMapper, never()).findUnpaidByParticipantIds(any());
+    }
+
+    @Test
+    @DisplayName("연체 대상 정산이 없으면 아무것도 조회하지 않는다")
+    void doesNothingWhenNoSettlements() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of());
+
+        sut.updateOverdueStatus(baseDate);
+
+        verify(participantMapper, never()).findBySettlementId(any());
+        verify(paymentObligationMapper, never()).updateOverdueSince(any(), any());
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,44 +39,30 @@ class OverdueSettlementServiceTest {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
         SettlementDTO overdue = settlement(1L);
         SettlementDTO notOverdue = settlement(2L);
+        LocalDate overdueRefDate = LocalDate.of(2026, 1, 15);
+        LocalDate notOverdueRefDate = LocalDate.of(2026, 2, 15);
 
         when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of(overdue, notOverdue));
-        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
-        when(overdueCriteria.isOverdue(notOverdue, baseDate)).thenReturn(false);
+        when(overdueCriteria.resolveReferenceDate(overdue)).thenReturn(overdueRefDate);
+        when(overdueCriteria.resolveReferenceDate(notOverdue)).thenReturn(notOverdueRefDate);
+        when(overdueCriteria.isOverdue(overdue, baseDate, overdueRefDate)).thenReturn(true);
+        when(overdueCriteria.isOverdue(notOverdue, baseDate, notOverdueRefDate)).thenReturn(false);
 
         sut.updateOverdueStatus(baseDate);
 
-        verify(overdueSettlementUpdater).updateOverdueForSettlement(overdue, baseDate);
-        verify(overdueSettlementUpdater, never()).updateOverdueForSettlement(eq(notOverdue), eq(baseDate));
-    }
-
-    @Test
-    @DisplayName("한 정산 갱신이 실패해도 나머지 정산은 계속 처리된다")
-    void continuesProcessingWhenOneUpdateFails() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        SettlementDTO s1 = settlement(1L);
-        SettlementDTO s2 = settlement(2L);
-
-        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of(s1, s2));
-        when(overdueCriteria.isOverdue(s1, baseDate)).thenReturn(true);
-        when(overdueCriteria.isOverdue(s2, baseDate)).thenReturn(true);
-        doThrow(new IllegalStateException("갱신 실패"))
-                .when(overdueSettlementUpdater).updateOverdueForSettlement(s1, baseDate);
-
-        sut.updateOverdueStatus(baseDate);
-
-        verify(overdueSettlementUpdater).updateOverdueForSettlement(s1, baseDate);
-        verify(overdueSettlementUpdater).updateOverdueForSettlement(s2, baseDate); // s1 실패와 무관하게 호출됨
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(overdue, overdueRefDate);
+        verify(overdueSettlementUpdater, never()).updateOverdueForSettlement(eq(notOverdue), any());
     }
 
     @Test
     @DisplayName("첫 페이지가 PAGE_SIZE 미만이면 다음 페이지를 조회하지 않고 종료한다")
     void stopsWhenFirstPageIsPartial() {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        List<SettlementDTO> partialPage = List.of(settlement(1L), settlement(2L)); // 200개 미만
+        List<SettlementDTO> partialPage = List.of(settlement(1L), settlement(2L));
 
         when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(partialPage);
-        when(overdueCriteria.isOverdue(any(), eq(baseDate))).thenReturn(false);
+        when(overdueCriteria.resolveReferenceDate(any())).thenReturn(LocalDate.of(2026, 3, 1));
+        when(overdueCriteria.isOverdue(any(), eq(baseDate), any())).thenReturn(false);
 
         sut.updateOverdueStatus(baseDate);
 
@@ -94,13 +80,13 @@ class OverdueSettlementServiceTest {
 
         when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(fullFirstPage);
         when(settlementMapper.findInProgressSettlements(200, 200)).thenReturn(secondPage);
-        when(overdueCriteria.isOverdue(any(), eq(baseDate))).thenReturn(false);
+        when(overdueCriteria.resolveReferenceDate(any())).thenReturn(LocalDate.of(2026, 3, 1));
+        when(overdueCriteria.isOverdue(any(), eq(baseDate), any())).thenReturn(false);
 
         sut.updateOverdueStatus(baseDate);
 
         verify(settlementMapper).findInProgressSettlements(0, 200);
         verify(settlementMapper).findInProgressSettlements(200, 200);
-        // 두 번째 페이지(1건, PAGE_SIZE 미만)에서 종료되므로 세 번째 조회는 없어야 함
         verify(settlementMapper, times(2)).findInProgressSettlements(anyInt(), anyInt());
     }
 
@@ -113,5 +99,28 @@ class OverdueSettlementServiceTest {
         sut.updateOverdueStatus(baseDate);
 
         verify(overdueSettlementUpdater, never()).updateOverdueForSettlement(any(), any());
+    }
+
+    @Test
+    @DisplayName("한 정산 갱신이 실패해도 나머지 정산은 계속 처리된다")
+    void continuesProcessingWhenOneUpdateFails() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO s1 = settlement(1L);
+        SettlementDTO s2 = settlement(2L);
+        LocalDate refDate1 = LocalDate.of(2026, 1, 15);
+        LocalDate refDate2 = LocalDate.of(2026, 1, 16);
+
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of(s1, s2));
+        when(overdueCriteria.resolveReferenceDate(s1)).thenReturn(refDate1);
+        when(overdueCriteria.resolveReferenceDate(s2)).thenReturn(refDate2);
+        when(overdueCriteria.isOverdue(s1, baseDate, refDate1)).thenReturn(true);
+        when(overdueCriteria.isOverdue(s2, baseDate, refDate2)).thenReturn(true);
+        doThrow(new IllegalStateException("갱신 실패"))
+                .when(overdueSettlementUpdater).updateOverdueForSettlement(s1, refDate1);
+
+        sut.updateOverdueStatus(baseDate);
+
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(s1, refDate1);
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(s2, refDate2);
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceTest.java
@@ -6,23 +6,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
-import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
-import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
-import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
 import org.teamsai.saibackend.domain.settlement.service.OverdueCriteria;
 import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementService;
-import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
-import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
-import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementUpdater;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,100 +24,94 @@ class OverdueSettlementServiceTest {
 
     @Mock private OverdueCriteria overdueCriteria;
     @Mock private SettlementMapper settlementMapper;
-    @Mock private SettlementParticipantMapper participantMapper;
-    @Mock private PaymentObligationMapper paymentObligationMapper;
+    @Mock private OverdueSettlementUpdater overdueSettlementUpdater;
 
     @InjectMocks
     private OverdueSettlementService sut;
 
-    private SettlementDTO settlement(Long id, SettlementType type) {
-        return SettlementDTO.builder()
-                .settlementId(id)
-                .settlementType(type)
-                .settlementStatus(SettlementStatus.IN_PROGRESS)
-                .build();
-    }
-
-    private SettlementParticipantDTO participant(Long participantId, SettlementParticipantStatus status) {
-        return SettlementParticipantDTO.builder()
-                .participantId(participantId)
-                .participantStatus(status)
-                .build();
+    private SettlementDTO settlement(Long id) {
+        return SettlementDTO.builder().settlementId(id).build();
     }
 
     @Test
-    @DisplayName("연체로 판정된 정산만 참여자를 조회하고, 판정 안 된 정산은 건드리지 않는다")
-    void onlyProcessesOverdueSettlements() {
+    @DisplayName("연체로 판정된 정산만 updater에 위임하고, 판정 안 된 정산은 건드리지 않는다")
+    void onlyDelegatesOverdueSettlementsToUpdater() {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
-        SettlementDTO notOverdue = settlement(2L, SettlementType.SHARED);
+        SettlementDTO overdue = settlement(1L);
+        SettlementDTO notOverdue = settlement(2L);
 
-        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue, notOverdue));
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of(overdue, notOverdue));
         when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
         when(overdueCriteria.isOverdue(notOverdue, baseDate)).thenReturn(false);
-        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
-                participant(101L, SettlementParticipantStatus.ACTIVE)
-        ));
-        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of());
 
         sut.updateOverdueStatus(baseDate);
 
-        verify(participantMapper).findBySettlementId(1L);
-        verify(participantMapper, never()).findBySettlementId(2L);
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(overdue, baseDate);
+        verify(overdueSettlementUpdater, never()).updateOverdueForSettlement(eq(notOverdue), eq(baseDate));
     }
 
     @Test
-    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 baseDate 자정으로 채운다")
-    void updatesOverdueSinceForUnpaidObligations() {
+    @DisplayName("한 정산 갱신이 실패해도 나머지 정산은 계속 처리된다")
+    void continuesProcessingWhenOneUpdateFails() {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
+        SettlementDTO s1 = settlement(1L);
+        SettlementDTO s2 = settlement(2L);
 
-        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue));
-        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
-        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
-                participant(101L, SettlementParticipantStatus.ACTIVE),
-                participant(102L, SettlementParticipantStatus.LEFT) // 제외되어야 함
-        ));
-        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
-                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
-                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
-        ));
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of(s1, s2));
+        when(overdueCriteria.isOverdue(s1, baseDate)).thenReturn(true);
+        when(overdueCriteria.isOverdue(s2, baseDate)).thenReturn(true);
+        doThrow(new IllegalStateException("갱신 실패"))
+                .when(overdueSettlementUpdater).updateOverdueForSettlement(s1, baseDate);
 
         sut.updateOverdueStatus(baseDate);
 
-        LocalDateTime expectedOverdueSince = baseDate.atStartOfDay();
-        verify(paymentObligationMapper).updateOverdueSince(9001L, expectedOverdueSince);
-        verify(paymentObligationMapper).updateOverdueSince(9002L, expectedOverdueSince);
-        // LEFT 참여자는 findUnpaidByParticipantIds 호출 시 애초에 포함 안 됨
-        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(s1, baseDate);
+        verify(overdueSettlementUpdater).updateOverdueForSettlement(s2, baseDate); // s1 실패와 무관하게 호출됨
     }
 
     @Test
-    @DisplayName("ACTIVE 참여자가 없으면 obligation 조회 자체를 하지 않는다")
-    void skipsWhenNoActiveParticipants() {
+    @DisplayName("첫 페이지가 PAGE_SIZE 미만이면 다음 페이지를 조회하지 않고 종료한다")
+    void stopsWhenFirstPageIsPartial() {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        SettlementDTO overdue = settlement(1L, SettlementType.SHARED);
+        List<SettlementDTO> partialPage = List.of(settlement(1L), settlement(2L)); // 200개 미만
 
-        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of(overdue));
-        when(overdueCriteria.isOverdue(overdue, baseDate)).thenReturn(true);
-        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
-                participant(101L, SettlementParticipantStatus.LEFT)
-        ));
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(partialPage);
+        when(overdueCriteria.isOverdue(any(), eq(baseDate))).thenReturn(false);
 
         sut.updateOverdueStatus(baseDate);
 
-        verify(paymentObligationMapper, never()).findUnpaidByParticipantIds(any());
+        verify(settlementMapper, times(1)).findInProgressSettlements(anyInt(), anyInt());
     }
 
     @Test
-    @DisplayName("연체 대상 정산이 없으면 아무것도 조회하지 않는다")
+    @DisplayName("페이지가 가득 차면 다음 offset으로 계속 조회하고, 빈 페이지가 나오면 종료한다")
+    void continuesToNextPageWhenFull() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        List<SettlementDTO> fullFirstPage = IntStream.rangeClosed(1, 200)
+                .mapToObj(i -> settlement((long) i))
+                .toList();
+        List<SettlementDTO> secondPage = List.of(settlement(201L));
+
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(fullFirstPage);
+        when(settlementMapper.findInProgressSettlements(200, 200)).thenReturn(secondPage);
+        when(overdueCriteria.isOverdue(any(), eq(baseDate))).thenReturn(false);
+
+        sut.updateOverdueStatus(baseDate);
+
+        verify(settlementMapper).findInProgressSettlements(0, 200);
+        verify(settlementMapper).findInProgressSettlements(200, 200);
+        // 두 번째 페이지(1건, PAGE_SIZE 미만)에서 종료되므로 세 번째 조회는 없어야 함
+        verify(settlementMapper, times(2)).findInProgressSettlements(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("대상 정산이 없으면 updater를 전혀 호출하지 않는다")
     void doesNothingWhenNoSettlements() {
         LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        when(settlementMapper.findInProgressSettlements()).thenReturn(List.of());
+        when(settlementMapper.findInProgressSettlements(0, 200)).thenReturn(List.of());
 
         sut.updateOverdueStatus(baseDate);
 
-        verify(participantMapper, never()).findBySettlementId(any());
-        verify(paymentObligationMapper, never()).updateOverdueSince(any(), any());
+        verify(overdueSettlementUpdater, never()).updateOverdueForSettlement(any(), any());
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
@@ -11,13 +11,10 @@ import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
-import org.teamsai.saibackend.domain.settlement.service.OverdueCriteria;
 import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementUpdater;
 import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
-import org.teamsai.saibackend.domain.settlement.type.SettlementType;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +25,6 @@ class OverdueSettlementUpdaterTest {
 
     @Mock private SettlementParticipantMapper participantMapper;
     @Mock private PaymentObligationMapper paymentObligationMapper;
-    @Mock private OverdueCriteria overdueCriteria;
 
     @InjectMocks
     private OverdueSettlementUpdater sut;
@@ -45,42 +41,38 @@ class OverdueSettlementUpdaterTest {
     }
 
     @Test
-    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 실제 기준일(dueDate)로 채운다")
-    void updatesOverdueSinceUsingReferenceDate() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 5); // 배치가 며칠 밀려서 실행됨
-        LocalDate actualDueDate = LocalDate.of(2026, 2, 1); // 실제 만기일
-        SettlementDTO settlement = SettlementDTO.builder()
-                .settlementId(1L)
-                .settlementType(SettlementType.SHARED)
-                .dueDate(actualDueDate)
-                .build();
+    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 주어진 referenceDate로 채운다")
+    void updatesOverdueSinceUsingGivenReferenceDate() {
+        LocalDate referenceDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO settlement = settlement(1L);
 
-        when(overdueCriteria.resolveReferenceDate(settlement)).thenReturn(actualDueDate);
         when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
-                participant(101L, SettlementParticipantStatus.ACTIVE)
+                participant(101L, SettlementParticipantStatus.ACTIVE),
+                participant(102L, SettlementParticipantStatus.LEFT)
         ));
         when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
-                PaymentObligationDTO.builder().paymentObligationId(9001L).build()
+                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
+                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
         ));
-        when(paymentObligationMapper.updateOverdueSince(9001L, actualDueDate.atStartOfDay())).thenReturn(1);
 
-        sut.updateOverdueForSettlement(settlement, baseDate);
+        sut.updateOverdueForSettlement(settlement, referenceDate);
 
-        // baseDate(2/5)가 아니라 actualDueDate(2/1)로 기록되는지 검증
-        verify(paymentObligationMapper).updateOverdueSince(9001L, actualDueDate.atStartOfDay());
+        verify(paymentObligationMapper).updateOverdueSince(9001L, referenceDate.atStartOfDay());
+        verify(paymentObligationMapper).updateOverdueSince(9002L, referenceDate.atStartOfDay());
+        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
     }
 
     @Test
     @DisplayName("ACTIVE 참여자가 없으면 obligation 조회 자체를 하지 않는다")
     void skipsWhenNoActiveParticipants() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        LocalDate referenceDate = LocalDate.of(2026, 2, 1);
         SettlementDTO settlement = settlement(1L);
 
         when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
                 participant(101L, SettlementParticipantStatus.LEFT)
         ));
 
-        sut.updateOverdueForSettlement(settlement, baseDate);
+        sut.updateOverdueForSettlement(settlement, referenceDate);
 
         verify(paymentObligationMapper, never()).findUnpaidByParticipantIds(any());
     }
@@ -88,7 +80,7 @@ class OverdueSettlementUpdaterTest {
     @Test
     @DisplayName("미납 obligation이 없으면 갱신할 것도 없다")
     void doesNothingWhenNoUnpaidObligations() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        LocalDate referenceDate = LocalDate.of(2026, 2, 1);
         SettlementDTO settlement = settlement(1L);
 
         when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
@@ -96,7 +88,7 @@ class OverdueSettlementUpdaterTest {
         ));
         when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of());
 
-        sut.updateOverdueForSettlement(settlement, baseDate);
+        sut.updateOverdueForSettlement(settlement, referenceDate);
 
         verify(paymentObligationMapper, never()).updateOverdueSince(any(), any());
     }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
@@ -54,12 +54,12 @@ class OverdueSettlementUpdaterTest {
                 PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
                 PaymentObligationDTO.builder().paymentObligationId(9002L).build()
         ));
-        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay()))
+        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.plusDays(1).atStartOfDay()))
                 .thenReturn(2);
 
         sut.updateOverdueForSettlement(settlement, referenceDate);
 
-        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay());
+        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.plusDays(1).atStartOfDay());
     }
 
     @Test
@@ -75,14 +75,12 @@ class OverdueSettlementUpdaterTest {
                 PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
                 PaymentObligationDTO.builder().paymentObligationId(9002L).build()
         ));
-        // 2건 대상인데 1건만 실제 갱신됨 (나머지는 이미 완납 등으로 조건 불일치)
-        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay()))
+        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.plusDays(1).atStartOfDay()))
                 .thenReturn(1);
 
         sut.updateOverdueForSettlement(settlement, referenceDate);
 
-        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay());
-        // 예외 없이 정상 종료되는지가 핵심 (별도 assertion 불필요, 예외 발생 시 테스트 자체가 실패함)
+        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.plusDays(1).atStartOfDay());
     }
 
     @Test

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
@@ -41,8 +41,8 @@ class OverdueSettlementUpdaterTest {
     }
 
     @Test
-    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 주어진 referenceDate로 채운다")
-    void updatesOverdueSinceUsingGivenReferenceDate() {
+    @DisplayName("ACTIVE 참여자의 미납 obligation들을 벌크로 한 번에 갱신한다")
+    void updatesOverdueSinceInBulk() {
         LocalDate referenceDate = LocalDate.of(2026, 2, 1);
         SettlementDTO settlement = settlement(1L);
 
@@ -54,12 +54,35 @@ class OverdueSettlementUpdaterTest {
                 PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
                 PaymentObligationDTO.builder().paymentObligationId(9002L).build()
         ));
+        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay()))
+                .thenReturn(2);
 
         sut.updateOverdueForSettlement(settlement, referenceDate);
 
-        verify(paymentObligationMapper).updateOverdueSince(9001L, referenceDate.atStartOfDay());
-        verify(paymentObligationMapper).updateOverdueSince(9002L, referenceDate.atStartOfDay());
-        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
+        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay());
+    }
+
+    @Test
+    @DisplayName("일부만 갱신되면(이미 완납 등) 로그로 남기되 예외는 던지지 않는다")
+    void logsWhenPartiallyUpdated() {
+        LocalDate referenceDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO settlement = settlement(1L);
+
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.ACTIVE)
+        ));
+        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
+                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
+                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
+        ));
+        // 2건 대상인데 1건만 실제 갱신됨 (나머지는 이미 완납 등으로 조건 불일치)
+        when(paymentObligationMapper.updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay()))
+                .thenReturn(1);
+
+        sut.updateOverdueForSettlement(settlement, referenceDate);
+
+        verify(paymentObligationMapper).updateOverdueSinceBulk(List.of(9001L, 9002L), referenceDate.atStartOfDay());
+        // 예외 없이 정상 종료되는지가 핵심 (별도 assertion 불필요, 예외 발생 시 테스트 자체가 실패함)
     }
 
     @Test
@@ -90,6 +113,6 @@ class OverdueSettlementUpdaterTest {
 
         sut.updateOverdueForSettlement(settlement, referenceDate);
 
-        verify(paymentObligationMapper, never()).updateOverdueSince(any(), any());
+        verify(paymentObligationMapper, never()).updateOverdueSinceBulk(any(), any());
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
@@ -11,8 +11,10 @@ import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
 import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
 import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.OverdueCriteria;
 import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementUpdater;
 import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,6 +28,7 @@ class OverdueSettlementUpdaterTest {
 
     @Mock private SettlementParticipantMapper participantMapper;
     @Mock private PaymentObligationMapper paymentObligationMapper;
+    @Mock private OverdueCriteria overdueCriteria;
 
     @InjectMocks
     private OverdueSettlementUpdater sut;
@@ -42,26 +45,29 @@ class OverdueSettlementUpdaterTest {
     }
 
     @Test
-    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 baseDate 자정으로 채운다")
-    void updatesOverdueSinceForUnpaidObligations() {
-        LocalDate baseDate = LocalDate.of(2026, 2, 1);
-        SettlementDTO settlement = settlement(1L);
+    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 실제 기준일(dueDate)로 채운다")
+    void updatesOverdueSinceUsingReferenceDate() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 5); // 배치가 며칠 밀려서 실행됨
+        LocalDate actualDueDate = LocalDate.of(2026, 2, 1); // 실제 만기일
+        SettlementDTO settlement = SettlementDTO.builder()
+                .settlementId(1L)
+                .settlementType(SettlementType.SHARED)
+                .dueDate(actualDueDate)
+                .build();
 
+        when(overdueCriteria.resolveReferenceDate(settlement)).thenReturn(actualDueDate);
         when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
-                participant(101L, SettlementParticipantStatus.ACTIVE),
-                participant(102L, SettlementParticipantStatus.LEFT) // 제외되어야 함
+                participant(101L, SettlementParticipantStatus.ACTIVE)
         ));
         when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
-                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
-                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
+                PaymentObligationDTO.builder().paymentObligationId(9001L).build()
         ));
+        when(paymentObligationMapper.updateOverdueSince(9001L, actualDueDate.atStartOfDay())).thenReturn(1);
 
         sut.updateOverdueForSettlement(settlement, baseDate);
 
-        LocalDateTime expectedOverdueSince = baseDate.atStartOfDay();
-        verify(paymentObligationMapper).updateOverdueSince(9001L, expectedOverdueSince);
-        verify(paymentObligationMapper).updateOverdueSince(9002L, expectedOverdueSince);
-        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
+        // baseDate(2/5)가 아니라 actualDueDate(2/1)로 기록되는지 검증
+        verify(paymentObligationMapper).updateOverdueSince(9001L, actualDueDate.atStartOfDay());
     }
 
     @Test

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementUpdaterTest.java
@@ -1,0 +1,97 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
+import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementParticipantDTO;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementParticipantMapper;
+import org.teamsai.saibackend.domain.settlement.service.OverdueSettlementUpdater;
+import org.teamsai.saibackend.domain.settlement.type.SettlementParticipantStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OverdueSettlementUpdaterTest {
+
+    @Mock private SettlementParticipantMapper participantMapper;
+    @Mock private PaymentObligationMapper paymentObligationMapper;
+
+    @InjectMocks
+    private OverdueSettlementUpdater sut;
+
+    private SettlementDTO settlement(Long id) {
+        return SettlementDTO.builder().settlementId(id).build();
+    }
+
+    private SettlementParticipantDTO participant(Long participantId, SettlementParticipantStatus status) {
+        return SettlementParticipantDTO.builder()
+                .participantId(participantId)
+                .participantStatus(status)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 참여자의 미납 obligation에 overdueSince를 baseDate 자정으로 채운다")
+    void updatesOverdueSinceForUnpaidObligations() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO settlement = settlement(1L);
+
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.ACTIVE),
+                participant(102L, SettlementParticipantStatus.LEFT) // 제외되어야 함
+        ));
+        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of(
+                PaymentObligationDTO.builder().paymentObligationId(9001L).build(),
+                PaymentObligationDTO.builder().paymentObligationId(9002L).build()
+        ));
+
+        sut.updateOverdueForSettlement(settlement, baseDate);
+
+        LocalDateTime expectedOverdueSince = baseDate.atStartOfDay();
+        verify(paymentObligationMapper).updateOverdueSince(9001L, expectedOverdueSince);
+        verify(paymentObligationMapper).updateOverdueSince(9002L, expectedOverdueSince);
+        verify(paymentObligationMapper).findUnpaidByParticipantIds(List.of(101L));
+    }
+
+    @Test
+    @DisplayName("ACTIVE 참여자가 없으면 obligation 조회 자체를 하지 않는다")
+    void skipsWhenNoActiveParticipants() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO settlement = settlement(1L);
+
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.LEFT)
+        ));
+
+        sut.updateOverdueForSettlement(settlement, baseDate);
+
+        verify(paymentObligationMapper, never()).findUnpaidByParticipantIds(any());
+    }
+
+    @Test
+    @DisplayName("미납 obligation이 없으면 갱신할 것도 없다")
+    void doesNothingWhenNoUnpaidObligations() {
+        LocalDate baseDate = LocalDate.of(2026, 2, 1);
+        SettlementDTO settlement = settlement(1L);
+
+        when(participantMapper.findBySettlementId(1L)).thenReturn(List.of(
+                participant(101L, SettlementParticipantStatus.ACTIVE)
+        ));
+        when(paymentObligationMapper.findUnpaidByParticipantIds(List.of(101L))).thenReturn(List.of());
+
+        sut.updateOverdueForSettlement(settlement, baseDate);
+
+        verify(paymentObligationMapper, never()).updateOverdueSince(any(), any());
+    }
+}


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #145 

## 🛠 작업 사항

- OverdueCriteria — SHARED/RECURRING 타입별 연체 판정 및 기준일 산출 로직 분리
- OverdueSettlementService / OverdueSettlementUpdater — 페이징 순회 + 정산 단위 독립 트랜잭션으로 연체 상태 갱신
- 완납 시 연체 자동 해제 — SettlementPaymentService.applyPayment() 연동

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [ ] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 스케줄러 연결과 RECURRING 자동생성 연동은 다른 브랜치에서 진행

---