### PR TITLE
feat/(#146): 계약 변경 요청 전자서명 스텝 추가

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/controller/ContractChangeController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/controller/ContractChangeController.java
@@ -9,10 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRejectRequest;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
@@ -38,33 +40,44 @@ public class ContractChangeController {
         return "contractchange/request";
     }
 
+    @Hidden
+    @GetMapping("/contracts/{contractId}/change-requests/{changeRequestId}/signature")
+    public String changeRequestSignaturePage(
+            @PathVariable Long contractId,
+            @PathVariable Long changeRequestId,
+            Model model
+    ) {
+        model.addAttribute("contractId", contractId);
+        model.addAttribute("changeRequestId", changeRequestId);
+        return "contractchange/change-request-signature";
+    }
+
     @Operation(
             summary = "계약 조건 변경 요청",
-            description = "채권자가 기존 계약의 만기일, 이율, 상환방식, 상환일, 특약사항 중 하나 이상을 변경 요청합니다." +
-                    "변경하지 않는 항목은 값을 비워두면 기존 계약 값이 그대로 유지됩니다." +
-                    "요청이 등록되면 채무자의 승인을 거쳐 계약에 반영됩니다." +
+            description = "계약 당사자가 기존 계약의 만기일, 이율, 상환방식, 상환일, 특약사항 중 하나 이상을 변경 요청하고, " +
+                    "요청 시 전자서명을 함께 제출합니다. " +
+                    "변경하지 않는 항목은 값을 비워두면 기존 계약 값이 그대로 유지됩니다. " +
+                    "요청이 등록되면 상대방의 승인을 거쳐 계약에 반영됩니다. " +
                     "이미 처리 대기 중인 변경 요청이 있으면 새 요청을 등록할 수 없습니다."
     )
-
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "변경 요청 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음 (이율 범위, 상환일 범위 등"),
+            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음 (이율 범위, 상환일 범위 등)"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "403", description = "계약 당사자(채권자)가 아님"),
+            @ApiResponse(responseCode = "403", description = "계약 당사자가 아님"),
             @ApiResponse(responseCode = "404", description = "계약을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 처리 대기 중인 변경 요청이 있음")
-
     })
 
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/api/contracts/{contractId}/change-requests")
+    @PostMapping("/api/contracts/{contractId}/change-requests")   // ← consumes 삭제, JSON으로
     public LoanContractChangeDTO requestChange(
             @PathVariable Long contractId,
-            @Valid @RequestBody ContractChangeRequest request,
+            @Valid @RequestBody ContractChangeRequest request,     // ← @RequestBody로 원복
             @AuthenticationPrincipal(expression = "userId") Long userId
-    ){
-        return contractChangeService.requestChange(contractId, request, userId);
+    ) {
+        return contractChangeService.requestChange(contractId, request, userId);   // signature 인자 삭제
     }
 
     @Operation(
@@ -88,5 +101,51 @@ public class ContractChangeController {
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
         return contractChangeService.rejectChange(contractId, changeRequestId, request.getReturnReason(), userId);
+    }
+
+    @Operation(
+            summary = "계약 변경 요청 전자서명 제출",
+            description = "변경 요청을 등록한 당사자가 전자서명을 제출하면, 상대방에게 알림이 발송됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "서명 제출 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "요청 등록 당사자가 아님"),
+            @ApiResponse(responseCode = "404", description = "변경 요청을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 처리된 요청임")
+    })
+    @ResponseBody
+    @PatchMapping(value = "/api/contracts/{contractId}/change-requests/{changeRequestId}/signature",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public LoanContractChangeDTO submitRequesterSignature(
+            @PathVariable Long contractId,
+            @PathVariable Long changeRequestId,
+            @RequestParam("signature") MultipartFile signature,
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        return contractChangeService.submitRequesterSignature(contractId, changeRequestId, userId, signature);
+    }
+
+    @Operation(
+            summary = "계약 변경 요청 취소",
+            description = "요청 등록 당사자가 아직 서명을 제출하지 않은 자신의 변경 요청을 취소합니다. " +
+                    "이미 서명을 제출해 상대방에게 전송된 요청은 취소할 수 없습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "취소 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "요청 등록 당사자가 아님"),
+            @ApiResponse(responseCode = "404", description = "변경 요청을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 서명이 제출됐거나 처리된 요청임")
+    })
+    @ResponseBody
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/api/contracts/{contractId}/change-requests/{changeRequestId}")
+    public void cancelChangeRequest(
+            @PathVariable Long contractId,
+            @PathVariable Long changeRequestId,
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        contractChangeService.cancelChangeRequest(contractId, changeRequestId, userId);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/controller/ContractChangeController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/controller/ContractChangeController.java
@@ -18,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRejectRequest;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
+import org.teamsai.saibackend.domain.contractchange.exception.ContractChangeErrorCode;
 import org.teamsai.saibackend.domain.contractchange.service.ContractChangeService;
 
 @Tag(
@@ -123,6 +124,9 @@ public class ContractChangeController {
             @RequestParam("signature") MultipartFile signature,
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
+        if (signature == null || signature.isEmpty()) {
+            throw ContractChangeErrorCode.SIGNATURE_REQUIRED.toException();
+        }
         return contractChangeService.submitRequesterSignature(contractId, changeRequestId, userId, signature);
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/dto/LoanContractChangeDTO.java
@@ -29,5 +29,6 @@ public class LoanContractChangeDTO {
     private LocalDateTime updatedAt;
     private Long contractId;
     private String returnReason;
+    private String requesterSignature;
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
@@ -18,7 +18,8 @@ public enum ContractChangeErrorCode implements BaseErrorCode<DomainException> {
     CHANGE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "변경 요청을 찾을 수 없습니다."),
     CONTRACT_ALREADY_SUPERSEDED(HttpStatus.CONFLICT, "이미 변경된 계약입니다. 최신 계약서를 확인해주세요."),
     NOT_DEBTOR(HttpStatus.FORBIDDEN, "채무자만 접근 가능합니다."),
-    ALREADY_BEING_REQUEST(HttpStatus.CONFLICT, "이미 처리된 요청입니다.");
+    ALREADY_BEING_REQUEST(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
+    ALREADY_SIGNED(HttpStatus.CONFLICT, "이미 서명을 제출하여 상대방에게 전송된 요청은 취소할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
@@ -19,7 +19,8 @@ public enum ContractChangeErrorCode implements BaseErrorCode<DomainException> {
     CONTRACT_ALREADY_SUPERSEDED(HttpStatus.CONFLICT, "이미 변경된 계약입니다. 최신 계약서를 확인해주세요."),
     NOT_DEBTOR(HttpStatus.FORBIDDEN, "채무자만 접근 가능합니다."),
     ALREADY_BEING_REQUEST(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
-    ALREADY_SIGNED(HttpStatus.CONFLICT, "이미 서명을 제출하여 상대방에게 전송된 요청은 취소할 수 없습니다.");
+    ALREADY_SIGNED(HttpStatus.CONFLICT, "이미 서명을 제출하여 상대방에게 전송된 요청은 취소할 수 없습니다."),
+    SIGNATURE_REQUIRED(HttpStatus.BAD_REQUEST, "서명 이미지가 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/mapper/ContractChangeMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/mapper/ContractChangeMapper.java
@@ -2,8 +2,8 @@ package org.teamsai.saibackend.domain.contractchange.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.teamsai.saibackend.domain.contractchange.type.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
+import org.teamsai.saibackend.domain.contractchange.type.ChangeRequestStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +33,11 @@ public interface ContractChangeMapper {
             @Param("changeRequestId") Long changeRequestId,
             @Param("status") ChangeRequestStatus status,
             @Param("returnReason") String returnReason
+    );
+
+    int updateRequesterSignature(
+            @Param("changeRequestId") Long changeRequestId,
+            @Param("requesterSignature") String requesterSignature
     );
 
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/mapper/ContractChangeMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/mapper/ContractChangeMapper.java
@@ -40,5 +40,7 @@ public interface ContractChangeMapper {
             @Param("requesterSignature") String requesterSignature
     );
 
+    int cancelPendingUnsignedRequest(@Param("changeRequestId") Long changeRequestId);
+
 
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -264,13 +264,9 @@ public class ContractChangeService {
             throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
         }
 
-        if (changeDTO.getRequesterSignature() != null) {
-            throw ContractChangeErrorCode.ALREADY_SIGNED.toException();
-        }
-
-        int updatedRows = contractChangeMapper.updateStatus(changeRequestId, ChangeRequestStatus.CANCELLED);
+        int updatedRows = contractChangeMapper.cancelPendingUnsignedRequest(changeRequestId);
         if (updatedRows == 0) {
-            throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
+            throw ContractChangeErrorCode.ALREADY_SIGNED.toException();
         }
 
         LoanContractResponse v2 = getPendingChangedContract(contractId);
@@ -289,11 +285,11 @@ public class ContractChangeService {
     ) {
         LoanContractChangeDTO changeDTO = getChangeRequest(changeRequestId);
 
-        if(!changeDTO.getContractId().equals(contractId)) {
+        if (!changeDTO.getContractId().equals(contractId)) {
             throw ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND.toException();
         }
 
-        if(!changeDTO.getUserId().equals(userId)) {
+        if (!changeDTO.getUserId().equals(userId)) {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
         }
 
@@ -302,7 +298,11 @@ public class ContractChangeService {
         }
 
         String savedPath = fileService.saveSignatureFile(changeRequestId, signature);
-        contractChangeMapper.updateRequesterSignature(changeRequestId, savedPath);
+
+        int updatedRows = contractChangeMapper.updateRequesterSignature(changeRequestId, savedPath);
+        if (updatedRows == 0) {
+            throw ContractChangeErrorCode.ALREADY_SIGNED.toException();
+        }
 
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         UserResponse requesterInfo = userService.getMyInfo(userId);

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -7,11 +7,13 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.event.ContractChangeApprovedEvent;
+import org.teamsai.saibackend.domain.contract.service.LoanContractFileService;
 import org.teamsai.saibackend.domain.contract.service.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
@@ -38,6 +40,7 @@ public class ContractChangeService {
     private final RepaymentScheduleService repaymentScheduleService;
     private final NotificationService notificationService;
     private final UserService userService;
+    private final LoanContractFileService fileService;
 
 
     public void checkAccess(Long contractId, Long userId) {
@@ -71,7 +74,11 @@ public class ContractChangeService {
 
 
     @Transactional
-    public LoanContractChangeDTO requestChange(Long contractId, ContractChangeRequest request, Long userId) {
+    public LoanContractChangeDTO requestChange(
+            Long contractId,
+            ContractChangeRequest request,
+            Long userId
+            ) {
 
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
@@ -144,17 +151,6 @@ public class ContractChangeService {
                 .build();
 
         loanContractService.insertChangedContract(newContractDTO);
-
-        UserResponse creditorInfo = userService.getMyInfo(userId);
-
-        notificationService.create(
-                contract.getDebtorId(),
-                NotificationType.CONTRACT_CHANGE,
-                "계약 변경 요청",
-                creditorInfo.getName() + "님으로부터 계약 내용 변경 요청이 도착했습니다.",
-                contractId,
-                changeDTO.getChangeRequestId()
-        );
 
         log.info("계약 변경 요청 생성 및 차용증 재저장 완료: contractId={}, userId={}",
                 contractId, userId);
@@ -250,5 +246,76 @@ public class ContractChangeService {
         List<LoanContractChangeDTO> existingRequests = contractChangeMapper.findByContractId(contractId);
         return existingRequests.stream()
                 .anyMatch(changeRequest -> ChangeRequestStatus.PENDING.equals(changeRequest.getStatus()));
+    }
+
+    @Transactional
+    public void cancelChangeRequest(Long contractId, Long changeRequestId, Long userId) {
+        LoanContractChangeDTO changeDTO = getChangeRequest(changeRequestId);
+
+        if (!changeDTO.getContractId().equals(contractId)) {
+            throw ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND.toException();
+        }
+
+        if (!changeDTO.getUserId().equals(userId)) {
+            throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
+        }
+
+        if (changeDTO.getStatus() != ChangeRequestStatus.PENDING) {
+            throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
+        }
+
+        if (changeDTO.getRequesterSignature() != null) {
+            throw ContractChangeErrorCode.ALREADY_SIGNED.toException();
+        }
+
+        int updatedRows = contractChangeMapper.updateStatus(changeRequestId, ChangeRequestStatus.CANCELLED);
+        if (updatedRows == 0) {
+            throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
+        }
+
+        LoanContractResponse v2 = getPendingChangedContract(contractId);
+        loanContractService.rejectChangedContract(v2.getContractId());
+
+        log.info("계약 변경 요청 취소 처리 완료: contractId={}, changeRequestId={}, userId={}",
+                contractId, changeRequestId, userId);
+    }
+
+    @Transactional
+    public LoanContractChangeDTO submitRequesterSignature(
+            Long contractId,
+            Long changeRequestId,
+            Long userId,
+            MultipartFile signature
+    ) {
+        LoanContractChangeDTO changeDTO = getChangeRequest(changeRequestId);
+
+        if(!changeDTO.getContractId().equals(contractId)) {
+            throw ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND.toException();
+        }
+
+        if(!changeDTO.getUserId().equals(userId)) {
+            throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
+        }
+
+        if (changeDTO.getStatus() != ChangeRequestStatus.PENDING) {
+            throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
+        }
+
+        String savedPath = fileService.saveSignatureFile(changeRequestId, signature);
+        contractChangeMapper.updateRequesterSignature(changeRequestId, savedPath);
+
+        LoanContractResponse contract = loanContractService.findContract(contractId, userId);
+        UserResponse requesterInfo = userService.getMyInfo(userId);
+
+        notificationService.create(
+                contract.getDebtorId(),
+                NotificationType.CONTRACT_CHANGE,
+                "계약 변경 요청",
+                requesterInfo.getName() + "님으로부터 계약 내용 변경 요청이 도착했습니다.",
+                contractId,
+                changeRequestId
+        );
+
+        return getChangeRequest(changeRequestId);
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/type/ChangeRequestStatus.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/type/ChangeRequestStatus.java
@@ -3,5 +3,6 @@ package org.teamsai.saibackend.domain.contractchange.type;
 public enum ChangeRequestStatus {
     PENDING,
     APPROVED,
-    REJECTED
+    REJECTED,
+    CANCELLED
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contractchangedetail/service/ChangeRequestDetailService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchangedetail/service/ChangeRequestDetailService.java
@@ -100,6 +100,7 @@ public class ChangeRequestDetailService {
             case PENDING -> "승인 대기 중";
             case APPROVED -> "승인됨";
             case REJECTED -> "거절됨";
+            case CANCELLED -> "취소됨";
 
         };
 

--- a/src/main/resources/db/03_contractchange.sql
+++ b/src/main/resources/db/03_contractchange.sql
@@ -38,3 +38,13 @@ ALTER TABLE loan_contract_change_request
 
 ALTER TABLE loan_contract_change_request
     MODIFY COLUMN new_repayment_type VARCHAR(30) NULL;
+
+ALTER TABLE loan_contract_change_request
+    ADD COLUMN requester_signature VARCHAR(255) NULL AFTER return_reason;
+
+ALTER TABLE loan_contract_change_request
+DROP CONSTRAINT status;
+
+ALTER TABLE loan_contract_change_request
+    ADD CONSTRAINT chk_change_request_status
+        CHECK (status IN ('PENDING', 'APPROVED', 'REJECTED', 'CANCELLED'));

--- a/src/main/resources/db/03_contractchange.sql
+++ b/src/main/resources/db/03_contractchange.sql
@@ -43,7 +43,10 @@ ALTER TABLE loan_contract_change_request
     ADD COLUMN requester_signature VARCHAR(255) NULL AFTER return_reason;
 
 ALTER TABLE loan_contract_change_request
-DROP CONSTRAINT status;
+DROP CONSTRAINT IF EXISTS status;
+
+ALTER TABLE loan_contract_change_request
+DROP CONSTRAINT IF EXISTS chk_change_request_status;
 
 ALTER TABLE loan_contract_change_request
     ADD CONSTRAINT chk_change_request_status

--- a/src/main/resources/mapper/contractchange/ContractChangeMapper.xml
+++ b/src/main/resources/mapper/contractchange/ContractChangeMapper.xml
@@ -23,7 +23,7 @@
         SELECT
             change_request_id, user_id, change_reason, new_maturity_date, new_interest_rate,
             new_repayment_type, new_repayment_date, new_terms, status, created_at, updated_at, contract_id,
-            return_reason
+            return_reason, requester_signature
         FROM loan_contract_change_request
         WHERE contract_id = #{contractId}
     </select>
@@ -33,7 +33,7 @@
         SELECT
             change_request_id, user_id, change_reason, new_maturity_date, new_interest_rate,
             new_repayment_type, new_repayment_date, new_terms, status, created_at, updated_at, contract_id,
-            return_reason
+            return_reason, requester_signature
         FROM loan_contract_change_request
         WHERE change_request_id = #{changeRequestId}
     </select>
@@ -52,6 +52,12 @@
         updated_at = NOW()
         WHERE change_request_id = #{changeRequestId}
         AND status = 'PENDING'
+    </update>
+
+    <update id="updateRequesterSignature">
+        UPDATE loan_contract_change_request
+        SET requester_signature = #{requesterSignature}
+        WHERE change_request_id = #{changeRequestId}
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/contractchange/ContractChangeMapper.xml
+++ b/src/main/resources/mapper/contractchange/ContractChangeMapper.xml
@@ -58,6 +58,17 @@
         UPDATE loan_contract_change_request
         SET requester_signature = #{requesterSignature}
         WHERE change_request_id = #{changeRequestId}
+          AND status = 'PENDING'
+          AND requester_signature IS NULL
+    </update>
+
+    <update id="cancelPendingUnsignedRequest">
+        UPDATE loan_contract_change_request
+        SET status = 'CANCELLED',
+            updated_at = NOW()
+        WHERE change_request_id = #{changeRequestId}
+          AND status = 'PENDING'
+          AND requester_signature IS NULL
     </update>
 
 </mapper>

--- a/src/main/resources/static/js/contractchange/change-request-signature.js
+++ b/src/main/resources/static/js/contractchange/change-request-signature.js
@@ -46,12 +46,21 @@
     if (!confirmed) return;
 
     try {
-      await fetch(`/api/contracts/${contractId}/change-requests/${changeRequestId}`, {
+      const response = await fetch(`/api/contracts/${contractId}/change-requests/${changeRequestId}`, {
         method: "DELETE",
         headers: authHeaders(),
       });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        showStatus(body?.message || "취소에 실패했습니다. 잠시 후 다시 시도해 주세요.", true);
+        return;
+      }
     } catch (err) {
+      showStatus("취소 요청 중 오류가 발생했습니다. 네트워크를 확인해 주세요.", true);
+      return;
     }
+
     window.location.href = `/contracts/${encodeURIComponent(contractId)}/contract-detail`;
   });
 

--- a/src/main/resources/static/js/contractchange/change-request-signature.js
+++ b/src/main/resources/static/js/contractchange/change-request-signature.js
@@ -1,0 +1,152 @@
+(function () {
+  "use strict";
+
+  const contractId = document.getElementById("contractId").value;
+  const changeRequestId = document.getElementById("changeRequestId").value;
+
+  const canvas = document.getElementById("signatureCanvas");
+  const signPlaceholder = document.getElementById("signPlaceholder");
+  const clearBtn = document.getElementById("clearSignature");
+  const agreeCheckbox = document.getElementById("agreeCheckbox");
+  const submitBtn = document.getElementById("btnSubmit");
+  const cancelBtn = document.getElementById("btnCancel");
+  const statusEl = document.getElementById("formStatus");
+
+  if (!canvas) return;
+
+  const ctx = canvas.getContext("2d");
+  ctx.lineWidth = 2.5;
+  ctx.lineCap = "round";
+  ctx.strokeStyle = "#181c1e";
+
+  let hasSignature = false;
+  let drawing = false;
+
+  function authHeaders(extra) {
+    const token = sessionStorage.getItem("accessToken");
+    return Object.assign(
+        token ? { Authorization: `Bearer ${token}` } : {},
+        extra || {}
+    );
+  }
+
+  function showStatus(message, isError) {
+    statusEl.textContent = message;
+    statusEl.classList.toggle("is-error", Boolean(isError));
+  }
+
+  if (!contractId || !changeRequestId) {
+    alert("잘못된 접근입니다. 변경 요청 화면으로 돌아갑니다.");
+    window.location.href = "/dashboard";
+    return;
+  }
+
+  cancelBtn?.addEventListener("click", async () => {
+    const confirmed = confirm("작성 중인 변경 요청을 취소하시겠습니까?");
+    if (!confirmed) return;
+
+    try {
+      await fetch(`/api/contracts/${contractId}/change-requests/${changeRequestId}`, {
+        method: "DELETE",
+        headers: authHeaders(),
+      });
+    } catch (err) {
+    }
+    window.location.href = `/contracts/${encodeURIComponent(contractId)}/contract-detail`;
+  });
+
+  function canvasPoint(event) {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const source = event.touches ? event.touches[0] : event;
+    return {
+      x: (source.clientX - rect.left) * scaleX,
+      y: (source.clientY - rect.top) * scaleY,
+    };
+  }
+
+  function startDraw(event) {
+    event.preventDefault();
+    drawing = true;
+    if (signPlaceholder) signPlaceholder.hidden = true;
+    const { x, y } = canvasPoint(event);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  }
+
+  function moveDraw(event) {
+    if (!drawing) return;
+    event.preventDefault();
+    const { x, y } = canvasPoint(event);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    hasSignature = true;
+  }
+
+  function endDraw() {
+    drawing = false;
+  }
+
+  canvas.addEventListener("mousedown", startDraw);
+  canvas.addEventListener("mousemove", moveDraw);
+  window.addEventListener("mouseup", endDraw);
+
+  canvas.addEventListener("touchstart", startDraw, { passive: false });
+  canvas.addEventListener("touchmove", moveDraw, { passive: false });
+  canvas.addEventListener("touchend", endDraw);
+
+  function clearSignature() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    hasSignature = false;
+    if (signPlaceholder) signPlaceholder.hidden = false;
+  }
+
+  clearBtn?.addEventListener("click", clearSignature);
+
+  function canvasToBlob() {
+    return new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+  }
+
+  async function submitSignature() {
+    const blob = await canvasToBlob();
+    const formData = new FormData();
+    formData.append("signature", blob, "signature.png");
+
+    const response = await fetch(
+        `/api/contracts/${contractId}/change-requests/${changeRequestId}/signature`,
+        { method: "PATCH", headers: authHeaders(), body: formData }
+    );
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      throw new Error(body?.message || `HTTP ${response.status}`);
+    }
+    return response.json();
+  }
+
+  submitBtn?.addEventListener("click", async () => {
+    if (!hasSignature) {
+      showStatus("서명 패드에 서명을 남겨 주세요.", true);
+      return;
+    }
+
+    if (!agreeCheckbox?.checked) {
+      showStatus("변경 내용 확인 및 전자 서명 동의에 체크해 주세요.", true);
+      return;
+    }
+
+    submitBtn.disabled = true;
+    showStatus("변경 요청을 전송하는 중입니다...", false);
+
+    try {
+      await submitSignature();
+
+      window.location.href =
+          `/contracts/edit-complete?contractId=${encodeURIComponent(contractId)}`;
+    } catch (err) {
+      showStatus(err.message || "변경 요청 전송에 실패했습니다. 잠시 후 다시 시도해 주세요.", true);
+      submitBtn.disabled = false;
+    }
+  });
+})();

--- a/src/main/resources/static/js/contractchange/contractchange.js
+++ b/src/main/resources/static/js/contractchange/contractchange.js
@@ -127,17 +127,19 @@ document.getElementById('changeRequestForm').addEventListener('submit', function
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(requestBody)
     })
-        .then(response => {
+        .then(async response => {
             if (!response.ok) {
-                throw new Error('요청 실패');
+                const body = await response.json().catch(() => null);
+                throw new Error(body?.message || '요청 실패');
             }
             return response.json();
         })
-        .then(() => {
-            window.location.href = `/contracts/edit-complete?contractId=${encodeURIComponent(contractId)}`;
+        .then(changeDTO => {
+            window.location.href =
+                `/contracts/${contractId}/change-requests/${changeDTO.changeRequestId}/signature`;
         })
-        .catch(() => {
-            alert('변경 요청 중 오류가 발생했습니다.');
+        .catch(err => {
+            alert(err.message || '변경 요청 중 오류가 발생했습니다.');
         });
 });
 

--- a/src/main/resources/templates/contractchange/change-request-signature.html
+++ b/src/main/resources/templates/contractchange/change-request-signature.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>계약 변경 요청 서명 | 사이원장</title>
+    <link rel="stylesheet" as="style" crossorigin
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+    <link rel="stylesheet" th:href="@{/css/contract/contract-form.css}" href="../../static/css/contract/contract-form.css" />
+    <link rel="stylesheet" th:href="@{/css/contract/contract-debtor-approve.css}" href="../../static/css/contract/contract-debtor-approve.css" />
+    <link rel="stylesheet" href="/css/contractchange/site-common.css" />
+</head>
+<body>
+
+<header class="site-header">
+    <div class="header-inner">
+        <a class="brand" href="/">사이원장</a>
+        <nav class="main-nav" aria-label="주요 메뉴">
+            <a href="#">서비스 소개</a>
+            <a class="active" href="/dashboard">금전거래대차</a>
+            <a href="/settlements">정산</a>
+            <a href="#">거래 일정</a>
+        </nav>
+        <div class="header-actions">
+            <button class="icon-button" type="button" aria-label="알림">♧</button>
+            <a class="profile-link" href="/mypage" aria-label="마이페이지">
+                <span class="profile-avatar">사</span>
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="page">
+
+    <div class="stepper-card">
+        <ol class="stepper">
+            <li class="stepper__step is-done">
+        <span class="stepper__circle">
+          <svg viewBox="0 0 16 16" width="12" height="12" fill="none">
+            <path d="M3 8.5 6.2 12 13 4" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </span>
+                <span class="stepper__label">변경 내용 작성</span>
+            </li>
+            <li class="stepper__step is-active">
+                <span class="stepper__circle">2</span>
+                <span class="stepper__label">전자서명</span>
+            </li>
+            <li class="stepper__step">
+                <span class="stepper__circle">3</span>
+                <span class="stepper__label">상대방 승인</span>
+            </li>
+        </ol>
+    </div>
+
+    <div class="doc" id="signatureCard">
+
+        <h1 class="doc__title">계 약 변 경 요 청 서 명</h1>
+
+        <div id="contractFields">
+
+            <section class="doc__article">
+                <span class="doc__clause">안내</span>
+                <div class="doc__body">
+          <span class="doc__text">
+            서명을 제출하면 변경 요청이 상대방에게 전송되고, 상대방의 승인을 거쳐 계약에 반영됩니다.
+          </span>
+                </div>
+            </section>
+
+            <section class="sign">
+                <h2 class="sign__title">서명 (Signature)</h2>
+                <p class="doc__hint">서명 패드에 수기 서명을 남겨주세요.</p>
+                <div class="sign__pad-wrap">
+                    <div class="sign__placeholder" id="signPlaceholder">SIGN HERE</div>
+                    <canvas id="signatureCanvas" class="sign__canvas" width="590" height="220"></canvas>
+                    <button type="button" class="sign__clear" id="clearSignature">지우기</button>
+                </div>
+            </section>
+
+            <div class="agreement">
+                <input type="checkbox" class="agreement__checkbox" id="agreeCheckbox" />
+                <label class="agreement__label" for="agreeCheckbox">
+                    위 변경 내용을 모두 확인하였으며, 전자 서명을 통한 변경 요청 의사를 기록합니다.
+                </label>
+            </div>
+
+            <div class="doc__actions">
+                <button type="button" class="btn btn--ghost" id="btnCancel">취소</button>
+                <button type="button" class="btn btn--primary" id="btnSubmit">전송</button>
+            </div>
+
+        </div>
+
+        <p class="doc__status" id="formStatus" role="status" aria-live="polite"></p>
+    </div>
+</main>
+
+<footer class="site-footer">
+    <div class="footer-inner">
+        <div>
+            <strong>사이원장</strong>
+            <p>© Sai-Wonjang. All rights reserved.</p>
+        </div>
+        <nav>
+            <a href="#">이용약관</a>
+            <a href="#">개인정보처리방침</a>
+            <a href="#">고객센터</a>
+        </nav>
+    </div>
+</footer>
+
+<input type="hidden" id="contractId" th:value="${contractId}" />
+<input type="hidden" id="changeRequestId" th:value="${changeRequestId}" />
+
+<script th:src="@{/js/contractchange/change-request-signature.js}" src="../../static/js/contractchange/change-request-signature.js"></script>
+</body>
+</html>

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -8,11 +8,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 import org.teamsai.saibackend.domain.contract.dto.request.ContractStatus;
 import org.teamsai.saibackend.domain.contract.dto.request.RepaymentMethod;
 import org.teamsai.saibackend.domain.contract.dto.response.ChangeLoanContractResponse;
 import org.teamsai.saibackend.domain.contract.dto.response.LoanContractResponse;
 import org.teamsai.saibackend.domain.contract.exception.LoanContractErrorCode;
+import org.teamsai.saibackend.domain.contract.service.LoanContractFileService;
 import org.teamsai.saibackend.domain.contract.service.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.dto.LoanContractChangeDTO;
 import org.teamsai.saibackend.domain.contractchange.dto.request.ContractChangeRequest;
@@ -21,21 +23,23 @@ import org.teamsai.saibackend.domain.contractchange.mapper.ContractChangeMapper;
 import org.teamsai.saibackend.domain.contractchange.service.ContractChangeService;
 import org.teamsai.saibackend.domain.contractchange.type.ChangeRequestStatus;
 import org.teamsai.saibackend.domain.notification.service.NotificationService;
+import org.teamsai.saibackend.domain.notification.type.NotificationType;
 import org.teamsai.saibackend.domain.user.dto.response.UserResponse;
 import org.teamsai.saibackend.domain.user.service.UserService;
 import org.teamsai.saibackend.global.exception.DomainException;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ContractChangeService 단위 테스트")
@@ -56,6 +60,9 @@ class ContractChangeServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private LoanContractFileService fileService;
 
     @InjectMocks
     private ContractChangeService contractChangeService;
@@ -129,6 +136,8 @@ class ContractChangeServiceTest {
                 .build();
     }
 
+
+
     @Nested
     @DisplayName("변경 요청 저장")
     class RequestChange {
@@ -140,8 +149,6 @@ class ContractChangeServiceTest {
                     .willReturn(createContract(ContractStatus.COMPLETED));
             given(contractChangeMapper.findByContractId(CONTRACT_ID))
                     .willReturn(List.of());
-            given(userService.getMyInfo(USER_ID))
-                    .willReturn(UserResponse.builder().name("채권자").build());
 
             contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID);
 
@@ -383,6 +390,134 @@ class ContractChangeServiceTest {
                     );
 
             verify(loanContractService, never()).rejectChangedContract(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("변경 요청 전자서명 제출")
+    class SubmitRequesterSignature {
+
+        private static final Long CHANGE_REQUEST_ID = 200L;
+        private static final String SAVED_PATH = "uploads/signatures/change_200_signature.png";
+
+        private LoanContractChangeDTO changeRequestDTO(ChangeRequestStatus status, Long ownerUserId, Long contractId) {
+            return LoanContractChangeDTO.builder()
+                    .changeRequestId(CHANGE_REQUEST_ID)
+                    .userId(ownerUserId)
+                    .contractId(contractId)
+                    .changeReason("이자율 조정 요청")
+                    .status(status)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+        }
+
+        @Test
+        @DisplayName("요청 등록 당사자가 대기 중인 요청에 서명하면 서명을 저장하고 상대방에게 알림을 보낸다")
+        void submitRequesterSignatureSuccess() {
+            MultipartFile signature = mock(MultipartFile.class);
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID)));
+            given(fileService.saveSignatureFile(CHANGE_REQUEST_ID, signature))
+                    .willReturn(SAVED_PATH);
+            given(loanContractService.findContract(CONTRACT_ID, USER_ID))
+                    .willReturn(createContract(ContractStatus.COMPLETED));
+            given(userService.getMyInfo(USER_ID))
+                    .willReturn(UserResponse.builder().name("채권자").build());
+
+            contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID, signature);
+
+            verify(fileService).saveSignatureFile(CHANGE_REQUEST_ID, signature);
+            verify(contractChangeMapper).updateRequesterSignature(CHANGE_REQUEST_ID, SAVED_PATH);
+            verify(notificationService).create(
+                    eq(DEBTOR_ID),
+                    eq(NotificationType.CONTRACT_CHANGE),
+                    any(),
+                    any(),
+                    eq(CONTRACT_ID),
+                    eq(CHANGE_REQUEST_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("요청을 등록한 당사자가 아니면 예외가 발생한다")
+        void submitRequesterSignatureFailsWhenNotRequester() {
+            MultipartFile signature = mock(MultipartFile.class);
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, DEBTOR_ID, signature))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
+                    );
+
+            verify(fileService, never()).saveSignatureFile(any(), any());
+            verify(contractChangeMapper, never()).updateRequesterSignature(any(), any());
+        }
+
+        @Test
+        @DisplayName("이미 처리된 요청이면 예외가 발생한다")
+        void submitRequesterSignatureFailsWhenAlreadyProcessed() {
+            MultipartFile signature = mock(MultipartFile.class);
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.APPROVED, USER_ID, CONTRACT_ID)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID, signature))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.ALREADY_BEING_REQUEST)
+                    );
+
+            verify(fileService, never()).saveSignatureFile(any(), any());
+            verify(contractChangeMapper, never()).updateRequesterSignature(any(), any());
+        }
+
+        @Test
+        @DisplayName("변경 요청이 해당 계약의 것이 아니면 예외가 발생한다")
+        void submitRequesterSignatureFailsWhenContractIdMismatch() {
+            MultipartFile signature = mock(MultipartFile.class);
+            Long otherContractId = 999L;
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, otherContractId)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID, signature))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
+                    );
+
+            verify(fileService, never()).saveSignatureFile(any(), any());
+            verify(contractChangeMapper, never()).updateRequesterSignature(any(), any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 변경 요청이면 예외가 발생한다")
+        void submitRequesterSignatureFailsWhenChangeRequestNotFound() {
+            MultipartFile signature = mock(MultipartFile.class);
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID, signature))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
+                    );
+
+            verify(fileService, never()).saveSignatureFile(any(), any());
         }
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -520,4 +520,163 @@ class ContractChangeServiceTest {
             verify(fileService, never()).saveSignatureFile(any(), any());
         }
     }
+
+    @Nested
+    @DisplayName("변경 요청 취소")
+    class CancelChangeRequest {
+
+        private static final Long CHANGE_REQUEST_ID = 300L;
+        private static final Long V2_CONTRACT_ID = 301L;
+
+        private LoanContractChangeDTO changeRequestDTO(
+                ChangeRequestStatus status, Long ownerUserId, Long contractId, String requesterSignature
+        ) {
+            return LoanContractChangeDTO.builder()
+                    .changeRequestId(CHANGE_REQUEST_ID)
+                    .userId(ownerUserId)
+                    .contractId(contractId)
+                    .changeReason("이자율 조정 요청")
+                    .status(status)
+                    .requesterSignature(requesterSignature)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+        }
+
+        private LoanContractResponse pendingV2() {
+            return LoanContractResponse.builder()
+                    .contractId(V2_CONTRACT_ID)
+                    .previousContractId(CONTRACT_ID)
+                    .status(ContractStatus.PENDING)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("서명 전 요청은 요청자 본인이 취소할 수 있고, 임시 계약도 함께 무효화한다")
+        void cancelChangeRequestSuccess() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, null)));
+            given(contractChangeMapper.updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED))
+                    .willReturn(1);
+            given(loanContractService.findPendingContractByPreviousId(CONTRACT_ID))
+                    .willReturn(Optional.of(pendingV2()));
+
+            contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID);
+
+            verify(contractChangeMapper).updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED);
+            verify(loanContractService).rejectChangedContract(V2_CONTRACT_ID);
+        }
+
+        @Test
+        @DisplayName("이미 서명을 제출한 요청은 취소할 수 없다")
+        void cancelChangeRequestFailsWhenAlreadySigned() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(
+                            ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, "uploads/signatures/change_300_signature.png"
+                    )));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.ALREADY_SIGNED)
+                    );
+
+            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(loanContractService, never()).rejectChangedContract(any());
+        }
+
+        @Test
+        @DisplayName("요청을 등록한 당사자가 아니면 취소할 수 없다")
+        void cancelChangeRequestFailsWhenNotRequester() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, null)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, DEBTOR_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
+                    );
+
+            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(loanContractService, never()).rejectChangedContract(any());
+        }
+
+        @Test
+        @DisplayName("이미 처리된(승인/반려/취소) 요청이면 취소할 수 없다")
+        void cancelChangeRequestFailsWhenAlreadyProcessed() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.APPROVED, USER_ID, CONTRACT_ID, null)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.ALREADY_BEING_REQUEST)
+                    );
+
+            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(loanContractService, never()).rejectChangedContract(any());
+        }
+
+        @Test
+        @DisplayName("변경 요청이 해당 계약의 것이 아니면 취소할 수 없다")
+        void cancelChangeRequestFailsWhenContractIdMismatch() {
+            Long otherContractId = 999L;
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, otherContractId, null)));
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
+                    );
+
+            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(loanContractService, never()).rejectChangedContract(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 변경 요청이면 취소할 수 없다")
+        void cancelChangeRequestFailsWhenChangeRequestNotFound() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
+                    );
+
+            verify(contractChangeMapper, never()).updateStatus(any(), any());
+        }
+
+        @Test
+        @DisplayName("동시 요청으로 이미 상태가 바뀌어 갱신 행이 0건이면 예외가 발생한다")
+        void cancelChangeRequestFailsWhenRaceConditionLeavesZeroRowsUpdated() {
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, null)));
+            given(contractChangeMapper.updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED))
+                    .willReturn(0);
+
+            assertThatThrownBy(() ->
+                    contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(ContractChangeErrorCode.ALREADY_BEING_REQUEST)
+                    );
+
+            verify(loanContractService, never()).rejectChangedContract(any());
+        }
+    }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -421,6 +421,8 @@ class ContractChangeServiceTest {
                     .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID)));
             given(fileService.saveSignatureFile(CHANGE_REQUEST_ID, signature))
                     .willReturn(SAVED_PATH);
+            given(contractChangeMapper.updateRequesterSignature(CHANGE_REQUEST_ID, SAVED_PATH))
+                    .willReturn(1);
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
                     .willReturn(createContract(ContractStatus.COMPLETED));
             given(userService.getMyInfo(USER_ID))
@@ -556,14 +558,14 @@ class ContractChangeServiceTest {
         void cancelChangeRequestSuccess() {
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
                     .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, null)));
-            given(contractChangeMapper.updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED))
+            given(contractChangeMapper.cancelPendingUnsignedRequest(CHANGE_REQUEST_ID))
                     .willReturn(1);
             given(loanContractService.findPendingContractByPreviousId(CONTRACT_ID))
                     .willReturn(Optional.of(pendingV2()));
 
             contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID);
 
-            verify(contractChangeMapper).updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED);
+            verify(contractChangeMapper).cancelPendingUnsignedRequest(CHANGE_REQUEST_ID);
             verify(loanContractService).rejectChangedContract(V2_CONTRACT_ID);
         }
 
@@ -574,6 +576,8 @@ class ContractChangeServiceTest {
                     .willReturn(Optional.of(changeRequestDTO(
                             ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, "uploads/signatures/change_300_signature.png"
                     )));
+            given(contractChangeMapper.cancelPendingUnsignedRequest(CHANGE_REQUEST_ID))
+                    .willReturn(0);   // ← DB 조건(requester_signature IS NULL)에 안 걸려서 0건
 
             assertThatThrownBy(() ->
                     contractChangeService.cancelChangeRequest(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID))
@@ -583,7 +587,7 @@ class ContractChangeServiceTest {
                                     .isEqualTo(ContractChangeErrorCode.ALREADY_SIGNED)
                     );
 
-            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(contractChangeMapper).cancelPendingUnsignedRequest(CHANGE_REQUEST_ID);   // never() → 호출은 되지만 실패로 처리됨
             verify(loanContractService, never()).rejectChangedContract(any());
         }
 
@@ -601,7 +605,7 @@ class ContractChangeServiceTest {
                                     .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
                     );
 
-            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(contractChangeMapper, never()).cancelPendingUnsignedRequest(any());
             verify(loanContractService, never()).rejectChangedContract(any());
         }
 
@@ -619,7 +623,7 @@ class ContractChangeServiceTest {
                                     .isEqualTo(ContractChangeErrorCode.ALREADY_BEING_REQUEST)
                     );
 
-            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(contractChangeMapper, never()).cancelPendingUnsignedRequest(any());
             verify(loanContractService, never()).rejectChangedContract(any());
         }
 
@@ -639,7 +643,7 @@ class ContractChangeServiceTest {
                                     .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
                     );
 
-            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(contractChangeMapper, never()).cancelPendingUnsignedRequest(any());
             verify(loanContractService, never()).rejectChangedContract(any());
         }
 
@@ -657,15 +661,15 @@ class ContractChangeServiceTest {
                                     .isEqualTo(ContractChangeErrorCode.CHANGE_REQUEST_NOT_FOUND)
                     );
 
-            verify(contractChangeMapper, never()).updateStatus(any(), any());
+            verify(contractChangeMapper, never()).cancelPendingUnsignedRequest(any());
         }
 
         @Test
-        @DisplayName("동시 요청으로 이미 상태가 바뀌어 갱신 행이 0건이면 예외가 발생한다")
+        @DisplayName("동시 요청으로 이미 서명이 제출되어 갱신 행이 0건이면 예외가 발생한다")
         void cancelChangeRequestFailsWhenRaceConditionLeavesZeroRowsUpdated() {
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
                     .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, USER_ID, CONTRACT_ID, null)));
-            given(contractChangeMapper.updateStatus(CHANGE_REQUEST_ID, ChangeRequestStatus.CANCELLED))
+            given(contractChangeMapper.cancelPendingUnsignedRequest(CHANGE_REQUEST_ID))
                     .willReturn(0);
 
             assertThatThrownBy(() ->
@@ -673,7 +677,7 @@ class ContractChangeServiceTest {
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(ContractChangeErrorCode.ALREADY_BEING_REQUEST)
+                                    .isEqualTo(ContractChangeErrorCode.ALREADY_SIGNED)
                     );
 
             verify(loanContractService, never()).rejectChangedContract(any());


### PR DESCRIPTION
## 🔗 연관 이슈
- feat: 계약 변경 요청 전자서명 스텝 추가

## 🛠 작업 사항
- 계약 변경 요청 시 전자서명 제출 절차 추가 (요청 등록 → 서명 → 상대방 알림)
- 요청자가 서명 전 자신의 요청을 취소할 수 있는 기능 추가
- 관련 상태(CANCELLED), 에러코드(ALREADY_SIGNED) 추가

## 왜 2단계 + 취소 기능으로 설계했는가
요청 등록과 서명을 한 번에 처리하면, 요청 등록 후 서명을 완료하지
못하고 이탈하는 경우(브라우저 종료 등) 해당 계약의 변경 요청이 서명 없이
PENDING 상태로 영구히 남아 이후 어떤 변경 요청도 불가능해지는 문제가
있어, 서명 전 요청을 취소할 수 있는 API를 함께 추가했습니다.
서명이 완료돼 상대방에게 이미 전송된 요청은 취소할 수 없도록 제한했습니다.

## ✅ 테스트
- [x] 로컬 서버 테스트 완료
- [x] ContractChangeServiceTest 신규 케이스 12개(서명 5, 취소 7) 작성 및 통과
- [x] 기존 기능에 영향 없음 확인

## 📌 주의 사항 및 참고사항
- DB 마이그레이션 필요
  - loan_contract_change_request.requester_signature 컬럼 추가
  - status CHECK 제약조건에 CANCELLED 추가