### PR TITLE
feat(#134): refresh token + redis 적용 및 공용 파일 통일 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.security:spring-security-test"
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/teamsai/saibackend/domain/link/controller/AccountLinkFlowController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/link/controller/AccountLinkFlowController.java
@@ -48,25 +48,60 @@ public class AccountLinkFlowController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
-        UserDTO myInfo = userService.getUser(userId);
 
-        identityValidator.validateUserInformation(myInfo);
+        UserDTO myInfo =
+                userService.getUser(userId);
 
-        String state = jwtTokenProvider.createLinkStateToken(userId, myInfo.getName(), myInfo.getBirthDate());
+        identityValidator.validateUserInformation(
+                myInfo
+        );
 
-        List<Long> alreadyLinkedAccountIds = linkedBankAccountService.getLinkedAccountIds(userId);
-        String linkedIdsParam = alreadyLinkedAccountIds.stream()
-                .map(String::valueOf)
-                .collect(Collectors.joining(","));
+        String state =
+                jwtTokenProvider.createLinkStateToken(
+                        userId,
+                        myInfo.getName(),
+                        myInfo.getBirthDate()
+                );
 
-        String redirectUrl = UriComponentsBuilder
-                .fromUriString(mockBankBaseUrl + "/link/start")
-                .queryParam("returnUrl", backendBaseUrl + "/accounts/link/callback")
-                .queryParam("state", state)
-                .queryParam("excludeAccountIds", linkedIdsParam)
-                .toUriString();
+        List<Long> alreadyLinkedAccountIds =
+                linkedBankAccountService.getLinkedAccountIds(
+                        userId
+                );
 
-        return ResponseEntity.ok(Map.of("redirectUrl", redirectUrl));
+        String linkedIdsParam =
+                alreadyLinkedAccountIds.stream()
+                        .map(String::valueOf)
+                        .collect(
+                                Collectors.joining(",")
+                        );
+
+        String redirectUrl =
+                UriComponentsBuilder
+                        .fromUriString(
+                                mockBankBaseUrl
+                                        + "/link/start"
+                        )
+                        .queryParam(
+                                "returnUrl",
+                                backendBaseUrl
+                                        + "/accounts/link/callback"
+                        )
+                        .queryParam(
+                                "state",
+                                state
+                        )
+                        .queryParam(
+                                "excludeAccountIds",
+                                linkedIdsParam
+                        )
+                        .toUriString();
+
+        return ResponseEntity.ok(
+                Map.of(
+                        "redirectUrl",
+                        redirectUrl
+                )
+        );
     }
 
     @GetMapping("/accounts/link/callback")

--- a/src/main/java/org/teamsai/saibackend/domain/user/controller/AuthController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/controller/AuthController.java
@@ -6,18 +6,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
+import org.teamsai.saibackend.domain.user.dto.UserLoginDTO;
 import org.teamsai.saibackend.domain.user.dto.request.UserLoginRequest;
 import org.teamsai.saibackend.domain.user.dto.request.UserSignUpRequest;
+import org.teamsai.saibackend.domain.user.dto.response.AccessTokenResponse;
 import org.teamsai.saibackend.domain.user.dto.response.UserLoginResponse;
 import org.teamsai.saibackend.domain.user.dto.response.UserSignUpResponse;
 import org.teamsai.saibackend.domain.user.service.AuthService;
+
+import java.time.Duration;
 
 @Tag(
         name = "인증/인가 API",
@@ -28,6 +32,9 @@ import org.teamsai.saibackend.domain.user.service.AuthService;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Value("${jwt.cookie.secure:false}")
+    private boolean cookieSecure;
 
     @GetMapping("/login")
     public String loginPage() {
@@ -86,9 +93,87 @@ public class AuthController {
     })
     @ResponseBody
     @PostMapping("/api/auth/login")
-    public UserLoginResponse login(
+    public ResponseEntity<UserLoginResponse> login(
             @Valid @RequestBody UserLoginRequest request
     ) {
-        return authService.login(request);
+        UserLoginDTO loginDTO =
+                authService.login(request);
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(
+                                "refreshToken",
+                                loginDTO.getRefreshToken()
+                        )
+                        .httpOnly(true)
+                        .secure(cookieSecure)
+                        .sameSite("Lax")
+                        .path("/api/auth")
+                        .maxAge(Duration.ofDays(14))
+                        .build();
+
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        refreshTokenCookie.toString()
+                )
+                .body(
+                        UserLoginResponse.from(
+                                loginDTO
+                        )
+                );
+    }
+
+    @Operation(
+            summary = "Access Token 재발급",
+            description = "Refresh Token을 검증하여 새로운 Access Token을 발급합니다."
+    )
+    @ResponseBody
+    @PostMapping("/api/auth/reissue")
+    public AccessTokenResponse reissue(
+            @CookieValue(
+                    value = "refreshToken",
+                    required = false
+            )
+            String refreshToken
+    ) {
+        return authService.reissue(
+                refreshToken
+        );
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "Refresh Token을 삭제하여 로그아웃합니다."
+    )
+    @ResponseBody
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<Void> logout(
+            @CookieValue(
+                    value = "refreshToken",
+                    required = false
+            )
+            String refreshToken
+    ) {
+        authService.logout(refreshToken);
+
+        ResponseCookie expiredCookie =
+                ResponseCookie.from(
+                                "refreshToken",
+                                ""
+                        )
+                        .httpOnly(true)
+                        .secure(cookieSecure)
+                        .sameSite("Lax")
+                        .path("/api/auth")
+                        .maxAge(Duration.ZERO)
+                        .build();
+
+        return ResponseEntity
+                .noContent()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        expiredCookie.toString()
+                )
+                .build();
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/UserLoginDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/UserLoginDTO.java
@@ -1,0 +1,29 @@
+package org.teamsai.saibackend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserLoginDTO {
+
+    private String accessToken;
+    private String refreshToken;
+    private String userToken;
+    private String name;
+
+    public static UserLoginDTO of(
+            UserDTO user,
+            String accessToken,
+            String refreshToken
+    ){
+        return UserLoginDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userToken(user.getUserToken())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/AccessTokenResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/AccessTokenResponse.java
@@ -1,0 +1,11 @@
+package org.teamsai.saibackend.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserLoginResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/dto/response/UserLoginResponse.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.dto.UserLoginDTO;
 
 @Getter
 @Builder
@@ -16,14 +16,13 @@ public class UserLoginResponse {
     private String userToken;
     private String name;
 
-    public static UserLoginResponse of(
-            UserDTO user,
-            String accessToken
+    public static UserLoginResponse from(
+            UserLoginDTO loginDTO
     ) {
         return UserLoginResponse.builder()
-                .accessToken(accessToken)
-                .userToken(user.getUserToken())
-                .name(user.getName())
+                .accessToken(loginDTO.getAccessToken())
+                .userToken(loginDTO.getUserToken())
+                .name(loginDTO.getName())
                 .build();
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/exception/UserErrorCode.java
@@ -61,6 +61,10 @@ public enum UserErrorCode
             HttpStatus.CONFLICT,
             "계좌 연동 처리 중 충돌이 발생했습니다. 다시 시도해주세요."
 
+    ),
+    INVALID_REFRESH_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "리프레시 토큰이 유효하지 않거나 만료되었습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/teamsai/saibackend/domain/user/service/AuthService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/service/AuthService.java
@@ -5,11 +5,12 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.dto.UserLoginDTO;
 import org.teamsai.saibackend.domain.user.dto.request.UserLoginRequest;
 import org.teamsai.saibackend.domain.user.dto.request.UserSignUpRequest;
-import org.teamsai.saibackend.domain.user.dto.response.UserLoginResponse;
+import org.teamsai.saibackend.domain.user.dto.response.AccessTokenResponse;
 import org.teamsai.saibackend.domain.user.dto.response.UserSignUpResponse;
-import org.teamsai.saibackend.domain.user.dto.UserDTO;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
 import org.teamsai.saibackend.domain.user.mapper.UserMapper;
 import org.teamsai.saibackend.global.jwt.JwtTokenProvider;
@@ -19,13 +20,13 @@ import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuthService {
 
     private final UserMapper userMapper;
     private final AuthValidator authValidator;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public UserSignUpResponse signUp(
@@ -61,7 +62,7 @@ public class AuthService {
         return UserSignUpResponse.from(user);
     }
 
-    public UserLoginResponse login(UserLoginRequest request) {
+    public UserLoginDTO login(UserLoginRequest request) {
         String email = normalizeEmail(request.getEmail());
 
         UserDTO user = userMapper.findByEmail(email)
@@ -76,9 +77,17 @@ public class AuthService {
         String accessToken =
                 jwtTokenProvider.createAccessToken(user.getUserId());
 
-        return UserLoginResponse.of(
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(user.getUserId());
+
+        refreshTokenService.save(user.getUserId(),refreshToken);
+
+
+
+        return UserLoginDTO.of(
                 user,
-                accessToken
+                accessToken,
+                refreshToken
         );
     }
 
@@ -128,6 +137,70 @@ public class AuthService {
         }
 
         return false;
+    }
+
+    public AccessTokenResponse reissue(
+            String refreshToken
+    ) {
+        if (
+                refreshToken == null ||
+                        refreshToken.isBlank()
+        ) {
+            throw UserErrorCode
+                    .INVALID_REFRESH_TOKEN
+                    .toException();
+        }
+
+        Long userId =
+                jwtTokenProvider
+                        .getUserIdFromRefreshToken(
+                                refreshToken
+                        )
+                        .orElseThrow(
+                                UserErrorCode
+                                        .INVALID_REFRESH_TOKEN
+                                        ::toException
+                        );
+
+        if (!refreshTokenService.matches(
+                userId,
+                refreshToken
+        )) {
+            throw UserErrorCode
+                    .INVALID_REFRESH_TOKEN
+                    .toException();
+        }
+
+        String accessToken =
+                jwtTokenProvider.createAccessToken(
+                        userId
+                );
+
+        return new AccessTokenResponse(
+                accessToken
+        );
+    }
+
+    public void logout(
+            String refreshToken
+    ) {
+        if (refreshToken == null || refreshToken.isBlank()
+        ) {
+            return;
+        }
+
+        jwtTokenProvider
+                .getUserIdFromRefreshToken(
+                        refreshToken
+                )
+                .filter(
+                        userId ->
+                                refreshTokenService.matches(userId, refreshToken
+                                )
+                )
+                .ifPresent(
+                        refreshTokenService::delete
+                );
     }
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/user/service/RefreshTokenService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,57 @@
+package org.teamsai.saibackend.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String KEY_PREFIX = "auth:refresh:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-token-expiration-ms}")
+    private long refreshTokenExpirationMs;
+
+    public void save(Long userId, String refreshToken){
+        redisTemplate.opsForValue().set(
+                createKey(userId),
+                refreshToken,
+                Duration.ofMillis(refreshTokenExpirationMs));
+    }
+
+    public boolean matches(Long userId, String refreshToken
+    ) {
+        String storedRefreshToken = redisTemplate.opsForValue()
+                        .get(createKey(userId));
+
+        if (refreshToken == null || storedRefreshToken == null
+        ) {
+            return false;
+        }
+
+        return MessageDigest.isEqual(
+                refreshToken.getBytes(
+                        StandardCharsets.UTF_8
+                ),
+                storedRefreshToken.getBytes(
+                        StandardCharsets.UTF_8
+                )
+        );
+    }
+
+    public void delete(Long userId){
+        redisTemplate.delete(createKey(userId));
+    }
+
+    private String createKey(Long userId){
+        return KEY_PREFIX + userId;
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         "/api/auth/signup",
                                         "/api/auth/login",
+                                        "/api/auth/reissue",
+                                        "/api/auth/logout",
                                         "/login",
                                         "/signup",
                                         "/v3/api-docs/**",

--- a/src/main/java/org/teamsai/saibackend/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/teamsai/saibackend/global/jwt/JwtTokenProvider.java
@@ -19,79 +19,206 @@ public class JwtTokenProvider {
 
     private static final String CLAIM_PURPOSE = "purpose";
     private static final String CLAIM_IDENTITY_HASH = "identity-hash";
+
     private static final String PURPOSE_ACCESS = "access";
+    private static final String PURPOSE_REFRESH = "refresh";
     private static final String PURPOSE_BANK_LINK = "bank-link";
 
     private final SecretKey accessSigningKey;
     private final SecretKey linkStateSigningKey;
+
     private final long accessTokenExpirationMs;
+    private final long refreshTokenExpirationMs;
     private final long linkStateExpirationMs;
+
     private final String linkIdentityHashSecret;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String accessSecret,
             @Value("${link-state.secret}") String linkStateSecret,
             @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs,
+            @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs,
             @Value("${jwt.link-state-expiration-ms}") long linkStateExpirationMs,
             @Value("${link-identity.hash-secret}") String linkIdentityHashSecret
     ) {
-        this.accessSigningKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessSecret));
-        this.linkStateSigningKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(linkStateSecret));
-        this.accessTokenExpirationMs = accessTokenExpirationMs;
-        this.linkStateExpirationMs = linkStateExpirationMs;
-        this.linkIdentityHashSecret = linkIdentityHashSecret;
+        this.accessSigningKey =
+                Keys.hmacShaKeyFor(
+                        Decoders.BASE64.decode(accessSecret)
+                );
+
+        this.linkStateSigningKey =
+                Keys.hmacShaKeyFor(
+                        Decoders.BASE64.decode(linkStateSecret)
+                );
+
+        this.accessTokenExpirationMs =
+                accessTokenExpirationMs;
+
+        this.refreshTokenExpirationMs =
+                refreshTokenExpirationMs;
+
+        this.linkStateExpirationMs =
+                linkStateExpirationMs;
+
+        this.linkIdentityHashSecret =
+                linkIdentityHashSecret;
     }
 
     public String createAccessToken(Long userId) {
         Date issuedAt = new Date();
-        Date expiration = new Date(issuedAt.getTime() + accessTokenExpirationMs);
+
+        Date expiration =
+                new Date(
+                        issuedAt.getTime()
+                                + accessTokenExpirationMs
+                );
+
         return Jwts.builder()
                 .subject(String.valueOf(userId))
-                .claim(CLAIM_PURPOSE, PURPOSE_ACCESS)
+                .claim(
+                        CLAIM_PURPOSE,
+                        PURPOSE_ACCESS
+                )
                 .issuedAt(issuedAt)
                 .expiration(expiration)
                 .signWith(accessSigningKey)
                 .compact();
     }
 
-    public String createLinkStateToken(Long userId, String name, LocalDate birthDate) {
+    public String createRefreshToken(Long userId) {
         Date issuedAt = new Date();
-        Date expiration = new Date(issuedAt.getTime() + linkStateExpirationMs);
+
+        Date expiration =
+                new Date(
+                        issuedAt.getTime()
+                                + refreshTokenExpirationMs
+                );
+
         return Jwts.builder()
                 .subject(String.valueOf(userId))
-                .claim(CLAIM_PURPOSE, PURPOSE_BANK_LINK)
-                .claim(CLAIM_IDENTITY_HASH, LinkIdentityHasher.hash(name, birthDate, linkIdentityHashSecret))
+                .claim(
+                        CLAIM_PURPOSE,
+                        PURPOSE_REFRESH
+                )
+                .issuedAt(issuedAt)
+                .expiration(expiration)
+                .signWith(accessSigningKey)
+                .compact();
+    }
+
+    public String createLinkStateToken(
+            Long userId,
+            String name,
+            LocalDate birthDate
+    ) {
+        Date issuedAt = new Date();
+
+        Date expiration =
+                new Date(
+                        issuedAt.getTime()
+                                + linkStateExpirationMs
+                );
+
+        String identityHash =
+                LinkIdentityHasher.hash(
+                        name,
+                        birthDate,
+                        linkIdentityHashSecret
+                );
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim(
+                        CLAIM_PURPOSE,
+                        PURPOSE_BANK_LINK
+                )
+                .claim(
+                        CLAIM_IDENTITY_HASH,
+                        identityHash
+                )
                 .issuedAt(issuedAt)
                 .expiration(expiration)
                 .signWith(linkStateSigningKey)
                 .compact();
     }
 
-    public Optional<Long> getUserIdFromLinkState(String token) {
-        return getUserIdIfPurposeMatches(token, PURPOSE_BANK_LINK, linkStateSigningKey);
+    public Optional<Long> getUserIdFromLinkState(
+            String token
+    ) {
+        return getUserIdIfPurposeMatches(
+                token,
+                PURPOSE_BANK_LINK,
+                linkStateSigningKey
+        );
     }
 
-    public Optional<Long> getUserIdIfValid(String token) {
-        return getUserIdIfPurposeMatches(token, PURPOSE_ACCESS, accessSigningKey);
+    public Optional<Long> getUserIdIfValid(
+            String token
+    ) {
+        return getUserIdIfPurposeMatches(
+                token,
+                PURPOSE_ACCESS,
+                accessSigningKey
+        );
     }
 
-    private Optional<Long> getUserIdIfPurposeMatches(String token, String expectedPurpose, SecretKey key) {
+    public Optional<Long> getUserIdFromRefreshToken(
+            String token
+    ) {
+        return getUserIdIfPurposeMatches(
+                token,
+                PURPOSE_REFRESH,
+                accessSigningKey
+        );
+    }
+
+    private Optional<Long> getUserIdIfPurposeMatches(
+            String token,
+            String expectedPurpose,
+            SecretKey key
+    ) {
         try {
-            Claims claims = parseClaims(token, key);
-            if (!expectedPurpose.equals(claims.get(CLAIM_PURPOSE, String.class))) {
+            Claims claims =
+                    parseClaims(
+                            token,
+                            key
+                    );
+
+            if (!expectedPurpose.equals(
+                    claims.get(
+                            CLAIM_PURPOSE,
+                            String.class
+                    )
+            )) {
                 return Optional.empty();
             }
-            String subject = claims.getSubject();
-            if (subject == null || subject.isBlank()) {
+
+            String subject =
+                    claims.getSubject();
+
+            if (
+                    subject == null
+                            || subject.isBlank()
+            ) {
                 return Optional.empty();
             }
-            return Optional.of(Long.valueOf(subject));
-        } catch (JwtException | IllegalArgumentException exception) {
+
+            return Optional.of(
+                    Long.valueOf(subject)
+            );
+
+        } catch (
+                JwtException
+                | IllegalArgumentException exception
+        ) {
             return Optional.empty();
         }
     }
 
-    private Claims parseClaims(String token, SecretKey key) {
+    private Claims parseClaims(
+            String token,
+            SecretKey key
+    ) {
         return Jwts.parser()
                 .verifyWith(key)
                 .build()

--- a/src/main/resources/static/css/archive/archive.css
+++ b/src/main/resources/static/css/archive/archive.css
@@ -1,178 +1,274 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css");
-
 * {
     box-sizing: border-box;
 }
 
 body {
     margin: 0;
-    padding: 24px 16px 60px;
+    padding: 0;
+
     background: #f7f7f8;
-    font-family: "Pretendard", sans-serif;
+
+    font-family:
+            "Pretendard",
+            sans-serif;
 }
 
 .archive-container {
-    max-width: 720px;
+    width: 100%;
+    max-width: 960px;
+
     margin: 0 auto;
+    padding: 32px 24px 60px;
+}
+
+.archive-heading {
+    margin-bottom: 20px;
 }
 
 h1 {
+    margin: 0 0 4px;
+
+    color: #1a1a1a;
+
     font-size: 20px;
     font-weight: 700;
-    color: #1a1a1a;
-    margin: 0 0 4px;
 }
 
 .subtitle {
-    font-size: 13px;
+    margin: 0;
+
     color: #888;
-    margin: 0 0 20px;
+
+    font-size: 13px;
 }
 
 .archive-list {
     display: flex;
     flex-direction: column;
+
     gap: 12px;
 }
 
+
 .archive-card {
-    background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    padding: 16px 18px;
-    cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: space-between;
+
     gap: 12px;
-    transition: box-shadow 0.15s ease;
+
+    padding: 16px 18px;
+
+    background: #ffffff;
+
+    border-radius: 12px;
+
+    box-shadow:
+            0 2px 8px rgba(0, 0, 0, 0.06);
+
+    cursor: pointer;
+
+    transition:
+            box-shadow 0.15s ease,
+            transform 0.15s ease;
 }
 
 .archive-card:hover {
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
+    box-shadow:
+            0 4px 14px rgba(0, 0, 0, 0.1);
+
+    transform: translateY(-1px);
 }
 
 .archive-card-main {
     display: flex;
     flex-direction: column;
+
     gap: 6px;
+
     min-width: 0;
 }
 
 .archive-card-title {
+    overflow: hidden;
+
+    color: #1a1a1a;
+
     font-size: 16px;
     font-weight: 600;
-    color: #1a1a1a;
+
     white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
 }
 
 .archive-card-sub {
-    font-size: 13px;
     color: #888;
+
+    font-size: 13px;
 }
 
 .role-badge {
     display: inline-block;
+
+    margin-right: 6px;
     padding: 2px 8px;
+
     border-radius: 999px;
+
     font-size: 12px;
     font-weight: 600;
-    margin-right: 6px;
 }
 
-.role-badge.creditor { background: #e6f4ec; color: #0b3d2e; }
-.role-badge.debtor { background: #fdeee6; color: #a63d1a; }
+.role-badge.creditor {
+    background: #e6f4ec;
+    color: #0b3d2e;
+}
+
+.role-badge.debtor {
+    background: #fdeee6;
+    color: #a63d1a;
+}
+
 
 .status-pill {
     flex-shrink: 0;
+
     padding: 4px 12px;
+
     border-radius: 999px;
+
     font-size: 12px;
     font-weight: 600;
 }
 
-.status-pill.ongoing { background: #eef4ff; color: #1d4ed8; }
-.status-pill.completed { background: #f0f0f0; color: #666; }
+.status-pill.ongoing {
+    background: #eef4ff;
+    color: #1d4ed8;
+}
+
+.status-pill.completed {
+    background: #f0f0f0;
+    color: #666;
+}
+
 
 .card-actions {
     display: flex;
     align-items: center;
-    gap: 8px;
+
     flex-shrink: 0;
+
+    gap: 8px;
 }
 
 .btn-pdf-download {
-    border: 1px solid #0b3d2e;
-    background: #fff;
-    color: #0b3d2e;
-    border-radius: 6px;
     padding: 6px 10px;
+
+    border: 1px solid #0b3d2e;
+    border-radius: 6px;
+
+    background: #ffffff;
+    color: #0b3d2e;
+
+    font-family:
+            "Pretendard",
+            sans-serif;
+
     font-size: 12px;
     font-weight: 600;
+
     cursor: pointer;
-    font-family: "Pretendard", sans-serif;
+
+    transition:
+            background-color 0.15s ease;
 }
 
 .btn-pdf-download:hover {
     background: #f0f7f3;
 }
 
-.empty-state, .error-state {
-    text-align: center;
+.empty-state,
+.error-state {
     padding: 60px 0;
+
     color: #999;
+
     font-size: 14px;
+
+    text-align: center;
 }
+
 
 .pager {
     display: flex;
+    align-items: center;
     justify-content: center;
+
     margin-top: 20px;
 }
 
 .pager button {
-    border: 1px solid #ddd;
-    background: #fff;
-    border-radius: 8px;
     padding: 8px 16px;
+
+    border: 1px solid #ddd;
+    border-radius: 8px;
+
+    background: #ffffff;
+
+    font-family:
+            "Pretendard",
+            sans-serif;
+
     font-size: 13px;
+
     cursor: pointer;
-    font-family: "Pretendard", sans-serif;
 }
 
 .pager button:disabled {
     color: #ccc;
+
     cursor: not-allowed;
 }
 
 .pager-label {
-    margin: 0 12px;
     align-self: center;
-    font-size: 13px;
-    color: #666;
-}
 
+    margin: 0 12px;
+
+    color: #666;
+
+    font-size: 13px;
+}
 
 .print-only {
     position: fixed;
+
     top: 0;
     left: -10000px;
+
     width: 210mm;
+
     background: #ffffff;
+
     z-index: -9999;
 }
 
 .page {
     width: 210mm;
     min-height: 297mm;
+
+    margin: 0 auto 10px;
     padding: 20mm;
-    margin: 0 auto 10px auto;
+
     background: #ffffff;
-    box-sizing: border-box;
     color: #1a1a1a;
-    font-family: "Pretendard", sans-serif;
+
+    box-sizing: border-box;
+
+    font-family:
+            "Pretendard",
+            sans-serif;
 
     page-break-after: always;
     break-after: page;
@@ -180,17 +276,71 @@ h1 {
 
 .page .doc {
     padding: 0;
+
     border: none;
-    box-shadow: none;
     border-radius: 0;
+
+    box-shadow: none;
+}
+
+@media (max-width: 760px) {
+
+    .archive-container {
+        padding:
+                24px 16px
+                48px;
+    }
+
+    .archive-card {
+        align-items: flex-start;
+
+        padding: 15px 16px;
+    }
+
+    .card-actions {
+        align-items: flex-end;
+        flex-direction: column;
+    }
+}
+
+
+@media (max-width: 520px) {
+
+    .archive-container {
+        padding-left: 14px;
+        padding-right: 14px;
+    }
+
+    .archive-card {
+        flex-direction: column;
+
+        gap: 14px;
+    }
+
+    .archive-card-main {
+        width: 100%;
+    }
+
+    .card-actions {
+        width: 100%;
+
+        align-items: center;
+        flex-direction: row;
+        justify-content: flex-end;
+    }
 }
 
 @media print {
+
     body {
-        background: #ffffff;
+        margin: 0;
         padding: 0;
+
+        background: #ffffff;
     }
 
+    .app-header,
+    .app-footer,
     .archive-container,
     .pager {
         display: none !important;
@@ -198,7 +348,11 @@ h1 {
 
     .print-only {
         position: static;
+
         left: 0;
+
         width: 100%;
+
+        z-index: auto;
     }
 }

--- a/src/main/resources/static/css/common/app-shell.css
+++ b/src/main/resources/static/css/common/app-shell.css
@@ -1,0 +1,409 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css");
+
+html {
+    min-height: 100%;
+}
+
+body.app-shell-page {
+    min-height: 100vh;
+
+    display: flex;
+    flex-direction: column;
+
+    margin: 0;
+    padding: 0;
+}
+
+body.app-shell-page > .app-header {
+    flex: 0 0 auto;
+}
+
+body.app-shell-page > main {
+    flex: 1 0 auto;
+    min-width: 0;
+}
+
+body.app-shell-page > .app-footer {
+    flex: 0 0 auto;
+
+    margin-top: auto;
+}
+
+.app-header,
+.app-footer {
+    box-sizing: border-box;
+
+    font-family:
+            "Pretendard",
+            "Apple SD Gothic Neo",
+            Arial,
+            sans-serif;
+}
+
+.app-header *,
+.app-footer * {
+    box-sizing: border-box;
+}
+
+.app-header a,
+.app-footer a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.app-header {
+    position: relative;
+    z-index: 50;
+
+    width: 100%;
+    height: 80px;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    gap: 24px;
+
+    padding: 0 48px;
+
+    background: #ffffff;
+
+    border-bottom: 1px solid #d9dee8;
+}
+
+.app-brand {
+    min-width: 160px;
+
+    display: flex;
+    align-items: center;
+
+    gap: 10px;
+
+    color: #151922;
+
+    font-weight: 800;
+}
+
+.app-brand__mark {
+    width: 34px;
+    height: 34px;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    flex: 0 0 auto;
+
+    border-radius: 8px;
+
+    background: #0f8a5f;
+    color: #ffffff;
+
+    font-size: 16px;
+    font-weight: 900;
+    line-height: 1;
+}
+
+.app-brand__name {
+    color: #151922;
+
+    font-size: 18px;
+    font-weight: 800;
+    line-height: 1;
+
+    white-space: nowrap;
+}
+.app-nav {
+    display: flex;
+    align-items: center;
+
+    gap: 30px;
+
+    color: #667085;
+
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.app-nav__link {
+    position: relative;
+
+    height: 80px;
+
+    display: inline-flex;
+    align-items: center;
+
+    padding: 0;
+
+    border-bottom: 2px solid transparent;
+
+    color: #667085;
+
+    white-space: nowrap;
+
+    transition:
+            color 0.18s ease,
+            border-color 0.18s ease;
+}
+
+.app-nav__link:hover {
+    color: #151922;
+}
+
+.app-nav__link.is-active {
+    color: #0f8a5f;
+
+    border-bottom-color: #0f8a5f;
+}
+
+.app-header-actions {
+    display: flex;
+    align-items: center;
+
+    gap: 10px;
+}
+
+
+.app-icon-button {
+    width: 34px;
+    height: 34px;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    flex: 0 0 auto;
+
+    border: 0;
+    border-radius: 8px;
+
+    background: #fff4df;
+    color: #b46a00;
+
+    font-size: 14px;
+    font-weight: 900;
+    line-height: 1;
+
+    cursor: pointer;
+
+    transition:
+            background-color 0.18s ease,
+            transform 0.18s ease;
+}
+
+.app-icon-button:hover {
+    background: #ffecc9;
+}
+
+.app-icon-button:active {
+    transform: translateY(1px);
+}
+
+.app-icon-button.is-active {
+    outline: 2px solid #0f8a5f;
+    outline-offset: 2px;
+}
+
+.app-profile-button {
+    height: 34px;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: 0 14px;
+
+    border: 1px solid #d9dee8;
+    border-radius: 8px;
+
+    background: #ffffff;
+    color: #151922;
+
+    font-size: 13px;
+    font-weight: 800;
+
+    white-space: nowrap;
+
+    transition:
+            border-color 0.18s ease,
+            background-color 0.18s ease,
+            color 0.18s ease;
+}
+
+.app-profile-button:hover {
+    border-color: #b9c1ce;
+
+    background: #f8fafc;
+}
+
+.app-profile-button.is-active {
+    border-color: #0f8a5f;
+
+    background: #f0f8f5;
+    color: #0f8a5f;
+}
+.app-footer {
+    width: 100%;
+    min-height: 120px;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    gap: 24px;
+
+    padding: 24px 48px;
+
+    background: #1f2937;
+    color: #ffffff;
+}
+
+.app-footer strong {
+    display: block;
+
+    color: #ffffff;
+
+    font-size: 15px;
+    font-weight: 800;
+}
+
+.app-footer p {
+    margin: 8px 0 0;
+
+    color: #cfd6e3;
+
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+.app-footer nav {
+    display: flex;
+    align-items: center;
+
+    gap: 18px;
+
+    color: #dce3ef;
+
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.app-footer nav a {
+    color: #dce3ef;
+
+    transition: color 0.18s ease;
+}
+
+.app-footer nav a:hover {
+    color: #ffffff;
+}
+
+@media (max-width: 1180px) {
+
+    .app-header,
+    .app-footer {
+        padding-left: 28px;
+        padding-right: 28px;
+    }
+
+    .app-nav {
+        gap: 20px;
+    }
+
+    .app-brand {
+        min-width: auto;
+    }
+}
+
+@media (max-width: 760px) {
+
+    .app-header {
+        height: auto;
+
+        flex-wrap: wrap;
+
+        gap: 14px;
+
+        padding-top: 16px;
+        padding-bottom: 16px;
+    }
+
+    .app-brand {
+        min-width: 0;
+    }
+
+    .app-header-actions {
+        margin-left: auto;
+    }
+
+    .app-nav {
+        order: 3;
+
+        width: 100%;
+
+        justify-content: flex-start;
+
+        gap: 22px;
+
+        overflow-x: auto;
+
+        scrollbar-width: none;
+    }
+
+    .app-nav::-webkit-scrollbar {
+        display: none;
+    }
+
+    .app-nav__link {
+        height: auto;
+
+        flex: 0 0 auto;
+
+        padding: 12px 0;
+
+        white-space: nowrap;
+    }
+
+    .app-footer {
+        min-height: 0;
+
+        align-items: flex-start;
+        flex-direction: column;
+
+        padding-top: 28px;
+        padding-bottom: 28px;
+    }
+
+    .app-footer nav {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 480px) {
+
+    .app-header,
+    .app-footer {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+    .app-brand__name {
+        font-size: 17px;
+    }
+
+    .app-profile-button {
+        padding: 0 10px;
+    }
+
+    .app-nav {
+        gap: 18px;
+
+        font-size: 13px;
+    }
+
+    .app-footer nav {
+        gap: 12px;
+
+        font-size: 12px;
+    }
+}

--- a/src/main/resources/static/js/accounts/link-modal.js
+++ b/src/main/resources/static/js/accounts/link-modal.js
@@ -6,15 +6,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const agreeCheckbox = document.getElementById("link-agree-checkbox");
     const agreeDetailButton = document.getElementById("link-agree-detail");
 
-    document.addEventListener("DOMContentLoaded", () => {
-        const token = sessionStorage.getItem("accessToken");
-
-        if (!token) {
-            window.location.replace("/login?required=true");
-            return;
-        }
-    });
-
     function openModal() {
         backdrop.hidden = false;
         document.body.style.overflow = "hidden";
@@ -49,15 +40,12 @@ document.addEventListener("DOMContentLoaded", () => {
         confirmButton.textContent = "연동 중...";
 
         try {
-            const token = sessionStorage.getItem("accessToken");
-
-            const response = await fetch("/api/mock-bank/link", {
-                method: "POST",
-                headers: {
-                    "Authorization": `Bearer ${token}`
+            const response = await authFetch(
+                "/api/mock-bank/link",
+                {
+                    method: "POST"
                 }
-            });
-
+            );
             if (!response.ok) {
                 throw new Error("계좌 연동 준비에 실패했습니다.");
             }

--- a/src/main/resources/static/js/accounts/link-select.js
+++ b/src/main/resources/static/js/accounts/link-select.js
@@ -13,14 +13,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     const selectedIds = new Set();
     let accounts = [];
 
-    function getToken() {
-        return sessionStorage.getItem("accessToken");
-    }
-
-    function redirectToLogin() {
-        window.location.replace("/login?required=true");
-    }
-
     function showError(message) {
         errorEl.textContent = message;
         errorEl.hidden = false;
@@ -138,26 +130,13 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     async function loadAccounts() {
-        const token = getToken();
-
-        if (!token) {
-            redirectToLogin();
-            return;
-        }
-
         try {
-            const response = await fetch(API.available, {
+            const response = await authFetch(API.available, {
                 method: "GET",
                 headers: {
-                    "Accept": "application/json",
-                    "Authorization": `Bearer ${token}`
+                    "Accept": "application/json"
                 }
             });
-
-            if (response.status === 401 || response.status === 403) {
-                redirectToLogin();
-                return;
-            }
 
             if (!response.ok) {
                 throw new Error("계좌 목록을 불러오지 못했습니다.");
@@ -179,11 +158,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     confirmButton?.addEventListener("click", async () => {
-        const token = getToken();
-        if (!token) {
-            redirectToLogin();
-            return;
-        }
 
         const selectedAccounts = accounts
             .filter(account => selectedIds.has(account.accountId))
@@ -202,13 +176,14 @@ document.addEventListener("DOMContentLoaded", async () => {
         confirmButton.textContent = "연결 중...";
 
         try {
-            const response = await fetch(API.link, {
+            const response = await authFetch(API.link, {
                 method: "POST",
                 headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${token}`
+                    "Content-Type": "application/json"
                 },
-                body: JSON.stringify({ selectedAccounts })
+                body: JSON.stringify({
+                    selectedAccounts
+                })
             });
 
             if (!response.ok) {

--- a/src/main/resources/static/js/archive/archive.js
+++ b/src/main/resources/static/js/archive/archive.js
@@ -11,14 +11,6 @@
 
     let currentPage = 1;
 
-    function authHeaders(extra) {
-        const token = sessionStorage.getItem("accessToken");
-        return Object.assign(
-            token ? { Authorization: `Bearer ${token}` } : {},
-            extra || {}
-        );
-    }
-
     function escapeHtml(value) {
         if (value == null) return "";
         return String(value)
@@ -76,9 +68,13 @@
 
     async function downloadContractPdf(contractId) {
         try {
-            const response = await fetch(
+            const response = await authFetch(
                 `/api/contracts/${contractId}/pdf`,
-                { headers: authHeaders({ Accept: "application/pdf" }) }
+                {
+                    headers: {
+                        Accept: "application/pdf"
+                    }
+                }
             );
 
             if (!response.ok) {
@@ -121,25 +117,18 @@
     }
 
     async function loadArchive() {
-        const token = sessionStorage.getItem("accessToken");
-        if (!token) {
-            window.location.href = "/login?required=true";
-            return;
-        }
 
         const listEl = document.getElementById("archiveList");
 
         try {
-            const response = await fetch(
+            const response = await authFetch(
                 `/api/dashboard?roleFilter=ALL&page=${currentPage}`,
-                { headers: authHeaders({ Accept: "application/json" }) }
+                {
+                    headers: {
+                        Accept: "application/json"
+                    }
+                }
             );
-
-            if (response.status === 401) {
-                sessionStorage.removeItem("accessToken");
-                window.location.href = "/login?required=true";
-                return;
-            }
 
             if (!response.ok) {
                 throw new Error("보관함 조회 실패");

--- a/src/main/resources/static/js/common/auth.js
+++ b/src/main/resources/static/js/common/auth.js
@@ -1,0 +1,102 @@
+let reissuePromise = null;
+function getAccessToken() {
+    return sessionStorage.getItem("accessToken");
+}
+function setAccessToken(accessToken) {
+    sessionStorage.setItem("accessToken", accessToken);
+}
+function clearStoredAuth() {
+    sessionStorage.removeItem("accessToken");
+}
+async function reissueAccessToken() {
+    if (reissuePromise) {
+        return reissuePromise;
+    }
+    reissuePromise = (async () => {
+        try {
+            const response = await fetch("/api/auth/reissue", {
+                method: "POST",
+                credentials: "include"
+            });
+            if (!response.ok) {
+                clearStoredAuth();
+                return null;
+            }
+            const body = await response.json();
+            setAccessToken(body.accessToken);
+            return body.accessToken;
+        } finally {
+            reissuePromise = null;
+        }
+    })();
+    return reissuePromise;
+}
+
+async function authFetch(url, options = {}) {
+    let accessToken = getAccessToken();
+
+    if (!accessToken) {
+        accessToken = await reissueAccessToken();
+
+        if (!accessToken) {
+            redirectToLogin();
+            throw new Error("로그인이 필요합니다.");
+        }
+    }
+
+    const headers = new Headers(
+        options.headers || {}
+    );
+
+    headers.set(
+        "Authorization",
+        `Bearer ${accessToken}`
+    );
+
+    let response = await fetch(url, {
+        ...options,
+        headers,
+        credentials: "include"
+    });
+
+    if (response.status !== 401) {
+        return response;
+    }
+
+    const newAccessToken =
+        await reissueAccessToken();
+
+    if (!newAccessToken) {
+        redirectToLogin();
+        throw new Error(
+            "로그인이 만료되었습니다."
+        );
+    }
+
+    headers.set(
+        "Authorization",
+        `Bearer ${newAccessToken}`
+    );
+
+    const retryResponse = await fetch(url, {
+        ...options,
+        headers,
+        credentials: "include"
+    });
+
+    if (retryResponse.status === 401) {
+        redirectToLogin();
+        throw new Error(
+            "로그인이 만료되었습니다."
+        );
+    }
+
+    return retryResponse;
+}
+
+function redirectToLogin() {
+    clearStoredAuth();
+
+    window.location.href =
+        "/login?required=true";
+}

--- a/src/main/resources/static/js/contract/contract-complete.js
+++ b/src/main/resources/static/js/contract/contract-complete.js
@@ -13,15 +13,6 @@
     btnViewContract.disabled = true;
     return;
   }
-
-  function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-  }
-
   btnViewContract.addEventListener("click", () => {
     window.location.href = `/contracts/${encodeURIComponent(contractId)}/contract-detail`;
   });
@@ -30,9 +21,11 @@
     window.location.href = "/dashboard";
   });
 
-  fetch(`/api/contracts/${contractId}/listdetails`, {
+  authFetch(`/api/contracts/${contractId}/listdetails`, {
     method: "GET",
-    headers: authHeaders({ Accept: "application/json" }),
+    headers: {
+      Accept: "application/json"
+    },
   })
       .then((response) => (response.ok ? response.json() : null))
       .then((data) => {

--- a/src/main/resources/static/js/contract/contract-debtor-form.js
+++ b/src/main/resources/static/js/contract/contract-debtor-form.js
@@ -27,14 +27,6 @@
 
   if (nextBtn) nextBtn.disabled = true;
 
-  function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-      token ? { Authorization: `Bearer ${token}` } : {},
-      extra || {}
-    );
-  }
-
   function showStatus(message, isError) {
     statusEl.textContent = message;
     statusEl.classList.toggle("is-error", Boolean(isError));
@@ -52,10 +44,15 @@
   }
 
   async function loadContract() {
-    const response = await fetch(`/api/contracts/${contractId}/listdetails`, {
-      method: "GET",
-      headers: authHeaders({ Accept: "application/json" }),
-    });
+    const response = await authFetch(
+        `/api/contracts/${contractId}/listdetails`,
+        {
+          method: "GET",
+          headers: {
+            Accept: "application/json"
+          },
+        }
+    );
     if (!response.ok) {
       const error = new Error(`HTTP ${response.status}`);
       error.status = response.status;
@@ -96,10 +93,12 @@
   }
 
   async function linkAsDebtor() {
-    const response = await fetch(`/api/contracts/${contractId}/debtor`, {
-      method: "PATCH",
-      headers: authHeaders(),
-    });
+    const response = await authFetch(
+        `/api/contracts/${contractId}/debtor`,
+        {
+          method: "PATCH"
+        }
+    );
     if (!response.ok) {
       const body = await response.json().catch(() => null);
       throw new Error(body?.message || "계약서에 채무자로 연결하지 못했습니다.");

--- a/src/main/resources/static/js/contract/contract-debtor-signature.js
+++ b/src/main/resources/static/js/contract/contract-debtor-signature.js
@@ -35,14 +35,6 @@
     return;
   }
 
-  function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-      token ? { Authorization: `Bearer ${token}` } : {},
-      extra || {}
-    );
-  }
-
   function showStatus(message, isError) {
     statusEl.textContent = message;
     statusEl.classList.toggle("is-error", Boolean(isError));
@@ -113,11 +105,13 @@
     formData.append("signature", blob, "signature.png");
     formData.append("identityVerificationId", identityVerificationId);
 
-    const response = await fetch(`/api/contracts/${contractId}/approve`, {
-      method: "PATCH",
-      headers: authHeaders(),
-      body: formData,
-    });
+    const response = await authFetch(
+        `/api/contracts/${contractId}/approve`,
+        {
+          method: "PATCH",
+          body: formData,
+        }
+    );
 
     if (!response.ok) {
       const body = await response.json().catch(() => null);

--- a/src/main/resources/static/js/contract/contract-form.js
+++ b/src/main/resources/static/js/contract/contract-form.js
@@ -32,14 +32,6 @@
   const loanAccountNumber = document.getElementById("loanAccountNumber");
   const loanAccountHolder = document.getElementById("loanAccountHolder");
 
-  function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-  }
-
   function showStatus(message, isError) {
     statusEl.textContent = message;
     statusEl.classList.toggle("is-error", Boolean(isError));
@@ -201,9 +193,11 @@
     if (!linkedAccountSelect) return;
 
     try {
-      const response = await fetch("/api/contracts/accounts", {
+      const response = await authFetch("/api/contracts/accounts", {
         method: "GET",
-        headers: authHeaders({ Accept: "application/json" }),
+        headers: {
+          Accept: "application/json"
+        },
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const accounts = await response.json();
@@ -234,9 +228,11 @@
 
   async function loadCreditorInfo() {
     try {
-      const response = await fetch("/api/users/me", {
+      const response = await authFetch("/api/users/me", {
         method: "GET",
-        headers: authHeaders({ Accept: "application/json" }),
+        headers: {
+          Accept: "application/json"
+        },
       });
       if (!response.ok) return;
       const user = await response.json();
@@ -253,10 +249,15 @@
     nextBtn.hidden = true;
 
     try {
-      const response = await fetch(`/api/contracts/${contractId}/listdetails`, {
-        method: "GET",
-        headers: authHeaders({ Accept: "application/json" }),
-      });
+      const response = await authFetch(
+          `/api/contracts/${contractId}/listdetails`,
+          {
+            method: "GET",
+            headers: {
+              Accept: "application/json"
+            },
+          }
+      );
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
 

--- a/src/main/resources/static/js/contract/contract-signature.js
+++ b/src/main/resources/static/js/contract/contract-signature.js
@@ -22,14 +22,6 @@
   let hasSignature = false;
   let drawing = false;
 
-  function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-  }
-
   function showStatus(message, isError) {
     statusEl.textContent = message;
     statusEl.classList.toggle("is-error", Boolean(isError));
@@ -114,9 +106,11 @@
       identityVerificationId,
     };
 
-    const response = await fetch("/api/contracts/write", {
+    const response = await authFetch("/api/contracts/write", {
       method: "POST",
-      headers: authHeaders({ "Content-Type": "application/json" }),
+      headers: {
+        "Content-Type": "application/json"
+      },
       body: JSON.stringify(payload),
     });
 
@@ -137,11 +131,13 @@
     formData.append("debtorUserToken", debtorUserTokenInput.value.trim());
     formData.append("signature", blob, "signature.png");
 
-    const response = await fetch(`/api/contracts/${contractId}/signature`, {
-      method: "PATCH",
-      headers: authHeaders(),
-      body: formData,
-    });
+    const response = await authFetch(
+        `/api/contracts/${contractId}/signature`,
+        {
+          method: "PATCH",
+          body: formData,
+        }
+    );
 
     if (!response.ok) {
       const body = await response.json().catch(() => null);

--- a/src/main/resources/static/js/contractchange/contractchange.js
+++ b/src/main/resources/static/js/contractchange/contractchange.js
@@ -7,15 +7,8 @@ const REPAYMENT_TYPE_LABELS = {
     BULLET_REPAYMENT: '만기일시상환'
 };
 
-function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-}
-
-fetch(`/api/contracts/${contractId}`, { headers: authHeaders() })
+authFetch(
+    `/api/contracts/${contractId}`)
     .then(response => {
         if (!response.ok) {
             throw new Error('계약 조회 실패');
@@ -122,9 +115,11 @@ document.getElementById('changeRequestForm').addEventListener('submit', function
         newTerms: document.getElementById('newTerms').value.trim() || null,
     };
 
-    fetch(`/api/contracts/${contractId}/change-requests`, {
+    authFetch(`/api/contracts/${contractId}/change-requests`, {
         method: 'POST',
-        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        headers: {
+            'Content-Type': 'application/json'
+        },
         body: JSON.stringify(requestBody)
     })
         .then(response => {

--- a/src/main/resources/static/js/contractchangedetail/request-detail.js
+++ b/src/main/resources/static/js/contractchangedetail/request-detail.js
@@ -2,15 +2,9 @@ const contractId = document.getElementById('contractId').value;
 const changeRequestId = document.getElementById('changeRequestId').value;
 let newContractId = null;
 
-function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-}
-
-fetch(`/api/contracts/${contractId}/change-requests/${changeRequestId}`, { headers: authHeaders() })
+authFetch(
+    `/api/contracts/${contractId}/change-requests/${changeRequestId}`
+)
     .then(response => {
         if (!response.ok) {
             throw new Error('변경 요청 조회 실패');
@@ -95,11 +89,18 @@ rejectConfirmButton.addEventListener('click', function () {
         return;
     }
 
-    fetch(`/api/contracts/${contractId}/change-requests/${changeRequestId}/reject`, {
-        method: 'PATCH',
-        headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ returnReason: returnReason })
-    })
+    authFetch(
+        `/api/contracts/${contractId}/change-requests/${changeRequestId}/reject`,
+        {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                returnReason: returnReason
+            })
+        }
+    )
         .then(response => {
             if (!response.ok) {
                 throw new Error('반려 처리 실패');

--- a/src/main/resources/static/js/contractdashboard/contract-dashboard.js
+++ b/src/main/resources/static/js/contractdashboard/contract-dashboard.js
@@ -1,11 +1,3 @@
-function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-}
-
 let currentKeyword = '';
 let currentRoleFilter = 'ALL';
 let currentSortType = '';
@@ -23,7 +15,7 @@ function fetchDashboard() {
         + `&sortType=${currentSortType}`
         + `&page=${currentPage}`;
 
-    fetch(url, { headers: authHeaders() })
+    authFetch(url)
         .then(response => {
             if (!response.ok) throw new Error('조회 실패');
             return response.json();

--- a/src/main/resources/static/js/contractdetail/contractdetail.js
+++ b/src/main/resources/static/js/contractdetail/contractdetail.js
@@ -8,15 +8,9 @@ const REPAYMENT_TYPE_LABELS = {
     BULLET_REPAYMENT: '만기일시상환'
 };
 
-function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-}
-
-fetch(`/api/contracts/${contractId}/contract-detail`, { headers: authHeaders() })
+authFetch(
+    `/api/contracts/${contractId}/contract-detail`
+)
     .then(response => {
         if (!response.ok) {
             throw new Error("금전차용계약서 조회 실패");

--- a/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
+++ b/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
@@ -1,11 +1,3 @@
-function authHeaders(extra) {
-    const token = sessionStorage.getItem("accessToken");
-    return Object.assign(
-        token ? { Authorization: `Bearer ${token}` } : {},
-        extra || {}
-    );
-}
-
 const contractId = document.getElementById('contractId').value;
 
 let allSchedules = [];
@@ -25,8 +17,12 @@ const CONTRACT_STATUS_LABELS = {
 };
 
 Promise.all([
-    fetch(`/api/contracts/${contractId}/schedules`, { headers: authHeaders() }),
-    fetch(`/api/contracts/${contractId}/contract-detail`, { headers: authHeaders() })
+    authFetch(
+        `/api/contracts/${contractId}/schedules`
+    ),
+    authFetch(
+        `/api/contracts/${contractId}/contract-detail`
+    )
 ])
     .then(([scheduleRes, contractRes]) => {
         if (!scheduleRes.ok || !contractRes.ok) {

--- a/src/main/resources/static/js/identity/identity-test.js
+++ b/src/main/resources/static/js/identity/identity-test.js
@@ -18,14 +18,6 @@ document.addEventListener("DOMContentLoaded", () => {
     );
 
     async function startVerification() {
-        const accessToken = getAccessToken();
-
-        if (!accessToken) {
-            printResult(
-                "로그인 정보가 없습니다. 먼저 로그인해 주세요."
-            );
-            return;
-        }
 
         setLoading(true);
 
@@ -36,7 +28,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
             const prepare =
                 await prepareIdentityVerification(
-                    accessToken,
                     purposeSelect.value
                 );
 
@@ -52,7 +43,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
             const completeResult =
                 await completeIdentityVerification(
-                    accessToken,
                     prepare.identityVerificationId
                 );
 
@@ -94,18 +84,14 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function prepareIdentityVerification(
-        accessToken,
         purpose
     ) {
-        const response = await fetch(
+        const response = await authFetch(
             "/api/identity-verifications",
             {
                 method: "POST",
 
                 headers: {
-                    "Authorization":
-                        `Bearer ${accessToken}`,
-
                     "Content-Type":
                         "application/json"
                 },
@@ -172,21 +158,15 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function completeIdentityVerification(
-        accessToken,
         identityVerificationId
     ) {
         const encodedId =
             encodeURIComponent(identityVerificationId);
 
-        const response = await fetch(
+        const response = await authFetch(
             `/api/identity-verifications/${encodedId}/complete`,
             {
-                method: "POST",
-
-                headers: {
-                    "Authorization":
-                        `Bearer ${accessToken}`
-                }
+                method: "POST"
             }
         );
 
@@ -212,52 +192,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 "본인인증 준비 응답이 올바르지 않습니다."
             );
         }
-    }
-
-    function getAccessToken() {
-        const directToken =
-            sessionStorage.getItem("accessToken")
-            ?? sessionStorage.getItem(
-                "saiwonjangAccessToken"
-            );
-
-        if (directToken) {
-            return removeBearerPrefix(directToken);
-        }
-
-        const authJson =
-            sessionStorage.getItem("saiwonjangAuth");
-
-        if (!authJson) {
-            return null;
-        }
-
-        try {
-            const auth = JSON.parse(authJson);
-
-            const token =
-                auth.accessToken
-                ?? auth.token
-                ?? null;
-
-            return token
-                ? removeBearerPrefix(token)
-                : null;
-
-        } catch (error) {
-            console.error(
-                "로그인 정보 파싱 실패",
-                error
-            );
-
-            return null;
-        }
-    }
-
-    function removeBearerPrefix(token) {
-        return token
-            .trim()
-            .replace(/^Bearer\s+/i, "");
     }
 
     async function readResponse(response) {

--- a/src/main/resources/static/js/integration/dashboard.js
+++ b/src/main/resources/static/js/integration/dashboard.js
@@ -19,11 +19,6 @@ const transactionStatusClasses = {
     IN_PROGRESS: "waiting"
 };
 
-function authHeaders() {
-    const token = sessionStorage.getItem("accessToken");
-    return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 function toAmount(value) {
     const amount = Number(value);
     return Number.isFinite(amount) ? amount : 0;
@@ -47,12 +42,6 @@ function toYearMonth(date) {
 }
 
 async function loadDashboard(calendarOnly = false) {
-    const token = sessionStorage.getItem("accessToken");
-
-    if (!token) {
-        window.location.href = "/login?required=true";
-        return;
-    }
 
     if (!calendarOnly) {
         setLoadingState();
@@ -62,15 +51,9 @@ async function loadDashboard(calendarOnly = false) {
         const params = new URLSearchParams({
             yearMonth: toYearMonth(calendarCursor)
         });
-        const response = await fetch(`/api/integration/dashboard?${params}`, {
-            headers: authHeaders()
-        });
-
-        if (response.status === 401) {
-            sessionStorage.removeItem("accessToken");
-            window.location.href = "/login?required=true";
-            return;
-        }
+        const response = await authFetch(
+            `/api/integration/dashboard?${params}`
+        );
 
         if (!response.ok) {
             throw new Error(`통합 대시보드 조회 실패: ${response.status}`);

--- a/src/main/resources/static/js/notification/notification-center.js
+++ b/src/main/resources/static/js/notification/notification-center.js
@@ -13,21 +13,6 @@ function initNotificationCenter() {
         document.getElementById("notifList");
 
 
-    function authHeaders(extra = {}) {
-        const token =
-            sessionStorage.getItem("accessToken");
-
-        return {
-            ...(token
-                ? {
-                    Authorization:
-                        `Bearer ${token}`
-                }
-                : {}),
-            ...extra
-        };
-    }
-
 
     function escapeHtml(value) {
 
@@ -204,49 +189,18 @@ function initNotificationCenter() {
 
     async function fetchNotifications() {
 
-        const token =
-            sessionStorage.getItem(
-                "accessToken"
-            );
-
-        if (!token) {
-            window.location.href =
-                "/login?required=true";
-            return;
-        }
-
         try {
-
             const response =
-                await fetch(
+                await authFetch(
                     "/api/notifications",
                     {
                         method: "GET",
-
-                        headers:
-                            authHeaders({
-                                Accept:
-                                    "application/json"
-                            }),
-
-                        credentials:
-                            "include"
+                        headers: {
+                            Accept:
+                                "application/json"
+                        }
                     }
                 );
-
-
-            if (response.status === 401) {
-
-                sessionStorage.removeItem(
-                    "accessToken"
-                );
-
-                window.location.href =
-                    "/login?required=true";
-
-                return;
-            }
-
 
             if (!response.ok) {
                 throw new Error(

--- a/src/main/resources/static/js/settlement/settlement-create.js
+++ b/src/main/resources/static/js/settlement/settlement-create.js
@@ -22,8 +22,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const summaryParticipantCount = document.getElementById("summary-participant-count");
     const summaryPerPersonAmount = document.getElementById("summary-per-person-amount");
     const ownerChip = document.getElementById("owner-chip");
-
-    // key: userToken, value: 조회된 사용자 정보
     const selectedParticipants = new Map();
 
     setMinimumDueDate();
@@ -128,31 +126,12 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
-        const accessToken = getAccessToken();
-
-        if (!accessToken) {
-            window.location.href = "/login?required=true";
-            return;
-        }
-
         setParticipantLookupLoading(true);
 
         try {
-            const response = await fetch(
-                `/api/users/by-token/${encodeURIComponent(userToken)}`,
-                {
-                    headers: {
-                        Authorization: `Bearer ${accessToken}`
-                    },
-                    credentials: "include"
-                }
+            const response = await authFetch(
+                `/api/users/by-token/${encodeURIComponent(userToken)}`
             );
-
-            if (response.status === 401) {
-                clearStoredAuth();
-                window.location.href = "/login?required=true";
-                return;
-            }
 
             const responseBody = await readJsonSafely(response);
 
@@ -192,29 +171,16 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
     async function loadLinkedAccounts() {
-        const token = getAccessToken();
-
-        if (!token) {
-            return;
-        }
-
         try {
-            const response = await fetch(
+            const response = await authFetch(
                 "/api/linked-accounts",
                 {
                     method: "GET",
                     headers: {
-                        "Accept": "application/json",
-                        Authorization: `Bearer ${token}`
+                        "Accept": "application/json"
                     }
                 }
             );
-
-            if (response.status === 401 || response.status === 403) {
-                clearStoredAuth();
-                window.location.href = "/login?required=true";
-                return;
-            }
 
             if (!response.ok) {
                 throw new Error(
@@ -327,19 +293,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function loadCurrentUser() {
-        const token = getAccessToken();
-
-        if (!token) {
-            return;
-        }
-
         try {
-            const response = await fetch("/api/users/me", {
-                headers: {
-                    Authorization: `Bearer ${token}`
-                },
-                credentials: "include"
-            });
+            const response = await authFetch(
+                "/api/users/me"
+            );
 
             if (!response.ok) {
                 return;
@@ -386,31 +343,19 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
-        const token = getAccessToken();
-
-        if (!token) {
-            window.location.href = "/login?required=true";
-            return;
-        }
-
         setSubmitting(true);
 
         try {
-            const response = await fetch("/api/settlements/shared", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`
-                },
-                credentials: "include",
-                body: JSON.stringify(payload)
-            });
-
-            if (response.status === 401) {
-                clearStoredAuth();
-                window.location.href = "/login?required=true";
-                return;
-            }
+            const response = await authFetch(
+                "/api/settlements/shared",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify(payload)
+                }
+            );
 
             const responseBody =
                 await readJsonSafely(response);
@@ -543,14 +488,6 @@ document.addEventListener("DOMContentLoaded", () => {
         submitButton.textContent = isSubmitting
             ? "생성 중..."
             : "공동정산 생성";
-    }
-
-    function getAccessToken() {
-        return sessionStorage.getItem("accessToken");
-    }
-
-    function clearStoredAuth() {
-        sessionStorage.removeItem("accessToken");
     }
 
     function getValidationMessage(body) {

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -1,5 +1,4 @@
 document.addEventListener("DOMContentLoaded", () => {
-    const token = sessionStorage.getItem("accessToken");
     const settlementId = getSettlementIdFromPath();
 
     const toast = document.getElementById("toast");
@@ -14,11 +13,6 @@ document.addEventListener("DOMContentLoaded", () => {
             "정산 ID를 확인할 수 없습니다.",
             true
         );
-        return;
-    }
-
-    if (!token) {
-        redirectToLogin();
         return;
     }
 
@@ -144,28 +138,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     async function requestSettlementAccount() {
         const response =
-            await fetch(
+            await authFetch(
                 `/api/settlements/${settlementId}/account`,
                 {
-                    method: "GET",
-                    headers: {
-                        "Authorization":
-                            `Bearer ${token}`
-                    }
+                    method: "GET"
                 }
             );
-
-        if (response.status === 401) {
-            sessionStorage.removeItem(
-                "accessToken"
-            );
-
-            redirectToLogin();
-
-            throw new Error(
-                "로그인이 필요합니다."
-            );
-        }
 
         if (response.status === 403) {
             throw new Error(
@@ -190,32 +168,10 @@ document.addEventListener("DOMContentLoaded", () => {
         options = {}
     ) {
         const response =
-            await fetch(
+            await authFetch(
                 url,
-                {
-                    ...options,
-
-                    headers: {
-                        ...(options.headers || {}),
-
-                        "Authorization":
-                            `Bearer ${token}`
-                    }
-                }
+                options
             );
-
-
-        if (response.status === 401) {
-            sessionStorage.removeItem(
-                "accessToken"
-            );
-
-            redirectToLogin();
-
-            throw new Error(
-                "로그인이 필요합니다."
-            );
-        }
 
         if (response.status === 403) {
             throw new Error(
@@ -242,8 +198,6 @@ document.addEventListener("DOMContentLoaded", () => {
                     message;
 
             } catch (error) {
-                // JSON 응답이 아니면
-                // 기본 메시지 사용
             }
 
             throw new Error(message);
@@ -883,11 +837,6 @@ document.addEventListener("DOMContentLoaded", () => {
             loading
                 ? "불러오는 중..."
                 : "↻ 새로고침";
-    }
-
-    function redirectToLogin() {
-        window.location.href =
-            "/login?required=true";
     }
 
     function showToast(

--- a/src/main/resources/static/js/settlement/settlement-list.js
+++ b/src/main/resources/static/js/settlement/settlement-list.js
@@ -27,28 +27,17 @@ document.addEventListener("DOMContentLoaded", () => {
         try {
             syncButton.disabled = true;
 
-            const token = sessionStorage.getItem("accessToken");
-
-            if (!token) {
-                window.location.href = "/login?required=true";
-                return;
-            }
-
-            const response = await fetch("/api/transactions/sync", {
-                method: "POST",
-                headers: {
-                    "Authorization": `Bearer ${token}`
+            const response = await authFetch(
+                "/api/transactions/sync",
+                {
+                    method: "POST"
                 }
-            });
+            );
 
             if (!response.ok) {
-                if (response.status === 401) {
-                    sessionStorage.removeItem("accessToken");
-                    window.location.href = "/login?required=true";
-                    return;
-                }
-
-                throw new Error("거래내역 동기화에 실패했습니다.");
+                throw new Error(
+                    "거래내역 동기화에 실패했습니다."
+                );
             }
 
             const result = await response.json();
@@ -168,34 +157,17 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function loadSettlements() {
-        const token = sessionStorage.getItem("accessToken");
-
-        if (!token) {
-            window.location.href = "/login?required=true";
-            return;
-        }
-
-        const requestOptions = {
-            method: "GET",
-            headers: {
-                "Authorization": `Bearer ${token}`
-            }
-        };
-
         await Promise.all([
-            loadSettlementList(requestOptions),
-            loadSummary(requestOptions)
+            loadSettlementList(),
+            loadSummary()
         ]);
     }
 
-    async function loadSettlementList(requestOptions) {
+    async function loadSettlementList() {
         try {
-            const response = await fetch("/api/settlements", requestOptions);
-
-            if (response.status === 401) {
-                handleUnauthorized();
-                return;
-            }
+            const response = await authFetch(
+                "/api/settlements"
+            );
 
             if (!response.ok) {
                 throw new Error("정산 목록 조회에 실패했습니다.");
@@ -211,17 +183,11 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    async function loadSummary(requestOptions) {
+    async function loadSummary() {
         try {
-            const response = await fetch(
-                "/api/settlements/summary",
-                requestOptions
+            const response = await authFetch(
+                "/api/settlements/summary"
             );
-
-            if (response.status === 401) {
-                handleUnauthorized();
-                return;
-            }
 
             if (!response.ok) {
                 throw new Error("정산 요약 조회에 실패했습니다.");
@@ -233,11 +199,6 @@ document.addEventListener("DOMContentLoaded", () => {
             updateSummary({});
             showToast("정산 요약을 불러오지 못했습니다.", true);
         }
-    }
-
-    function handleUnauthorized() {
-        sessionStorage.removeItem("accessToken");
-        window.location.href = "/login?required=true";
     }
 
     function formatAmount(value) {

--- a/src/main/resources/static/js/user/login.js
+++ b/src/main/resources/static/js/user/login.js
@@ -183,13 +183,23 @@ document.addEventListener("DOMContentLoaded", () => {
     async function loginWithApi() {
         const response = await fetch(API.login, {
             method: "POST",
+
             headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json"
+                "Content-Type":
+                    "application/json",
+
+                "Accept":
+                    "application/json"
             },
+
+            credentials: "include",
+
             body: JSON.stringify({
-                email: emailInput.value.trim(),
-                password: passwordInput.value
+                email:
+                    emailInput.value.trim(),
+
+                password:
+                passwordInput.value
             })
         });
 

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -238,43 +238,55 @@ document.addEventListener(
         }
 
         async function handleConnectAccountClick() {
-            const bankWindow = window.open("about:blank", "sai-bank-link", "width=480,height=720");
-            const token = sessionStorage.getItem("accessToken");
+            const bankWindow = window.open(
+                "about:blank",
+                "sai-bank-link",
+                "width=480,height=720"
+            );
 
             try {
-                const response = await fetch("/api/accounts/link/start", {
-                    method: "POST",
-                    headers: { "Authorization": `Bearer ${token}` }
-                });
-
-                if (response.status === 401 || response.status === 403) {
-                    bankWindow?.close();
-                    sessionStorage.removeItem("accessToken");
-                    redirectToLogin(true);
-                    return;
-                }
+                const response = await authFetch(
+                    "/api/accounts/link/start",
+                    {
+                        method: "POST"
+                    }
+                );
 
                 if (!response.ok) {
                     bankWindow?.close();
-                    const errorData = await readJson(response);
-                    window.alert(errorData.message || "계좌 연동을 시작할 수 없습니다.");
+
+                    const errorData =
+                        await readJson(response);
+
+                    window.alert(
+                        errorData.message ||
+                        "계좌 연동을 시작할 수 없습니다."
+                    );
+
                     return;
                 }
 
-                const { redirectUrl } = await readJson(response);
+                const { redirectUrl } =
+                    await readJson(response);
 
                 if (bankWindow) {
-                    bankWindow.location.href = redirectUrl;
+                    bankWindow.location.href =
+                        redirectUrl;
                 }
+
             } catch (error) {
                 bankWindow?.close();
-                console.error(error);
-                window.alert("계좌 연동을 시작할 수 없습니다.");
-            }
-        }
 
-        window.addEventListener("message", (event) => {
-            if (event.origin !== "http://localhost:8081") return;
+                console.error(error);
+
+                window.alert(
+                    "계좌 연동을 시작할 수 없습니다."
+                );
+            }
+        }window.addEventListener("message", (event) => {
+            if (event.origin !== "http://localhost:8081") {
+                return;
+            }
 
             if (event.data?.type === "SAI_BANK_LINK_COMPLETE") {
                 if (event.data.success) {
@@ -367,34 +379,32 @@ document.addEventListener(
                 return;
             }
 
-            const token =
-                sessionStorage.getItem(
-                    "accessToken"
-                );
+            const [
+                meResponse,
+                accountsResponse
+            ] = await Promise.all([
+                authFetch(
+                    API.me,
+                    {
+                        method: "GET",
+                        headers: {
+                            "Accept":
+                                "application/json"
+                        }
+                    }
+                ),
 
-            if (!token) {
-                redirectToLogin(true);
-                return;
-            }
-
-            const authHeaders = {
-                "Accept": "application/json",
-                "Authorization": `Bearer ${token}`
-            };
-
-            const [meResponse, accountsResponse] = await Promise.all([
-                fetch(API.me, { method: "GET", headers: authHeaders }),
-                fetch(API.linkedAccounts, { method: "GET", headers: authHeaders })
+                authFetch(
+                    API.linkedAccounts,
+                    {
+                        method: "GET",
+                        headers: {
+                            "Accept":
+                                "application/json"
+                        }
+                    }
+                )
             ]);
-
-            if (
-                meResponse.status === 401 || meResponse.status === 403 ||
-                accountsResponse.status === 401 || accountsResponse.status === 403
-            ) {
-                sessionStorage.removeItem("accessToken");
-                redirectToLogin(true);
-                return;
-            }
 
             const meData = await readJson(meResponse);
 
@@ -433,7 +443,25 @@ document.addEventListener(
             renderMyPage(member);
         }
 
-        function logout() {
+        async function logout() {
+
+            if (!FILE_PREVIEW) {
+                try {
+                    await fetch(
+                        "/api/auth/logout",
+                        {
+                            method: "POST",
+                            credentials: "include"
+                        }
+                    );
+                } catch (error) {
+                    console.error(
+                        "로그아웃 API 호출 실패",
+                        error
+                    );
+                }
+            }
+
             sessionStorage.removeItem(
                 "accessToken"
             );
@@ -467,38 +495,12 @@ document.addEventListener(
                 return;
             }
 
-            const token =
-                sessionStorage.getItem(
-                    "accessToken"
-                );
-
-            if (!token) {
-                redirectToLogin(true);
-                return;
-            }
-
-            const response = await fetch(
+            const response = await authFetch(
                 API.me,
                 {
-                    method: "DELETE",
-                    headers: {
-                        "Authorization":
-                            `Bearer ${token}`
-                    }
+                    method: "DELETE"
                 }
             );
-
-            if (
-                response.status === 401 ||
-                response.status === 403
-            ) {
-                sessionStorage.removeItem(
-                    "accessToken"
-                );
-
-                redirectToLogin(true);
-                return;
-            }
 
             if (!response.ok) {
                 const responseData =
@@ -507,6 +509,21 @@ document.addEventListener(
                 throw new Error(
                     responseData.message ||
                     "회원 탈퇴에 실패했습니다."
+                );
+            }
+
+            try {
+                await fetch(
+                    "/api/auth/logout",
+                    {
+                        method: "POST",
+                        credentials: "include"
+                    }
+                );
+            } catch (error) {
+                console.warn(
+                    "탈퇴 후 토큰 정리 실패",
+                    error
                 );
             }
 

--- a/src/main/resources/templates/archive/archive.html
+++ b/src/main/resources/templates/archive/archive.html
@@ -1,26 +1,83 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
+
 <head>
     <meta charset="UTF-8">
-    <title>차용증 보관함 (임시)</title>
-    <link rel="stylesheet" th:href="@{/css/archive/archive.css}">
-    <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}">
+
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0">
+
+    <title>차용증 보관함 | 사이원장</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
+    <link
+            rel="stylesheet"
+            th:href="@{/css/archive/archive.css}"
+            href="/css/archive/archive.css">
+
 </head>
-<body>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
+</header>
+<main class="archive-container">
 
-<div class="archive-container">
-    <h1>차용증 보관함</h1>
-    <p class="subtitle">저장된 차용증을 눌러 상세 화면을 확인하세요. (임시 페이지)</p>
+    <div class="archive-heading">
+        <h1>차용증 보관함</h1>
 
-    <div class="archive-list" id="archiveList"></div>
-
-    <div class="pager" id="pager" style="display:none;">
-        <button id="prevPageBtn" type="button">이전</button>
-        <span id="pageLabel" class="pager-label"></span>
-        <button id="nextPageBtn" type="button">다음</button>
+        <p class="subtitle">
+            저장된 차용증을 눌러 상세 화면을 확인하세요.
+        </p>
     </div>
-</div>
 
-<script th:src="@{/js/archive/archive.js}"></script>
+
+    <div
+            class="archive-list"
+            id="archiveList">
+    </div>
+
+
+    <div
+            class="pager"
+            id="pager"
+            style="display: none;">
+
+        <button
+                id="prevPageBtn"
+                type="button">
+            이전
+        </button>
+
+        <span
+                id="pageLabel"
+                class="pager-label">
+        </span>
+
+        <button
+                id="nextPageBtn"
+                type="button">
+            다음
+        </button>
+
+    </div>
+
+</main>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+<script
+        th:src="@{/js/archive/archive.js}"
+        src="/js/archive/archive.js">
+</script>
+
+
 </body>
 </html>

--- a/src/main/resources/templates/contract/contract-complete.html
+++ b/src/main/resources/templates/contract/contract-complete.html
@@ -5,30 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>금전소비대차계약 체결 완료</title>
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
     <link rel="stylesheet" th:href="@{/css/contract/contract-complete.css}" href="../../static/css/contract/contract-complete.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="topnav">
-  <div class="topnav__inner">
-    <div class="topnav__logo">사이원장</div>
-
-    <nav class="topnav__menu">
-      <a class="topnav__link" href="#">서비스 소개</a>
-      <a class="topnav__link is-active" href="#">금전소비대차</a>
-      <a class="topnav__link" href="#">정산관리</a>
-      <a class="topnav__link" href="#">거래 일정</a>
-    </nav>
-
-    <a class="topnav__bell" href="/notifications" aria-label="알림">
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-        <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-    </a>
-  </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="page">
@@ -125,19 +111,13 @@
   </div>
 </main>
 
-<footer class="site-footer">
-  <div class="footer-inner">
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-  </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contract/contract-complete.js}" src="../../static/js/contract/contract-complete.js"></script>
 </body>

--- a/src/main/resources/templates/contract/contract-debtor-form.html
+++ b/src/main/resources/templates/contract/contract-debtor-form.html
@@ -6,32 +6,16 @@
   <title>금전차용계약서 확인 (채무자)</title>
   <link rel="stylesheet" as="style" crossorigin
         href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <th:block
+          th:replace="~{fragments/app-shell :: commonStyles}">
+  </th:block>
   <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-debtor-approve.css}" href="../../static/css/contract/contract-debtor-approve.css" />
 </head>
-<body>
-
-<header class="topnav">
-  <div class="topnav__inner">
-    <div class="topnav__logo">사이원장</div>
-
-    <nav class="topnav__menu">
-      <a class="topnav__link" href="#">서비스 소개</a>
-      <a class="topnav__link is-active" href="#">금전소비대차</a>
-      <a class="topnav__link" href="#">정산관리</a>
-      <a class="topnav__link" href="#">거래 일정</a>
-    </nav>
-
-    <a class="topnav__bell" href="/notifications" aria-label="알림">
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-        <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-    </a>
-  </div>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
-
 <main class="page">
 
   <!-- stepper-card: .doc 과 같은 부모(.page) 아래에서 폭을 지정하지 않으므로
@@ -189,19 +173,12 @@
   </form>
 </main>
 
-<footer class="site-footer">
-  <div class="footer-inner">
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-  </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contract/contract-debtor-form.js}" src="../../static/js/contract/contract-debtor-form.js"></script>
 </body>

--- a/src/main/resources/templates/contract/contract-debtor-signature.html
+++ b/src/main/resources/templates/contract/contract-debtor-signature.html
@@ -6,30 +6,15 @@
   <title>금전차용계약서 전자서명 (채무자)</title>
   <link rel="stylesheet" as="style" crossorigin
         href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <th:block
+          th:replace="~{fragments/app-shell :: commonStyles}">
+  </th:block>
   <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-debtor-approve.css}" href="../../static/css/contract/contract-debtor-approve.css" />
 </head>
-<body>
-
-<header class="topnav">
-  <div class="topnav__inner">
-    <div class="topnav__logo">사이원장</div>
-
-    <nav class="topnav__menu">
-      <a class="topnav__link" href="#">서비스 소개</a>
-      <a class="topnav__link is-active" href="#">금전소비대차</a>
-      <a class="topnav__link" href="#">정산관리</a>
-      <a class="topnav__link" href="#">거래 일정</a>
-    </nav>
-
-    <a class="topnav__bell" href="/notifications" aria-label="알림">
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-        <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-    </a>
-  </div>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="page">
@@ -89,19 +74,12 @@
   </div>
 </main>
 
-<footer class="site-footer">
-  <div class="footer-inner">
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-  </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contract/contract-debtor-signature.js}" src="../../static/js/contract/contract-debtor-signature.js"></script>
 </body>

--- a/src/main/resources/templates/contract/contract-form.html
+++ b/src/main/resources/templates/contract/contract-form.html
@@ -4,32 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>금전차용계약서 작성</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" as="style" crossorigin
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
     <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="topnav">
-  <div class="topnav__inner">
-    <div class="topnav__logo">사이원장</div>
-
-        <nav class="topnav__menu">
-            <a class="topnav__link" href="#">서비스 소개</a>
-            <a class="topnav__link is-active" href="#">금전소비대차</a>
-            <a class="topnav__link" href="#">정산관리</a>
-            <a class="topnav__link" href="#">거래 일정</a>
-        </nav>
-
-    <a class="topnav__bell" href="/notifications" aria-label="알림">
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-        <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-    </a>
-  </div>
-</header>
+<header th:replace="~{fragments/app-shell :: appHeader('contract')}"></header>
 
 <main class="page">
   <div class="stepper-card">
@@ -225,20 +209,9 @@
     </form>
 </main>
 
-<footer class="site-footer">
-  <div class="footer-inner">
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-  </div>
-</footer>
+<footer th:replace="~{fragments/app-shell :: appFooter}"></footer>
 
-<script th:src="@{/js/contract/contract-form.js}" src="../../static/js/contract/contract-form.js"></script>
+<th:block th:replace="~{fragments/app-shell :: commonScripts}"></th:block>
+<script th:src="@{/js/contract/contract-form.js}" src="/js/contract/contract-form.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/contract/contract-signature.html
+++ b/src/main/resources/templates/contract/contract-signature.html
@@ -6,30 +6,16 @@
   <title>금전차용계약서 서명 | 사이원장</title>
   <link rel="stylesheet" as="style" crossorigin
         href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <th:block
+          th:replace="~{fragments/app-shell :: commonStyles}">
+  </th:block>
   <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
   <link rel="stylesheet" th:href="@{/css/contract/contract-debtor-approve.css}" href="../../static/css/contract/contract-debtor-approve.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="topnav">
-  <div class="topnav__inner">
-    <div class="topnav__logo">사이원장</div>
-
-    <nav class="topnav__menu">
-      <a class="topnav__link" href="#">서비스 소개</a>
-      <a class="topnav__link is-active" href="#">금전소비대차</a>
-      <a class="topnav__link" href="#">정산관리</a>
-      <a class="topnav__link" href="#">거래 일정</a>
-    </nav>
-
-    <a class="topnav__bell" href="/notifications" aria-label="알림">
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-        <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-    </a>
-  </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="page">
@@ -110,19 +96,12 @@
   </div>
 </main>
 
-<footer class="site-footer">
-  <div class="footer-inner">
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-  </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contract/contract-signature.js}" src="../../static/js/contract/contract-signature.js"></script>
 </body>

--- a/src/main/resources/templates/contractchange/contract-edit-complete.html
+++ b/src/main/resources/templates/contractchange/contract-edit-complete.html
@@ -5,27 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>금전소비대차계약 수정 완료</title>
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contract/contract-edit-complete.css}" href="../../static/css/contract/contract-edit-complete.css" />
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="success-container">
@@ -73,20 +62,13 @@
         </button>
     </footer>
 </main>
-
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contractchange/contract-edit-complete.js}" src="../../static/js/contractchange/contract-edit-complete.js"></script>
 </body>

--- a/src/main/resources/templates/contractchange/request.html
+++ b/src/main/resources/templates/contractchange/request.html
@@ -3,27 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <title>계약 조건 변경 요청</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contractchange/contractchange.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <input type="hidden" id="contractId" th:value="${contractId}">
@@ -86,19 +75,12 @@
 
 <script th:src="@{/js/contractchange/contractchange.js}"></script>
 
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 </body>
 </html>

--- a/src/main/resources/templates/contractchangedetail/request-detail.html
+++ b/src/main/resources/templates/contractchangedetail/request-detail.html
@@ -3,27 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <title>변경 요청 수신 화면</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contractchangedetail/request-detail.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 
@@ -121,19 +110,12 @@
 
 <script th:src="@{/js/contractchangedetail/request-detail.js}"></script>
 
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 </body>
 </html>

--- a/src/main/resources/templates/contractdashboard/dashboard.html
+++ b/src/main/resources/templates/contractdashboard/dashboard.html
@@ -3,27 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <title>계약대시보드</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contractdashboard/contract-dashboard.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <div class="dashboard-page">
@@ -107,21 +96,12 @@
 
 
 </div>
-
-<script th:src="@{/js/contractdashboard/contract-dashboard.js}"></script>
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
-
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+<script th:src="@{/js/contractdashboard/contract-dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/contractdetail/detail.html
+++ b/src/main/resources/templates/contractdetail/detail.html
@@ -6,28 +6,17 @@
     <title>금전차용계약서 조회 | 사이원장</title>
     <link rel="stylesheet" as="style" crossorigin
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" />
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 <input type="hidden" id="contractId" th:value="${contractId}">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="page">
@@ -128,19 +117,12 @@
     </div>
 </main>
 
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
 <script th:src="@{/js/contractdetail/contractdetail.js}"></script>
 </body>

--- a/src/main/resources/templates/contractrepaymentschedule/schedule.html
+++ b/src/main/resources/templates/contractrepaymentschedule/schedule.html
@@ -3,29 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <title>상환현황 상세조회</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/contractrepaymentschedule/contractrepaymentschedule.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-
-
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a class="active" href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a href="#">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <div class="schedule-container">
@@ -104,22 +91,13 @@
         금액은 원 단위 미만을 반올림하여 표시됩니다.
     </p>
 </div>
-
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 <script th:src="@{/js/contractrepaymentschedule/contractrepaymentschedule.js}"></script>
-
-    <footer class="site-footer">
-        <div class="footer-inner">
-            <div>
-                <strong>사이원장</strong>
-                <p>© Sai-Wonjang. All rights reserved.</p>
-            </div>
-            <nav>
-                <a href="#">이용약관</a>
-                <a href="#">개인정보처리방침</a>
-                <a href="#">고객센터</a>
-            </nav>
-        </div>
-    </footer>
 
 
 </body>

--- a/src/main/resources/templates/fragments/app-shell.html
+++ b/src/main/resources/templates/fragments/app-shell.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
+
+<body>
+
+
+<!-- ① 공통 CSS -->
+<th:block th:fragment="commonStyles">
+
+    <link
+            rel="stylesheet"
+            th:href="@{/css/common/app-shell.css}">
+
+</th:block>
+
+
+
+<!-- ② 공통 Header -->
+<header
+        th:fragment="appHeader(activeMenu)"
+        class="app-header">
+
+    <a
+            class="app-brand"
+            th:href="@{/integration/dashboard}"
+            aria-label="사이원장 홈">
+
+        <span class="app-brand__mark">S</span>
+        <span class="app-brand__name">사이원장</span>
+
+    </a>
+
+
+    <nav
+            class="app-nav"
+            aria-label="주요 메뉴">
+
+        <a
+                class="app-nav__link"
+                th:classappend="${activeMenu == 'dashboard'} ? ' is-active' : ''"
+                th:href="@{/integration/dashboard}">
+            대시보드
+        </a>
+
+        <a
+                class="app-nav__link"
+                th:classappend="${activeMenu == 'settlement'} ? ' is-active' : ''"
+                th:href="@{/settlements}">
+            정산
+        </a>
+
+        <a
+                class="app-nav__link"
+                th:classappend="${activeMenu == 'contract'} ? ' is-active' : ''"
+                th:href="@{/dashboard}">
+            금전소비대차
+        </a>
+
+        <a
+                class="app-nav__link"
+                th:classappend="${activeMenu == 'calendar'} ? ' is-active' : ''"
+                href="#">
+            캘린더
+        </a>
+
+    </nav>
+
+
+    <div
+            class="app-header-actions"
+            aria-label="사용자 메뉴">
+
+        <a
+                class="app-icon-button"
+                th:href="@{/notifications}"
+                aria-label="알림">
+            !
+        </a>
+
+        <a
+                class="app-profile-button"
+                th:href="@{/mypage}">
+            마이페이지
+        </a>
+
+    </div>
+
+</header>
+
+
+
+<!-- ③ 공통 Footer -->
+<footer
+        th:fragment="appFooter"
+        class="app-footer">
+
+    <div>
+        <strong>사이원장</strong>
+
+        <p>
+            정산과 차용증 거래를 한 곳에서 확인하세요.
+        </p>
+    </div>
+
+    <nav aria-label="푸터 메뉴">
+        <a href="#">이용약관</a>
+        <a href="#">개인정보처리방침</a>
+        <a href="#">고객센터</a>
+    </nav>
+
+</footer>
+
+
+
+<!-- ④ 공통 JS -->
+<th:block th:fragment="commonScripts">
+
+    <script
+            th:src="@{/js/common/auth.js}">
+    </script>
+
+</th:block>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/identity/identity-test.html
+++ b/src/main/resources/templates/identity/identity-test.html
@@ -11,7 +11,9 @@
 
     <link rel="stylesheet" as="style" crossorigin
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
-
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet"
           href="/css/identity/identity-test.css"
           th:href="@{/css/identity/identity-test.css}">
@@ -24,27 +26,10 @@
     </script>
 </head>
 
-<body>
+<body class="app-shell-page">
 
-<header class="topnav">
-    <div class="topnav__inner">
-        <div class="topnav__logo">사이원장</div>
-
-        <nav class="topnav__menu">
-            <a class="topnav__link" href="#">서비스 소개</a>
-            <a class="topnav__link is-active" href="#">금전소비대차</a>
-            <a class="topnav__link" href="#">정산관리</a>
-            <a class="topnav__link" href="#">거래 일정</a>
-        </nav>
-
-        <a class="topnav__bell" href="/notifications" aria-label="알림">
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" aria-hidden="true">
-                <path d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-            </svg>
-            <span class="topnav__bell-badge" id="topnavBellBadge" hidden></span>
-        </a>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('contract')}">
 </header>
 
 <main class="page">
@@ -116,21 +101,11 @@
     </section>
 
 </main>
-
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
-
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 </body>
 </html>

--- a/src/main/resources/templates/integration/dashboard.html
+++ b/src/main/resources/templates/integration/dashboard.html
@@ -4,26 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>사이원장 통합 대시보드</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" th:href="@{/css/integration/dashboard.css}" href="/css/integration/dashboard.css">
 </head>
-<body>
-<div class="dashboard-shell">
-    <header class="site-header">
-        <a class="brand" href="/integration/dashboard" aria-label="사이원장 홈">
-            <span class="brand__mark">S</span>
-            <span class="brand__name">사이원장</span>
-        </a>
-        <nav class="site-nav" aria-label="주요 메뉴">
-            <a class="site-nav__link is-active" href="/integration/dashboard">대시보드</a>
-            <a class="site-nav__link" href="/settlements">정산</a>
-            <a class="site-nav__link" href="/dashboard">금전소비대차</a>
-            <a class="site-nav__link" href="#">캘린더</a>
-        </nav>
-        <div class="header-actions" aria-label="사용자 메뉴">
-            <a class="icon-button" href="/notifications" aria-label="알림">!</a>
-            <a class="profile-button" href="/mypage">마이페이지</a>
-        </div>
-    </header>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('dashboard')}">
+</header>
 
     <main class="dashboard-main">
         <h1 class="page-title">통합 대시보드</h1>
@@ -108,20 +97,16 @@
             </div>
         </section>
     </main>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
 
-    <footer class="site-footer">
-        <div>
-            <strong>사이원장</strong>
-            <p>정산과 차용증 거래를 한 곳에서 확인하세요.</p>
-        </div>
-        <nav aria-label="푸터 메뉴">
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </footer>
-</div>
-
-<script th:src="@{/js/integration/dashboard.js}" src="/js/integration/dashboard.js"></script>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+<script
+        th:src="@{/js/integration/dashboard.js}"
+        src="/js/integration/dashboard.js">
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/notification/notification-center.html
+++ b/src/main/resources/templates/notification/notification-center.html
@@ -1,64 +1,25 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>알림센터 | 사이원장</title>
+  <meta charset="UTF-8">
+  <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0">
 
+  <title>알림 | 사이원장</title>
+  <th:block
+          th:replace="~{fragments/app-shell :: commonStyles}">
+  </th:block>
   <link
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css"
-      rel="stylesheet"
-  />
+          rel="stylesheet"
+          href="/css/notification/notification-center.css">
 
-  <link
-      rel="stylesheet"
-      th:href="@{/css/notification/notification-center.css}"
-      href="./notification-center.css"
-  />
 </head>
 
-<body>
+<body class="app-shell-page">
 
-<header class="topnav">
-  <div class="topnav__inner">
-
-    <a class="topnav__logo" href="/">사이원장</a>
-
-    <nav class="topnav__menu">
-      <a class="topnav__link" href="/">서비스 소개</a>
-      <a class="topnav__link" href="/contracts">금전소비대차</a>
-      <a class="topnav__link" href="/settlements">정산관리</a>
-      <a class="topnav__link" href="/schedule">거래 일정</a>
-    </nav>
-
-    <a
-        class="topnav__bell"
-        href="/notifications"
-        aria-label="알림"
-    >
-      <svg
-          viewBox="0 0 24 24"
-          width="20"
-          height="20"
-          fill="none"
-          aria-hidden="true"
-      >
-        <path
-            d="M12 3a6 6 0 0 0-6 6v3.2c0 .5-.18 1-.5 1.4L4 15.5c-.6.7-.1 1.8.8 1.8h14.4c.9 0 1.4-1.1.8-1.8l-1.5-1.9a2.2 2.2 0 0 1-.5-1.4V9a6 6 0 0 0-6-6Z"
-            stroke="currentColor"
-            stroke-width="1.6"
-            stroke-linejoin="round"
-        />
-        <path
-            d="M9.5 19a2.5 2.5 0 0 0 5 0"
-            stroke="currentColor"
-            stroke-width="1.6"
-            stroke-linecap="round"
-        />
-      </svg>
-    </a>
-
-  </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('notification')}">
 </header>
 
 
@@ -127,29 +88,17 @@
 
 </main>
 
-
-<footer class="site-footer">
-  <div class="footer-inner">
-
-    <div>
-      <strong>사이원장</strong>
-      <p>© Sai-Wonjang. All rights reserved.</p>
-    </div>
-
-    <nav>
-      <a href="#">이용약관</a>
-      <a href="#">개인정보처리방침</a>
-      <a href="#">고객센터</a>
-    </nav>
-
-  </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
 
-
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 <script
-    th:src="@{/js/notification/notification-center.js}"
-    src="./notification-center.js"
-></script>
+        th:src="@{/js/notification/notification-center.js}"
+        src="/js/notification/notification-center.js">
+</script>
 
 </body>
 </html>

--- a/src/main/resources/templates/settlement/settlement-create.html
+++ b/src/main/resources/templates/settlement/settlement-create.html
@@ -1,31 +1,33 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0">
     <title>새로운 정산 만들기 | 사이원장</title>
-    <link rel="stylesheet" href="/css/settlement/settlement-common.css">
-    <link rel="stylesheet" href="/css/settlement/settlement-create.css">
-    <link rel="stylesheet" href="/css/settlement/settlement-create-payer.css">
-    <script src="/js/settlement/settlement-create.js" defer></script>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
+    <link
+            rel="stylesheet"
+            href="/css/settlement/settlement-common.css">
+
+    <link
+            rel="stylesheet"
+            href="/css/settlement/settlement-create.css">
+
+    <link
+            rel="stylesheet"
+            href="/css/settlement/settlement-create-payer.css">
+
 </head>
-<body>
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="/">서비스 소개</a>
-            <a href="/contracts">금전거래대차</a>
-            <a class="active" href="/settlements">정산</a>
-            <a href="/schedule">거래 일정</a>
-        </nav>
-
-        <div class="header-actions">
-            <a class="text-link" href="/login">로그인</a>
-            <a class="button button-primary button-small" href="/signup">회원가입</a>
-        </div>
-    </div>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('settlement')}">
 </header>
 
 <main class="create-shell">
@@ -278,20 +280,22 @@
     </div>
 </main>
 
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<div
+        id="toast"
+        class="toast"
+        role="status"
+        aria-live="polite">
+</div>
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
 
-<div id="toast" class="toast" role="status" aria-live="polite"></div>
+<script
+        th:src="@{/js/settlement/settlement-create.js}"
+        src="/js/settlement/settlement-create.js">
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/settlement/settlement-detail.html
+++ b/src/main/resources/templates/settlement/settlement-detail.html
@@ -1,25 +1,24 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0">
   <title>정산 상세 | 사이원장</title>
-  <link rel="stylesheet" href="/css/settlement/settlement-detail.css">
+  <th:block
+          th:replace="~{fragments/app-shell :: commonStyles}">
+  </th:block>
+  <link
+          rel="stylesheet"
+          href="/css/settlement/settlement-detail.css">
+
 </head>
-<body>
-<header class="site-header">
-  <div class="header-inner">
-    <a class="brand" href="/">
-      <span class="brand-mark"></span><span>사이원장</span>
-    </a>
-    <nav class="main-nav">
-      <a href="/">서비스소개</a>
-      <a href="/contracts">금전소비대차</a>
-      <a class="active" href="/settlements">정산</a>
-      <a href="/calendar">캘린더</a>
-    </nav>
-    <div class="profile-chip"></div>
-  </div>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('settlement')}">
 </header>
 
 <main class="page-shell">
@@ -128,7 +127,22 @@
   </div>
 </main>
 
-<div id="toast" class="toast"></div>
-<script src="/js/settlement/settlement-detail.js"></script>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
+
+
+<div
+        id="toast"
+        class="toast">
+</div>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+<script
+        th:src="@{/js/settlement/settlement-detail.js}"
+        src="/js/settlement/settlement-detail.js">
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/settlement/settlement-list.html
+++ b/src/main/resources/templates/settlement/settlement-list.html
@@ -1,33 +1,17 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>내 정산 | 사이원장</title>
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet" href="/css/settlement/settlement-common.css">
     <link rel="stylesheet" href="/css/settlement/settlement-list.css">
-    <script src="/js/settlement/settlement-list.js" defer></script>
 </head>
-<body>
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/integration/dashboard">사이원장</a>
-
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="/">서비스 소개</a>
-            <a href="/dashboard">금전거래대차</a>
-            <a class="active" href="/settlements">정산</a>
-            <a href="/schedule">거래 일정</a>
-        </nav>
-
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
-</header>
+<body class="app-shell-page">
+<header th:replace="~{fragments/app-shell :: appHeader('settlement')}"></header>
 
 <main class="page-shell">
     <section class="page-heading">
@@ -125,20 +109,11 @@
     </p>
 </main>
 
-<footer class="site-footer">
-    <div class="footer-inner">
-        <div>
-            <strong>사이원장</strong>
-            <p>© Sai-Wonjang. All rights reserved.</p>
-        </div>
-        <nav>
-            <a href="#">이용약관</a>
-            <a href="#">개인정보처리방침</a>
-            <a href="#">고객센터</a>
-        </nav>
-    </div>
-</footer>
+<footer th:replace="~{fragments/app-shell :: appFooter}"></footer>
 
 <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+<th:block th:replace="~{fragments/app-shell :: commonScripts}"></th:block>
+<script th:src="@{/js/settlement/settlement-list.js}" src="/js/settlement/settlement-list.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,19 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet"
           th:href="@{/css/user/login.css}"
           href="/css/user/login.css">
 </head>
-<script th:src="@{/js/user/login.js}"
-        src="/js/user/login.js"
-        defer></script>
 <body>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('mypage')}">
+</header>
 <div class="page">
-    <header class="site-header">
-        <a class="logo" data-route="main" href="/">사이원장</a>
-        <a class="header-link" data-route="signup" href="/signup">회원가입</a>
-    </header>
 
     <main class="auth-main">
         <section class="auth-wrap">
@@ -96,17 +97,19 @@
             </div>
         </section>
     </main>
-
-    <footer class="site-footer">
-        <div class="footer-links">
-            <a href="/terms">이용약관</a>
-            <span>|</span>
-            <a href="/privacy"><strong>개인정보 처리방침</strong></a>
-        </div>
-        <p class="copyright">© 2026 Sai-Wonjang. All rights reserved.</p>
-    </footer>
 </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
 
-<script src="./login.js"></script>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+
+<script
+        th:src="@{/js/user/login.js}"
+        src="/js/user/login.js">
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,52 +9,16 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet"
           th:href="@{/css/user/mypage.css}"
           href="/css/user/mypage.css">
 </head>
-<script th:src="@{/js/user/mypage.js}"
-        src="/js/user/mypage.js"
-        defer></script>
-<body>
-<header class="top-header">
-    <nav class="breadcrumb">
-        <a data-route="main" href="/">메인</a>
-        <span>›</span>
-        <strong>내 정보</strong>
-    </nav>
-
-    <div class="header-tools">
-        <label class="search-box">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-                <circle cx="11" cy="11" r="8"></circle>
-                <path d="m21 21-4.3-4.3"></path>
-            </svg>
-            <input type="search" placeholder="검색어 입력">
-        </label>
-
-        <button class="icon-button notification-button"
-                type="button"
-                aria-label="알림">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"></path>
-                <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
-            </svg>
-            <span></span>
-        </button>
-
-        <strong id="header-user-name" class="header-user-name"></strong>
-
-        <div class="header-profile">
-            <img id="header-profile-image" alt="프로필 이미지" hidden>
-            <svg id="header-profile-placeholder"
-                 viewBox="0 0 24 24"
-                 aria-hidden="true">
-                <circle cx="12" cy="8" r="4"></circle>
-                <path d="M4 21a8 8 0 0 1 16 0"></path>
-            </svg>
-        </div>
-    </div>
+<body class="app-shell-page">
+<header
+        th:replace="~{fragments/app-shell :: appHeader('mypage')}">
 </header>
 
 <main class="mypage-main">
@@ -163,7 +129,19 @@
         </span>
     </section>
 </main>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
 
-<script src="/js/user/mypage.js"></script>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+
+
+<script
+        th:src="@{/js/user/mypage.js}"
+        src="/js/user/mypage.js">
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,19 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
     <link rel="stylesheet"
           th:href="@{/css/user/signup.css}"
           href="/css/user/signup.css">
 </head>
-<script th:src="@{/js/user/signup.js}"
-        src="/js/user/signup.js"
-        defer></script>
 <body>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('mypage')}">
+</header>
 <div class="page">
-    <header class="site-header">
-        <a class="logo" data-route="main" href="/">사이원장</a>
-        <a class="header-link" data-route="login" href="/login">로그인</a>
-    </header>
 
     <main class="auth-main">
         <section class="auth-wrap">
@@ -108,17 +109,19 @@
             </div>
         </section>
     </main>
-
-    <footer class="site-footer">
-        <div class="footer-links">
-            <a href="/terms">이용약관</a>
-            <span>|</span>
-            <a href="/privacy"><strong>개인정보 처리방침</strong></a>
-        </div>
-        <p class="copyright">© 2026 Sai-Wonjang. All rights reserved.</p>
-    </footer>
 </div>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
 
-<script src="./signup.js"></script>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+
+<script
+        th:src="@{/js/user/signup.js}"
+        src="/js/user/signup.js">
+</script>
 </body>
 </html>

--- a/src/test/java/org/teamsai/saibackend/domain/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/jwt/JwtTokenProviderTest.java
@@ -20,14 +20,23 @@ class JwtTokenProviderTest {
 
     private static final long ACCESS_TOKEN_EXPIRATION_MS =
             60 * 60 * 1000L;
+
+    private static final long REFRESH_TOKEN_EXPIRATION_MS =
+            14 * 24 * 60 * 60 * 1000L;
+
     private static final long LINK_STATE_EXPIRATION_MS =
             10 * 60 * 1000L;
+
+    private static final String LINK_IDENTITY_HASH_SECRET =
+            "test-link-identity-secret";
+
     private static final Long USER_ID = 1L;
-    private static final String TEST_LINK_IDENTITY_HASH_SECRET = "test-link-identity-secret";
 
     private String accessSecret;
     private String linkStateSecret;
-    private SecretKey signingKey;
+
+    private SecretKey accessSigningKey;
+
     private JwtTokenProvider jwtTokenProvider;
 
     @BeforeEach
@@ -35,21 +44,29 @@ class JwtTokenProviderTest {
         byte[] accessKeyBytes =
                 "01234567890123456789012345678901"
                         .getBytes(StandardCharsets.UTF_8);
-        accessSecret = Encoders.BASE64.encode(accessKeyBytes);
-        signingKey = Keys.hmacShaKeyFor(accessKeyBytes);
 
         byte[] linkStateKeyBytes =
                 "98765432109876543210987654321098"
                         .getBytes(StandardCharsets.UTF_8);
-        linkStateSecret = Encoders.BASE64.encode(linkStateKeyBytes);
 
-        jwtTokenProvider = new JwtTokenProvider(
-                accessSecret,
-                linkStateSecret,
-                ACCESS_TOKEN_EXPIRATION_MS,
-                LINK_STATE_EXPIRATION_MS,
-                TEST_LINK_IDENTITY_HASH_SECRET
-        );
+        accessSecret =
+                Encoders.BASE64.encode(accessKeyBytes);
+
+        linkStateSecret =
+                Encoders.BASE64.encode(linkStateKeyBytes);
+
+        accessSigningKey =
+                Keys.hmacShaKeyFor(accessKeyBytes);
+
+        jwtTokenProvider =
+                new JwtTokenProvider(
+                        accessSecret,
+                        linkStateSecret,
+                        ACCESS_TOKEN_EXPIRATION_MS,
+                        REFRESH_TOKEN_EXPIRATION_MS,
+                        LINK_STATE_EXPIRATION_MS,
+                        LINK_IDENTITY_HASH_SECRET
+                );
     }
 
     @Test
@@ -68,37 +85,41 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("subject가 숫자가 아니면 유효하지 않은 토큰으로 처리한다")
     void nonNumericSubjectIsInvalid() {
-        String token = createToken(
-                "SAI-ABCDEFGH",
-                new Date(
-                        System.currentTimeMillis()
-                                + ACCESS_TOKEN_EXPIRATION_MS
-                ),
-                signingKey
-        );
+        String token =
+                createAccessToken(
+                        "SAI-ABCDEFGH",
+                        new Date(
+                                System.currentTimeMillis()
+                                        + ACCESS_TOKEN_EXPIRATION_MS
+                        ),
+                        accessSigningKey
+                );
 
         Optional<Long> parsedUserId =
                 jwtTokenProvider.getUserIdIfValid(token);
 
-        assertThat(parsedUserId).isEmpty();
+        assertThat(parsedUserId)
+                .isEmpty();
     }
 
     @Test
     @DisplayName("만료된 토큰은 유효하지 않은 토큰으로 처리한다")
     void expiredTokenIsInvalid() {
-        String token = createToken(
-                String.valueOf(USER_ID),
-                new Date(
-                        System.currentTimeMillis()
-                                - 1000L
-                ),
-                signingKey
-        );
+        String token =
+                createAccessToken(
+                        String.valueOf(USER_ID),
+                        new Date(
+                                System.currentTimeMillis()
+                                        - 1000L
+                        ),
+                        accessSigningKey
+                );
 
         Optional<Long> parsedUserId =
                 jwtTokenProvider.getUserIdIfValid(token);
 
-        assertThat(parsedUserId).isEmpty();
+        assertThat(parsedUserId)
+                .isEmpty();
     }
 
     @Test
@@ -107,43 +128,83 @@ class JwtTokenProviderTest {
         byte[] otherKeyBytes =
                 "abcdefghijklmnopqrstuvwxyz123456"
                         .getBytes(StandardCharsets.UTF_8);
+
         SecretKey otherSigningKey =
                 Keys.hmacShaKeyFor(otherKeyBytes);
 
-        String token = createToken(
-                String.valueOf(USER_ID),
-                new Date(
-                        System.currentTimeMillis()
-                                + ACCESS_TOKEN_EXPIRATION_MS
-                ),
-                otherSigningKey
-        );
+        String token =
+                createAccessToken(
+                        String.valueOf(USER_ID),
+                        new Date(
+                                System.currentTimeMillis()
+                                        + ACCESS_TOKEN_EXPIRATION_MS
+                        ),
+                        otherSigningKey
+                );
 
         Optional<Long> parsedUserId =
                 jwtTokenProvider.getUserIdIfValid(token);
 
-        assertThat(parsedUserId).isEmpty();
+        assertThat(parsedUserId)
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("RefreshToken은 AccessToken으로 사용할 수 없다")
+    void refreshTokenCannotBeUsedAsAccessToken() {
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(USER_ID);
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdIfValid(refreshToken);
+
+        assertThat(parsedUserId)
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("RefreshToken에서 userId를 정상적으로 추출한다")
+    void getUserIdFromRefreshToken() {
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(USER_ID);
+
+        Optional<Long> parsedUserId =
+                jwtTokenProvider.getUserIdFromRefreshToken(
+                        refreshToken
+                );
+
+        assertThat(parsedUserId)
+                .contains(USER_ID);
     }
 
     @Test
     @DisplayName("createAccessToken으로 만든 토큰은 getUserIdFromLinkState로 검증되지 않는다")
     void accessTokenIsNotValidAsLinkState() {
-        String accessToken = jwtTokenProvider.createAccessToken(USER_ID);
+        String accessToken =
+                jwtTokenProvider.createAccessToken(USER_ID);
 
         Optional<Long> parsedUserId =
-                jwtTokenProvider.getUserIdFromLinkState(accessToken);
+                jwtTokenProvider.getUserIdFromLinkState(
+                        accessToken
+                );
 
-        assertThat(parsedUserId).isEmpty();
+        assertThat(parsedUserId)
+                .isEmpty();
     }
 
-    private String createToken(
+    private String createAccessToken(
             String subject,
             Date expiration,
             SecretKey key
     ) {
         Date issuedAt = new Date();
+
         return Jwts.builder()
                 .subject(subject)
+                .claim(
+                        "purpose",
+                        "access"
+                )
                 .issuedAt(issuedAt)
                 .expiration(expiration)
                 .signWith(key)

--- a/src/test/java/org/teamsai/saibackend/domain/user/AuthServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/user/AuthServiceTest.java
@@ -16,14 +16,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.teamsai.saibackend.domain.user.dto.UserDTO;
+import org.teamsai.saibackend.domain.user.dto.UserLoginDTO;
 import org.teamsai.saibackend.domain.user.dto.request.UserLoginRequest;
 import org.teamsai.saibackend.domain.user.dto.request.UserSignUpRequest;
-import org.teamsai.saibackend.domain.user.dto.response.UserLoginResponse;
+import org.teamsai.saibackend.domain.user.dto.response.AccessTokenResponse;
 import org.teamsai.saibackend.domain.user.dto.response.UserSignUpResponse;
 import org.teamsai.saibackend.domain.user.exception.UserErrorCode;
 import org.teamsai.saibackend.domain.user.mapper.UserMapper;
 import org.teamsai.saibackend.domain.user.service.AuthService;
 import org.teamsai.saibackend.domain.user.service.AuthValidator;
+import org.teamsai.saibackend.domain.user.service.RefreshTokenService;
 import org.teamsai.saibackend.global.exception.DomainException;
 import org.teamsai.saibackend.global.jwt.JwtTokenProvider;
 
@@ -35,10 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AuthService 단위 테스트")
@@ -66,6 +65,9 @@ class AuthServiceTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @InjectMocks
     private AuthService authService;
@@ -320,7 +322,7 @@ class AuthServiceTest {
             given(jwtTokenProvider.createAccessToken(USER_ID))
                     .willReturn("access-token");
 
-            UserLoginResponse response =
+            UserLoginDTO response =
                     authService.login(request);
 
             verify(authValidator)
@@ -405,6 +407,194 @@ class AuthServiceTest {
 
             verify(jwtTokenProvider, never())
                     .createAccessToken(anyLong());
+        }
+        @Nested
+        @DisplayName("AccessToken 재발급")
+        class Reissue {
+
+            private static final String REFRESH_TOKEN = "refresh-token";
+            private static final String NEW_ACCESS_TOKEN = "new-access-token";
+            private static final Long USER_ID = 1L;
+
+            @Test
+            @DisplayName("유효한 RefreshToken이고 Redis 값과 일치하면 AccessToken을 재발급한다")
+            void reissueSuccess() {
+                given(
+                        jwtTokenProvider.getUserIdFromRefreshToken(
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(
+                        Optional.of(USER_ID)
+                );
+
+                given(
+                        refreshTokenService.matches(
+                                USER_ID,
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(true);
+
+                given(
+                        jwtTokenProvider.createAccessToken(
+                                USER_ID
+                        )
+                ).willReturn(
+                        NEW_ACCESS_TOKEN
+                );
+
+                AccessTokenResponse response =
+                        authService.reissue(
+                                REFRESH_TOKEN
+                        );
+
+                assertThat(
+                        response.getAccessToken()
+                ).isEqualTo(
+                        NEW_ACCESS_TOKEN
+                );
+
+                verify(refreshTokenService)
+                        .matches(
+                                USER_ID,
+                                REFRESH_TOKEN
+                        );
+
+                verify(jwtTokenProvider)
+                        .createAccessToken(
+                                USER_ID
+                        );
+            }
+
+            @Test
+            @DisplayName("만료되거나 조작된 RefreshToken이면 재발급에 실패한다")
+            void reissueFailsWhenRefreshTokenIsInvalid() {
+                given(
+                        jwtTokenProvider.getUserIdFromRefreshToken(
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(
+                        Optional.empty()
+                );
+
+                assertThatThrownBy(
+                        () -> authService.reissue(
+                                REFRESH_TOKEN
+                        )
+                ).isInstanceOf(
+                        DomainException.class
+                );
+
+                verify(
+                        refreshTokenService,
+                        never()
+                ).matches(
+                        anyLong(),
+                        anyString()
+                );
+
+                verify(
+                        jwtTokenProvider,
+                        never()
+                ).createAccessToken(
+                        anyLong()
+                );
+            }
+
+            @Test
+            @DisplayName("RefreshToken이 Redis에 저장된 값과 다르면 재발급에 실패한다")
+            void reissueFailsWhenRedisTokenDoesNotMatch() {
+                given(
+                        jwtTokenProvider.getUserIdFromRefreshToken(
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(
+                        Optional.of(USER_ID)
+                );
+
+                given(
+                        refreshTokenService.matches(
+                                USER_ID,
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(false);
+
+                assertThatThrownBy(
+                        () -> authService.reissue(
+                                REFRESH_TOKEN
+                        )
+                ).isInstanceOf(
+                        DomainException.class
+                );
+
+                verify(
+                        jwtTokenProvider,
+                        never()
+                ).createAccessToken(
+                        anyLong()
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("로그아웃")
+        class Logout {
+
+            private static final String REFRESH_TOKEN = "refresh-token";
+            private static final Long USER_ID = 1L;
+
+            @Test
+            @DisplayName("유효한 RefreshToken이면 Redis에서 RefreshToken을 삭제한다")
+            void logoutDeletesRefreshToken() {
+                given(
+                        jwtTokenProvider.getUserIdFromRefreshToken(
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(
+                        Optional.of(USER_ID)
+                );
+
+                given(
+                        refreshTokenService.matches(
+                                USER_ID,
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(true);
+
+                authService.logout(
+                        REFRESH_TOKEN
+                );
+
+                verify(refreshTokenService)
+                        .delete(USER_ID);
+            }
+
+            @Test
+            @DisplayName("Redis의 RefreshToken과 일치하지 않으면 삭제하지 않는다")
+            void logoutDoesNotDeleteWhenTokenDoesNotMatch() {
+                given(
+                        jwtTokenProvider.getUserIdFromRefreshToken(
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(
+                        Optional.of(USER_ID)
+                );
+
+                given(
+                        refreshTokenService.matches(
+                                USER_ID,
+                                REFRESH_TOKEN
+                        )
+                ).willReturn(false);
+
+                authService.logout(
+                        REFRESH_TOKEN
+                );
+
+                verify(
+                        refreshTokenService,
+                        never()
+                ).delete(anyLong());
+            }
         }
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/user/RefreshTokenServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/user/RefreshTokenServiceTest.java
@@ -1,0 +1,114 @@
+package org.teamsai.saibackend.domain.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.teamsai.saibackend.domain.user.service.RefreshTokenService;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshTokenService 단위 테스트")
+class RefreshTokenServiceTest {
+
+    private static final Long USER_ID = 1L;
+
+    private static final String REFRESH_TOKEN =
+            "refresh-token";
+
+    private static final long REFRESH_TOKEN_EXPIRATION_MS =
+            14 * 24 * 60 * 60 * 1000L;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(
+                refreshTokenService,
+                "refreshTokenExpirationMs",
+                REFRESH_TOKEN_EXPIRATION_MS
+        );
+    }
+
+    @Test
+    @DisplayName("RefreshToken을 만료시간과 함께 Redis에 저장한다")
+    void saveRefreshToken() {
+        given(
+                redisTemplate.opsForValue()
+        ).willReturn(
+                valueOperations
+        );
+
+        refreshTokenService.save(
+                USER_ID,
+                REFRESH_TOKEN
+        );
+
+        verify(valueOperations)
+                .set(
+                        "auth:refresh:" + USER_ID,
+                        REFRESH_TOKEN,
+                        Duration.ofMillis(
+                                REFRESH_TOKEN_EXPIRATION_MS
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 RefreshToken과 같으면 true를 반환한다")
+    void matchesRefreshToken() {
+        given(
+                redisTemplate.opsForValue()
+        ).willReturn(
+                valueOperations
+        );
+
+        given(
+                valueOperations.get(
+                        "auth:refresh:" + USER_ID
+                )
+        ).willReturn(
+                REFRESH_TOKEN
+        );
+
+        boolean result =
+                refreshTokenService.matches(
+                        USER_ID,
+                        REFRESH_TOKEN
+                );
+
+        assertThat(result)
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 Redis의 RefreshToken을 삭제한다")
+    void deleteRefreshToken() {
+        refreshTokenService.delete(
+                USER_ID
+        );
+
+        verify(redisTemplate)
+                .delete(
+                        "auth:refresh:" + USER_ID
+                );
+    }
+}


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #134 

## 🛠 작업 사항

- AccessToken + RefreshToken 기반 JWT 인증 구조 적용
- Redis를 활용한 RefreshToken 저장 및 검증 로직 추가
- RefreshToken HttpOnly Cookie 적용
- AccessToken 재발급 및 로그아웃 처리 구현
- 프론트 인증 요청을 `authFetch` 기반으로 공통화하는 과정에서 footer, header 모두 통일

### 인증 구조 적용 이유

- AccessToken은 API 요청에 자주 사용되므로 로그인 Response를 통해 전달하고 클라이언트에서 관리
- RefreshToken은 장기간 유지되는 토큰이므로 JavaScript에서 직접 접근할 수 없도록 Response Body에 포함하지 않고 `HttpOnly Cookie`로 관리
- RefreshToken을 JWT 자체 검증만으로 사용하지 않고 Redis에도 저장하여 서버에서 토큰의 유효 여부를 제어할 수 있도록 구성
- AccessToken 만료 시 Cookie로 전달된 RefreshToken의 `userId`를 확인한 뒤, Redis에 저장된 RefreshToken과 일치하는지 비교하여 AccessToken 재발급
- 로그아웃 시 Redis의 RefreshToken을 제거하여 이후 해당 RefreshToken을 이용한 재발급을 차단

### 인증 흐름

`로그인`
→ AccessToken은 Response Body로 반환  
→ RefreshToken은 HttpOnly Cookie로 저장  
→ 동일한 RefreshToken을 Redis에 `auth:refresh:{userId}` 형태로 저장

`AccessToken 만료`
→ RefreshToken Cookie를 `/api/auth/reissue`로 전달  
→ RefreshToken에서 userId 확인  
→ Redis의 `auth:refresh:{userId}` 값과 Cookie의 RefreshToken 비교  
→ 일치할 경우에만 새로운 AccessToken 발급

`로그아웃`
→ Redis RefreshToken 삭제  
→ RefreshToken Cookie 만료 처리

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- application.yml 파일 수정 사항 있습니다. 
- redis 환경 설정이 필요합니다. 
- ### Redis 실행 필요

  - RefreshToken 저장 및 검증에 Redis를 사용하므로 로컬 실행 시 Redis가 실행되어 있어야 합니다.

   Docker 사용 시:

   ```bash 
    docker run --name sai-redis -p 6379:6379 -d redis:7-alpine