### PR TITLE
feat(#136): 대여 일정 캘린더 기능 (월간 그리드 + 날짜별 상세)

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/calendar/controller/CalendarController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,7 +40,7 @@ public class CalendarController {
     @GetMapping("/api/dashboard/calendar/{date}")
     public List<DashboardCalendarItemResponse> getCalendarDayDetail(
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-08-14")
-            @PathVariable LocalDate date,
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
 
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {

--- a/src/main/java/org/teamsai/saibackend/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/calendar/controller/CalendarController.java
@@ -1,0 +1,54 @@
+package org.teamsai.saibackend.domain.calendar.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.teamsai.saibackend.domain.calendar.response.DashboardCalendarItemResponse;
+import org.teamsai.saibackend.domain.integration.service.IntegrationDashboardService;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(
+        name = "캘린더 API",
+        description = "통합대시보드에서 전체보기 클릭 시 정산, 금전소비대차 목록을 캘린더에서 확인 가능"
+)
+@Controller
+@RequiredArgsConstructor
+public class CalendarController {
+
+    private final IntegrationDashboardService integrationDashboardService;
+
+    @Operation(
+            summary = "날짜별 캘린더 상세 조회",
+            description = "지정한 날짜에 해당하는 대여 상환 일정과 정산 일정을 함께 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @ResponseBody
+    @GetMapping("/api/dashboard/calendar/{date}")
+    public List<DashboardCalendarItemResponse> getCalendarDayDetail(
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-08-14")
+            @PathVariable LocalDate date,
+
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        return integrationDashboardService.getCalendarDayDetail(userId, date);
+    }
+
+    @Operation(hidden = true)
+    @GetMapping("/calendar")
+    public String calendarPage(){
+        return "calendar/calendar";
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
@@ -1,0 +1,18 @@
+package org.teamsai.saibackend.domain.calendar.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+
+import java.math.BigDecimal;
+
+@Getter@Builder
+public class DashboardCalendarItemResponse {
+
+    private Long targetId;
+    private PaymentTargetType type;
+    private String title;
+    private String subLabel;
+    private BigDecimal amount;
+    private String detailUrl;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -281,7 +281,7 @@ public class IntegrationDashboardService {
     ) {
         return loanSchedules.stream()
                 .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
-                .filter(context -> context.schedule().getDueDate().equals(date))
+                .filter(context -> date.equals(context.schedule().getDueDate()))
                 .map(context -> {
                     boolean isCreditor = userId.equals(context.contract().getCreditorId());
                     return DashboardCalendarItemResponse.builder()

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -3,6 +3,7 @@ package org.teamsai.saibackend.domain.integration.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.calendar.response.DashboardCalendarItemResponse;
 import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardContractRowResponse;
 import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardResponse;
 import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
@@ -270,6 +271,62 @@ public class IntegrationDashboardService {
                         .hasInbound(entry.getValue().inbound)
                         .hasOutbound(entry.getValue().outbound)
                         .build())
+                .toList();
+    }
+
+    private List<DashboardCalendarItemResponse> getLoanCalendarItems(
+            List<DashboardService.LoanScheduleContext> loanSchedules,
+            LocalDate date,
+            Long userId
+    ) {
+        return loanSchedules.stream()
+                .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
+                .filter(context -> context.schedule().getDueDate().equals(date))
+                .map(context -> {
+                    boolean isCreditor = userId.equals(context.contract().getCreditorId());
+                    return DashboardCalendarItemResponse.builder()
+                            .targetId(context.contract().getContractId())
+                            .type(PaymentTargetType.LOAN)
+                            .title(context.contract().getContractAlias())
+                            .subLabel(isCreditor ? "수취예정" : "납부예정")
+                            .amount(context.schedule().getTotalPaymentDue())
+                            .detailUrl("/contracts/" + context.contract().getContractId() + "/schedule")
+                            .build();
+                })
+                .toList();
+    }
+
+    private List<DashboardCalendarItemResponse> getSettlementCalendarItems(
+            List<SettlementContext> settlements,
+            LocalDate date
+    ) {
+        return settlements.stream()
+                .filter(context -> !isClosed(context.settlement()))
+                .filter(context -> context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
+                .filter(context -> context.settlement().dueDate() != null)
+                .filter(context -> context.settlement().dueDate().equals(date))
+                .map(context -> DashboardCalendarItemResponse.builder()
+                        .targetId(context.settlement().settlementId())
+                        .type(PaymentTargetType.SETTLEMENT)
+                        .title(context.settlement().title())
+                        .subLabel(context.isOwner() ? "받을 돈" : "낼 돈")
+                        .amount(context.roleRemainingAmount())
+                        .detailUrl("/settlements/" + context.settlement().settlementId())
+                        .build())
+                .toList();
+    }
+
+    public List<DashboardCalendarItemResponse> getCalendarDayDetail(Long userId, LocalDate date) {
+        DashboardService.IntegrationDashboardData loanData =
+                contractDashboardService.getIntegrationDashboardData(userId);
+        List<DashboardService.LoanScheduleContext> loanSchedules = loanData.loanSchedules();
+        List<SettlementContext> settlements = getSettlements(userId);
+
+        List<DashboardCalendarItemResponse> items = new ArrayList<>();
+        items.addAll(getLoanCalendarItems(loanSchedules, date, userId));
+        items.addAll(getSettlementCalendarItems(settlements, date));
+        return items.stream()
+                .sorted(Comparator.comparing(DashboardCalendarItemResponse::getTitle))
                 .toList();
     }
 

--- a/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/teamsai/saibackend/global/config/SecurityConfig.java
@@ -76,8 +76,10 @@ public class SecurityConfig {
                                         "/contracts/**",
                                         "/notifications",
                                         "/archive",
+                                        "/calendar",
 
                                         "/integration/dashboard"
+
 
                                 )
                                 .permitAll()

--- a/src/main/resources/static/css/calendar/calendar.css
+++ b/src/main/resources/static/css/calendar/calendar.css
@@ -1,0 +1,302 @@
+.calendar-page {
+    width: min(1344px, calc(100% - 96px));
+    margin: 40px auto;
+    padding: 0;
+    display: flex;
+    gap: 32px;
+    align-items: flex-start;
+}
+
+.calendar-main {
+    flex: 1 1 640px;
+    min-width: 0;
+}
+
+.month-picker {
+    position: relative;
+}
+
+.month-title-btn {
+    font-size: 28px;
+    font-weight: 500;
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font-family: inherit;
+}
+
+.month-title-btn:hover {
+    background: #f5f8ff;
+}
+
+.month-picker-popup {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    padding: 12px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    z-index: 10;
+}
+
+.month-picker-popup[hidden] {
+    display: none;
+}
+
+.month-picker-popup select {
+    font-size: 14px;
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+}
+
+.month-picker-go {
+    border: none;
+    background: #3b6de0;
+    color: #fff;
+    font-size: 14px;
+    padding: 7px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.calendar-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 32px;
+    margin-bottom: 24px;
+}
+
+.calendar-header h2 {
+    font-size: 28px;
+    margin: 0;
+}
+
+.nav-btn {
+    border: none;
+    background: none;
+    font-size: 28px;
+    cursor: pointer;
+    padding: 4px 16px;
+}
+
+.calendar-grid {
+    border: 1px solid #e5e5e5;
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 32px;
+}
+
+.weekday-row {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    background: #f7f7f7;
+    font-size: 16px;
+    color: #888;
+}
+
+.weekday-row span {
+    text-align: center;
+    padding: 14px 0;
+}
+
+.days-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+}
+
+.day-cell {
+    min-height: 110px;
+    border-top: 1px solid #eee;
+    border-left: 1px solid #eee;
+    border-right: none;
+    border-bottom: none;
+    background: none;
+    padding: 12px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-align: left;
+    font-family: inherit;
+    width: 100%;
+}
+
+.day-cell.empty {
+    cursor: default;
+    background: #fafafa;
+}
+
+.day-cell:hover:not(.empty) {
+    background: #f5f8ff;
+}
+
+.day-cell.selected {
+    background: #eaf1ff;
+    outline: 2px solid #3b6de0;
+    outline-offset: -2px;
+}
+
+.day-num {
+    font-size: 18px;
+}
+
+.day-dots {
+    display: flex;
+    gap: 6px;
+}
+
+.dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+}
+
+.dot-inbound {
+    background: #2f9e6b;
+}
+
+.dot-outbound {
+    background: #d8583a;
+}
+
+.calendar-legend {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 32px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    color: #666;
+}
+
+.detail-panel {
+    flex: 0 0 400px;
+    border: 1px solid #e5e5e5;
+    border-radius: 10px;
+    padding: 24px;
+    position: sticky;
+    top: 24px;
+}
+
+@media (max-width: 1080px) {
+    .calendar-page {
+        flex-direction: column;
+    }
+    .detail-panel {
+        flex: 1 1 auto;
+        width: 100%;
+        position: static;
+    }
+}
+
+.detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+#detailDate {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.type-tabs {
+    display: flex;
+    gap: 8px;
+}
+
+.tab-btn {
+    border: 1px solid #ddd;
+    background: #fff;
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-size: 15px;
+    cursor: pointer;
+}
+
+.tab-btn.active {
+    background: #3b6de0;
+    border-color: #3b6de0;
+    color: #fff;
+}
+
+.detail-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.detail-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 18px;
+    border: 1px solid #eee;
+    border-radius: 10px;
+    text-decoration: none;
+    color: inherit;
+}
+
+.detail-item:hover {
+    background: #f7f9fc;
+}
+
+.detail-item-main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.badge {
+    font-size: 13px;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: 999px;
+}
+
+.badge-loan {
+    background: #e1f5ee;
+    color: #0f6e56;
+}
+
+.badge-settlement {
+    background: #eeedfe;
+    color: #3c3489;
+}
+
+.detail-title {
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.detail-sub {
+    font-size: 14px;
+    color: #888;
+}
+
+.detail-amount {
+    font-size: 17px;
+    font-weight: 600;
+}
+
+.empty-state {
+    color: #999;
+    font-size: 15px;
+    padding: 20px 0;
+    text-align: center;
+}

--- a/src/main/resources/static/js/calendar/calendar.js
+++ b/src/main/resources/static/js/calendar/calendar.js
@@ -74,6 +74,7 @@
 
     async function loadMonth() {
         monthTitle.textContent = `${viewYear}년 ${viewMonth + 1}월`;
+        daysGrid.innerHTML = '<p class="empty-state">달력을 불러오는 중이에요...</p>';
 
         const yearMonth = toYearMonth(viewYear, viewMonth);
         const res = await fetch(`/api/integration/dashboard?yearMonth=${yearMonth}`, {
@@ -161,6 +162,7 @@
 
     async function loadDayDetail(dateStr) {
         detailDate.textContent = dateStr.replaceAll('-', '. ') + '.';
+        detailList.innerHTML = '<p class="empty-state">일정을 불러오는 중이에요...</p>';
 
         const res = await fetch(`/api/dashboard/calendar/${dateStr}`, {
             headers: authHeaders()

--- a/src/main/resources/static/js/calendar/calendar.js
+++ b/src/main/resources/static/js/calendar/calendar.js
@@ -1,0 +1,287 @@
+(function () {
+    function authHeaders(extra) {
+        const token = sessionStorage.getItem("accessToken");
+        return Object.assign(
+            token ? { Authorization: `Bearer ${token}` } : {},
+            extra || {}
+        );
+    }
+
+    function escapeHtml(value) {
+        return String(value ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    const monthTitle = document.getElementById('monthTitle');
+    const monthPickerPopup = document.getElementById('monthPickerPopup');
+    const yearSelect = document.getElementById('yearSelect');
+    const monthSelect = document.getElementById('monthSelect');
+    const monthPickerGoBtn = document.getElementById('monthPickerGoBtn');
+    const daysGrid = document.getElementById('daysGrid');
+    const prevMonthBtn = document.getElementById('prevMonthBtn');
+    const nextMonthBtn = document.getElementById('nextMonthBtn');
+    const detailDate = document.getElementById('detailDate');
+    const detailList = document.getElementById('detailList');
+    const typeTabs = document.getElementById('typeTabs');
+
+    const params = new URLSearchParams(location.search);
+    const initialDate = params.get('date');
+
+    let viewYear;
+    let viewMonth;
+    let selectedDate = initialDate || null;
+    let currentItems = [];
+    let currentFilter = 'ALL';
+
+    if (initialDate) {
+        const [y, m] = initialDate.split('-');
+        viewYear = Number(y);
+        viewMonth = Number(m) - 1;
+    } else {
+        const today = new Date();
+        viewYear = today.getFullYear();
+        viewMonth = today.getMonth();
+    }
+
+    function pad(n) {
+        return String(n).padStart(2, '0');
+    }
+
+    function toYearMonth(year, month) {
+        return `${year}-${pad(month + 1)}`;
+    }
+
+    function toDateString(year, month, day) {
+        return `${year}-${pad(month + 1)}-${pad(day)}`;
+    }
+
+    function updateUrl(dateStr) {
+        const url = new URL(location.href);
+        url.searchParams.set('date', dateStr);
+        history.replaceState(null, '', url);
+    }
+
+    function clearSelection() {
+        selectedDate = null;
+        detailDate.textContent = '날짜를 선택하세요';
+        currentItems = [];
+        detailList.innerHTML = '<p class="empty-state">달력에서 날짜를 선택하면 해당 날짜의 일정이 보여요.</p>';
+    }
+
+    async function loadMonth() {
+        monthTitle.textContent = `${viewYear}년 ${viewMonth + 1}월`;
+
+        const yearMonth = toYearMonth(viewYear, viewMonth);
+        const res = await fetch(`/api/integration/dashboard?yearMonth=${yearMonth}`, {
+            headers: authHeaders()
+        });
+
+        if (!res.ok) {
+            daysGrid.innerHTML = '<p class="empty-state">달력을 불러오지 못했어요.</p>';
+            return;
+        }
+
+        const data = await res.json();
+        const markerMap = {};
+        (data.calendarDays || []).forEach(day => {
+            markerMap[day.date] = day;
+        });
+
+        renderGrid(markerMap);
+    }
+
+    function renderGrid(markerMap) {
+        daysGrid.innerHTML = '';
+
+        const firstDayOfMonth = new Date(viewYear, viewMonth, 1);
+        const startWeekday = firstDayOfMonth.getDay();
+        const totalDays = new Date(viewYear, viewMonth + 1, 0).getDate();
+
+        for (let i = 0; i < startWeekday; i++) {
+            const empty = document.createElement('div');
+            empty.className = 'day-cell empty';
+            daysGrid.appendChild(empty);
+        }
+
+        for (let day = 1; day <= totalDays; day++) {
+            const dateStr = toDateString(viewYear, viewMonth, day);
+            const marker = markerMap[dateStr];
+
+            const cell = document.createElement('button');
+            cell.type = 'button';
+            cell.className = 'day-cell';
+            cell.dataset.date = dateStr;
+            cell.setAttribute('aria-label', `${viewMonth + 1}월 ${day}일`);
+            if (dateStr === selectedDate) {
+                cell.classList.add('selected');
+            }
+
+            const num = document.createElement('span');
+            num.className = 'day-num';
+            num.textContent = String(day);
+            cell.appendChild(num);
+
+            if (marker) {
+                const dots = document.createElement('div');
+                dots.className = 'day-dots';
+                if (marker.hasInbound) {
+                    const dot = document.createElement('span');
+                    dot.className = 'dot dot-inbound';
+                    dots.appendChild(dot);
+                }
+                if (marker.hasOutbound) {
+                    const dot = document.createElement('span');
+                    dot.className = 'dot dot-outbound';
+                    dots.appendChild(dot);
+                }
+                cell.appendChild(dots);
+            }
+
+            cell.addEventListener('click', () => onDateClick(dateStr));
+            daysGrid.appendChild(cell);
+        }
+    }
+
+    async function onDateClick(dateStr) {
+        selectedDate = dateStr;
+        updateUrl(dateStr);
+
+        daysGrid.querySelectorAll('.day-cell.selected').forEach(el => el.classList.remove('selected'));
+        const target = daysGrid.querySelector(`[data-date="${dateStr}"]`);
+        if (target) {
+            target.classList.add('selected');
+        }
+
+        await loadDayDetail(dateStr);
+    }
+
+    async function loadDayDetail(dateStr) {
+        detailDate.textContent = dateStr.replaceAll('-', '. ') + '.';
+
+        const res = await fetch(`/api/dashboard/calendar/${dateStr}`, {
+            headers: authHeaders()
+        });
+
+        if (!res.ok) {
+            currentItems = [];
+            detailList.innerHTML = '<p class="empty-state">일정을 불러오지 못했어요. 다시 로그인해보세요.</p>';
+            return;
+        }
+
+        currentItems = await res.json();
+        currentFilter = 'ALL';
+        document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+        document.querySelector('.tab-btn[data-type="ALL"]').classList.add('active');
+
+        renderDetailList();
+    }
+
+    function renderDetailList() {
+        const items = currentFilter === 'ALL'
+            ? currentItems
+            : currentItems.filter(item => item.type === currentFilter);
+
+        if (items.length === 0) {
+            detailList.innerHTML = '<p class="empty-state">이 날짜엔 일정이 없어요.</p>';
+            return;
+        }
+
+        detailList.innerHTML = items.map(item => {
+            const badgeClass = item.type === 'LOAN' ? 'badge-loan' : 'badge-settlement';
+            const badgeLabel = item.type === 'LOAN' ? '대여' : '정산';
+            const amount = Number(item.amount).toLocaleString(undefined, { maximumFractionDigits: 0 });
+
+            return `
+                <a class="detail-item" href="${escapeHtml(item.detailUrl)}">
+                    <div class="detail-item-main">
+                        <span class="badge ${badgeClass}">${badgeLabel}</span>
+                        <span class="detail-title">${escapeHtml(item.title)}</span>
+                        <span class="detail-sub">${escapeHtml(item.subLabel)}</span>
+                    </div>
+                    <span class="detail-amount">${amount}원</span>
+                </a>
+            `;
+        }).join('');
+    }
+
+    prevMonthBtn.addEventListener('click', () => {
+        viewMonth -= 1;
+        if (viewMonth < 0) {
+            viewMonth = 11;
+            viewYear -= 1;
+        }
+        clearSelection();
+        loadMonth();
+    });
+
+    nextMonthBtn.addEventListener('click', () => {
+        viewMonth += 1;
+        if (viewMonth > 11) {
+            viewMonth = 0;
+            viewYear += 1;
+        }
+        clearSelection();
+        loadMonth();
+    });
+
+    function openMonthPicker() {
+        yearSelect.innerHTML = '';
+        const rangeStart = viewYear - 5;
+        const rangeEnd = viewYear + 5;
+        for (let y = rangeStart; y <= rangeEnd; y++) {
+            const opt = document.createElement('option');
+            opt.value = String(y);
+            opt.textContent = `${y}년`;
+            if (y === viewYear) opt.selected = true;
+            yearSelect.appendChild(opt);
+        }
+        monthSelect.value = String(viewMonth);
+        monthPickerPopup.hidden = false;
+    }
+
+    function closeMonthPicker() {
+        monthPickerPopup.hidden = true;
+    }
+
+    monthTitle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (monthPickerPopup.hidden) {
+            openMonthPicker();
+        } else {
+            closeMonthPicker();
+        }
+    });
+
+    monthPickerPopup.addEventListener('click', (e) => e.stopPropagation());
+
+    document.addEventListener('click', () => {
+        if (!monthPickerPopup.hidden) closeMonthPicker();
+    });
+
+    monthPickerGoBtn.addEventListener('click', () => {
+        viewYear = Number(yearSelect.value);
+        viewMonth = Number(monthSelect.value);
+        closeMonthPicker();
+        clearSelection();
+        loadMonth();
+    });
+
+    typeTabs.addEventListener('click', (e) => {
+        const btn = e.target.closest('.tab-btn');
+        if (!btn) return;
+        currentFilter = btn.dataset.type;
+        document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+        btn.classList.add('active');
+        renderDetailList();
+    });
+
+    loadMonth().then(() => {
+        if (initialDate) {
+            onDateClick(initialDate);
+        }
+    });
+})();

--- a/src/main/resources/static/js/calendar/calendar.js
+++ b/src/main/resources/static/js/calendar/calendar.js
@@ -62,7 +62,7 @@
     function updateUrl(dateStr) {
         const url = new URL(location.href);
         url.searchParams.set('date', dateStr);
-        history.replaceState(null, '', url);
+        history.pushState({ date: dateStr }, '', url);
     }
 
     function clearSelection() {
@@ -150,15 +150,41 @@
     async function onDateClick(dateStr) {
         selectedDate = dateStr;
         updateUrl(dateStr);
+        await selectDate(dateStr);
+    }
 
+    async function selectDate(dateStr) {
         daysGrid.querySelectorAll('.day-cell.selected').forEach(el => el.classList.remove('selected'));
         const target = daysGrid.querySelector(`[data-date="${dateStr}"]`);
         if (target) {
             target.classList.add('selected');
         }
-
         await loadDayDetail(dateStr);
     }
+
+    window.addEventListener('popstate', () => {
+        const params = new URLSearchParams(location.search);
+        const dateStr = params.get('date');
+
+        if (!dateStr) {
+            clearSelection();
+            return;
+        }
+
+        const [y, m] = dateStr.split('-');
+        const targetYear = Number(y);
+        const targetMonth = Number(m) - 1;
+
+        if (targetYear !== viewYear || targetMonth !== viewMonth) {
+            viewYear = targetYear;
+            viewMonth = targetMonth;
+            selectedDate = dateStr;
+            loadMonth().then(() => selectDate(dateStr));
+        } else {
+            selectedDate = dateStr;
+            selectDate(dateStr);
+        }
+    });
 
     async function loadDayDetail(dateStr) {
         detailDate.textContent = dateStr.replaceAll('-', '. ') + '.';
@@ -283,7 +309,7 @@
 
     loadMonth().then(() => {
         if (initialDate) {
-            onDateClick(initialDate);
+            selectDate(initialDate);
         }
     });
 })();

--- a/src/main/resources/static/js/integration/dashboard.js
+++ b/src/main/resources/static/js/integration/dashboard.js
@@ -287,6 +287,10 @@ function bindEvents() {
         await loadDashboard(true);
     });
 
+    document.getElementById("calendarViewAllButton").addEventListener("click", () => {
+        window.location.href = `/calendar?date=${toDateKey(calendarCursor)}`;
+    });
+
     document.querySelectorAll(".filter-tab").forEach((button) => {
         button.addEventListener("click", () => {
             document.querySelectorAll(".filter-tab").forEach((tab) => tab.classList.remove("is-active"));

--- a/src/main/resources/static/js/integration/dashboard.js
+++ b/src/main/resources/static/js/integration/dashboard.js
@@ -226,6 +226,11 @@ function renderCalendar() {
                 ${calendarDay.hasOutbound ? '<i class="dot dot--outbound"></i>' : ""}
             </span>
         `;
+
+        dayButton.addEventListener("click", () => {
+            window.location.href = `/calendar?date=${dateKey}`;
+        });
+
         grid.appendChild(dayButton);
     });
 }

--- a/src/main/resources/templates/calendar/calendar.html
+++ b/src/main/resources/templates/calendar/calendar.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>일정 캘린더</title>
+    <link rel="stylesheet" th:href="@{/css/calendar/calendar.css}">
+    <link rel="stylesheet" href="/css/contractchange/site-common.css" />
+</head>
+<body>
+
+<header class="site-header">
+    <div class="header-inner">
+        <a class="brand" href="/">사이원장</a>
+        <nav class="main-nav" aria-label="주요 메뉴">
+            <a href="#">서비스 소개</a>
+            <a href="/dashboard">금전거래대차</a>
+            <a href="/settlements">정산</a>
+            <a class="active" href="/calendar">거래 일정</a>
+        </nav>
+        <div class="header-actions">
+            <button class="icon-button" type="button" aria-label="알림">♧</button>
+            <a class="profile-link" href="/mypage" aria-label="마이페이지">
+                <span class="profile-avatar">사</span>
+            </a>
+        </div>
+    </div>
+</header>
+
+<div class="calendar-page">
+
+    <div class="calendar-main">
+        <div class="calendar-header">
+            <button id="prevMonthBtn" class="nav-btn" type="button" aria-label="이전 달">‹</button>
+            <div class="month-picker">
+                <button id="monthTitle" class="month-title-btn" type="button">2026년 8월</button>
+                <div id="monthPickerPopup" class="month-picker-popup" hidden>
+                    <select id="yearSelect"></select>
+                    <select id="monthSelect">
+                        <option value="0">1월</option>
+                        <option value="1">2월</option>
+                        <option value="2">3월</option>
+                        <option value="3">4월</option>
+                        <option value="4">5월</option>
+                        <option value="5">6월</option>
+                        <option value="6">7월</option>
+                        <option value="7">8월</option>
+                        <option value="8">9월</option>
+                        <option value="9">10월</option>
+                        <option value="10">11월</option>
+                        <option value="11">12월</option>
+                    </select>
+                    <button id="monthPickerGoBtn" class="month-picker-go" type="button">이동</button>
+                </div>
+            </div>
+            <button id="nextMonthBtn" class="nav-btn" type="button" aria-label="다음 달">›</button>
+        </div>
+
+        <div class="calendar-grid">
+            <div class="weekday-row">
+                <span>일</span><span>월</span><span>화</span><span>수</span>
+                <span>목</span><span>금</span><span>토</span>
+            </div>
+            <div id="daysGrid" class="days-grid"></div>
+        </div>
+
+        <div class="calendar-legend">
+            <span class="legend-item"><span class="dot dot-inbound"></span>받을 돈</span>
+            <span class="legend-item"><span class="dot dot-outbound"></span>낼 돈</span>
+        </div>
+    </div>
+
+    <div class="detail-panel">
+        <div class="detail-header">
+            <span id="detailDate">날짜를 선택하세요</span>
+            <div id="typeTabs" class="type-tabs">
+                <button class="tab-btn active" data-type="ALL" type="button">전체</button>
+                <button class="tab-btn" data-type="LOAN" type="button">대여</button>
+                <button class="tab-btn" data-type="SETTLEMENT" type="button">정산</button>
+            </div>
+        </div>
+        <div id="detailList" class="detail-list">
+            <p class="empty-state">달력에서 날짜를 선택하면 해당 날짜의 일정이 보여요.</p>
+        </div>
+    </div>
+
+</div>
+
+<script th:src="@{/js/calendar/calendar.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/integration/dashboard.html
+++ b/src/main/resources/templates/integration/dashboard.html
@@ -43,7 +43,7 @@
             <article class="panel calendar-panel">
                 <div class="panel-header">
                     <h2>월별 현황</h2>
-                    <button class="text-button" type="button">전체보기</button>
+                    <button id="calendarViewAllButton" class="text-button" type="button">전체보기</button>
                 </div>
                 <div class="calendar-card">
                     <div class="calendar-toolbar">

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -214,6 +214,21 @@ public class CalendarTest {
                 .containsExactly("가나다 정산", "차용증 대출");
     }
 
+    @Test
+    void 상환예정일이_없는_스케줄은_예외없이_결과에서_제외된다() {
+        LoanContractResponse contract = buildContract(16L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(null, RepaymentScheduleStatus.PENDING, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).isEmpty();
+    }
+
     private LoanContractResponse buildContract(
             Long contractId, Long creditorId, Long debtorId, String alias
     ) {
@@ -226,8 +241,8 @@ public class CalendarTest {
                 .principalAmount(BigDecimal.valueOf(1_000_000))
                 .interestRate(BigDecimal.valueOf(5))
                 .repaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
-                .startDate(LocalDate.now().minusMonths(1))
-                .maturityDate(LocalDate.now().plusMonths(11))
+                .startDate(LocalDate.of(2026, 7, 14))
+                .maturityDate(LocalDate.of(2027, 6, 14))
                 .build();
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -1,0 +1,293 @@
+package org.teamsai.saibackend.domain.calendar;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.calendar.response.DashboardCalendarItemResponse;
+import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
+import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
+import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardResponse;
+import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
+import org.teamsai.saibackend.domain.contractdashboard.service.DashboardService;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.dto.RepaymentScheduleDTO;
+import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
+import org.teamsai.saibackend.domain.integration.service.IntegrationDashboardService;
+import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementListResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentObligationResponse;
+import org.teamsai.saibackend.domain.settlement.dto.response.SettlementPaymentStatusResponse;
+import org.teamsai.saibackend.domain.settlement.service.SettlementPaymentStatusService;
+import org.teamsai.saibackend.domain.settlement.service.SettlementQueryService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CalendarTest {
+
+    @Mock
+    private DashboardService contractDashboardService;
+
+    @Mock
+    private SettlementQueryService settlementQueryService;
+
+    @Mock
+    private SettlementPaymentStatusService settlementPaymentStatusService;
+
+    @InjectMocks
+    private IntegrationDashboardService integrationDashboardService;
+
+    private static final Long USER_ID = 1L;
+    private static final LocalDate TARGET_DATE = LocalDate.of(2026, 8, 14);
+
+    @Test
+    void 채권자인_대여_스케줄은_수취예정으로_표시된다() {
+        LoanContractResponse contract = buildContract(10L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getType()).isEqualTo(PaymentTargetType.LOAN);
+        assertThat(item.getTargetId()).isEqualTo(10L);
+        assertThat(item.getSubLabel()).isEqualTo("수취예정");
+        assertThat(item.getAmount()).isEqualByComparingTo("600000");
+        assertThat(item.getDetailUrl()).isEqualTo("/contracts/10/schedule");
+    }
+
+    @Test
+    void 채무자인_대여_스케줄은_납부예정으로_표시된다() {
+        LoanContractResponse contract = buildContract(11L, 2L, USER_ID, "차량구입 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 350_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getSubLabel()).isEqualTo("납부예정");
+    }
+
+    @Test
+    void 다른_날짜의_스케줄은_결과에서_제외된다() {
+        LoanContractResponse contract = buildContract(12L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(
+                TARGET_DATE.plusDays(1), RepaymentScheduleStatus.PENDING, 600_000
+        );
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 이미_납부완료된_스케줄은_결과에서_제외된다() {
+        LoanContractResponse contract = buildContract(13L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PAID, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 정산_참여자는_낼_돈으로_표시된다() {
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(null, null));
+
+        SettlementListResponse settlement = settlement(
+                100L, "회식비 정산", "MEMBER", "OPEN", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(100L, USER_ID))
+                .thenReturn(paymentStatus(
+                        100L,
+                        BigDecimal.valueOf(35_000),
+                        BigDecimal.valueOf(35_000),
+                        obligation(1L, USER_ID, BigDecimal.valueOf(35_000))
+                ));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getType()).isEqualTo(PaymentTargetType.SETTLEMENT);
+        assertThat(item.getSubLabel()).isEqualTo("낼 돈");
+        assertThat(item.getAmount()).isEqualByComparingTo("35000");
+        assertThat(item.getDetailUrl()).isEqualTo("/settlements/100");
+    }
+
+    @Test
+    void 마감된_정산은_결과에서_제외된다() {
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(null, null));
+
+        SettlementListResponse settlement = settlement(
+                101L, "종료된 정산", "OWNER", "CLOSED", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(101L, USER_ID))
+                .thenReturn(paymentStatus(101L, BigDecimal.ZERO, BigDecimal.ZERO));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 대여와_정산_항목이_함께_반환된다() {
+        LoanContractResponse contract = buildContract(14L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 600_000);
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+
+        SettlementListResponse settlement = settlement(
+                102L, "회식비 정산", "OWNER", "OPEN", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(102L, USER_ID))
+                .thenReturn(paymentStatus(
+                        102L,
+                        BigDecimal.valueOf(20_000),
+                        BigDecimal.valueOf(20_000)
+                ));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(DashboardCalendarItemResponse::getType)
+                .containsExactlyInAnyOrder(PaymentTargetType.LOAN, PaymentTargetType.SETTLEMENT);
+        assertThat(result)
+                .filteredOn(item -> item.getType() == PaymentTargetType.SETTLEMENT)
+                .extracting(DashboardCalendarItemResponse::getSubLabel)
+                .containsExactly("받을 돈");
+    }
+
+    @Test
+    void 결과는_제목_가나다순으로_정렬된다() {
+        LoanContractResponse contract = buildContract(15L, USER_ID, 2L, "차용증 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 100_000);
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+
+        SettlementListResponse settlement = settlement(
+                103L, "가나다 정산", "OWNER", "OPEN", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(103L, USER_ID))
+                .thenReturn(paymentStatus(103L, BigDecimal.valueOf(10_000), BigDecimal.valueOf(10_000)));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).extracting(DashboardCalendarItemResponse::getTitle)
+                .containsExactly("가나다 정산", "차용증 대출");
+    }
+
+    private LoanContractResponse buildContract(
+            Long contractId, Long creditorId, Long debtorId, String alias
+    ) {
+        return LoanContractResponse.builder()
+                .contractId(contractId)
+                .status(ContractStatus.COMPLETED)
+                .contractAlias(alias)
+                .creditorId(creditorId)
+                .debtorId(debtorId)
+                .principalAmount(BigDecimal.valueOf(1_000_000))
+                .interestRate(BigDecimal.valueOf(5))
+                .repaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
+                .startDate(LocalDate.now().minusMonths(1))
+                .maturityDate(LocalDate.now().plusMonths(11))
+                .build();
+    }
+
+    private RepaymentScheduleDTO buildSchedule(
+            LocalDate dueDate, RepaymentScheduleStatus status, long amount
+    ) {
+        return RepaymentScheduleDTO.builder()
+                .dueDate(dueDate)
+                .status(status)
+                .totalPaymentDue(BigDecimal.valueOf(amount))
+                .remainingPrincipal(BigDecimal.valueOf(amount))
+                .build();
+    }
+
+    private SettlementListResponse settlement(
+            Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
+    ) {
+        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, createdAt);
+    }
+
+    private SettlementPaymentStatusResponse paymentStatus(
+            Long settlementId,
+            BigDecimal totalExpected,
+            BigDecimal totalRemaining,
+            SettlementPaymentObligationResponse... obligations
+    ) {
+        return SettlementPaymentStatusResponse.builder()
+                .settlementId(settlementId)
+                .obligations(List.of(obligations))
+                .totalExpectedAmount(totalExpected)
+                .totalRemainingAmount(totalRemaining)
+                .build();
+    }
+
+    private SettlementPaymentObligationResponse obligation(Long id, Long userId, BigDecimal remaining) {
+        return SettlementPaymentObligationResponse.builder()
+                .paymentObligationId(id)
+                .userId(userId)
+                .expectedAmount(remaining)
+                .paidAmount(BigDecimal.ZERO)
+                .remainingAmount(remaining)
+                .build();
+    }
+
+    private DashboardService.IntegrationDashboardData loanData(
+            LoanContractResponse contract, RepaymentScheduleDTO schedule
+    ) {
+        DashboardResponse dashboard = DashboardResponse.builder()
+                .summary(DashboardSummaryResponse.builder()
+                        .totalLentAmount(BigDecimal.ZERO)
+                        .totalBorrowedAmount(BigDecimal.ZERO)
+                        .build())
+                .contracts(List.of())
+                .build();
+
+        List<DashboardService.LoanScheduleContext> contexts = contract == null
+                ? List.of()
+                : List.of(new DashboardService.LoanScheduleContext(contract, schedule));
+
+        return new DashboardService.IntegrationDashboardData(dashboard, contexts);
+    }
+}
+


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #5

## 🛠 작업 사항

- 통합대시보드 "전체보기" / 날짜 클릭 시 이동할 `/calendar` 페이지 신규 구현 (월간 그리드 + 날짜별 상세 패널)
- `GET /api/dashboard/calendar/{date}` API 신규 추가 — 대여 상환 스케줄 + 정산 항목을 합쳐서 날짜별 상세 조회
  - `DashboardService.getContractScheduleContexts()` 배치조회 재사용, N+1 없음
  - 기존 `getCalendarDays()`와 동일한 필터 기준(정산 CLOSED 제외, 잔액 0 제외) 적용해 마커/상세가 항상 일치하도록 구성
- 월간 마커는 기존 `GET /api/integration/dashboard?yearMonth=` 응답의 `calendarDays`를 그대로 재사용 (신규 API 불필요)
- 상세 목록에 전체/대여/정산 탭 필터, 항목 클릭 시 각 상세화면(계약 상환 스케줄 / 정산 상세)으로 이동
- 연/월 직접 선택 팝업, 날짜 클릭 시 URL 동기화(뒤로가기 시 마지막 조회 상태 복원)
- 통합대시보드에 `/calendar` 이동 이벤트 연결 (날짜 클릭 → 해당 날짜, "전체보기" → 현재 보던 달)
- `SecurityConfig`에 `/calendar` permitAll 추가
- 사이트 전체에 `favicon.ico` 추가 (기존 404 로그 제거)

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료 (`IntegrationDashboardServiceCalendarTest`, 9건)
- [x] 기존 기능에 영향이 없는지 확인 (`LoanContractServiceTest` 1건 실패는 본 PR과 무관한 기존 이슈, 전자서명 도메인)

## 📌 주의 사항 및 참고사항

- `favicon.ico` 추가는 이번 캘린더 작업과 무관하게 전체 프로젝트에 영향을 주는 변경입니다.