### PR TITLE
feat(#153): 정기정산 기능 구현

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/settlement/controller/RecurringSettlementController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/controller/RecurringSettlementController.java
@@ -1,0 +1,50 @@
+package org.teamsai.saibackend.domain.settlement.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateRecurringSettlementRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateRecurringSettlementResponse;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementService;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
+
+@Tag(
+        name = "정기정산 API",
+        description = "정기정산 설정 및 관리 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/settlements/recurring")
+public class RecurringSettlementController {
+
+    private final RecurringSettlementService recurringSettlementService;
+
+    @Operation(
+            summary = "정기정산 생성",
+            description = "정기정산을 등록하고 최초 정산 회차를 생성합니다."
+    )
+    @PostMapping
+    public ResponseEntity<CreateRecurringSettlementResponse>
+    createRecurringSettlement(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Valid
+            @RequestBody CreateRecurringSettlementRequest request
+    ) {
+
+        CreateRecurringSettlementResponse response =
+                recurringSettlementService.create(
+                        userDetails.getUserId(),
+                        request
+                );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateRecurringSettlementRequest.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/request/CreateRecurringSettlementRequest.java
@@ -1,0 +1,54 @@
+package org.teamsai.saibackend.domain.settlement.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.settlement.type.CycleRule;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateRecurringSettlementRequest {
+    @NotBlank(message = "정산 성격을 입력해 주세요.")
+    @Size(max = 50, message = "정산 성격은 50자 이하로 입력해 주세요.")
+    private String settlementCategory;
+
+    @NotBlank(message = "정산명을 입력해 주세요.")
+    @Size(max = 200, message = "정산명은 200자 이하로 입력해 주세요.")
+    private String title;
+
+    @NotNull(message = "총 금액을 입력해 주세요.")
+    @DecimalMin(value = "1", message = "총 금액은 1원 이상이어야 합니다.")
+    @Digits(integer = 13, fraction = 0, message = "총 금액은 원 단위로 입력해 주세요.")
+    private BigDecimal totalAmount;
+
+    @NotNull(message = "정산 주기를 선택해 주세요.")
+    private CycleRule cycleRule;
+
+    @NotNull(message = "정기정산 시작일을 입력해 주세요.")
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @NotNull(message = "정산 수취 계좌를 선택해 주세요.")
+    private Long linkedAccountId;
+
+    @Valid
+    @NotEmpty(message = "참여자를 한 명 이상 선택해 주세요.")
+    private List<CreateSettlementParticipantRequest> participants;
+
+    @AssertTrue(message = "종료일은 시작일보다 빠를 수 없습니다.")
+    public boolean isValidPeriod() {
+        return startDate == null
+                || endDate == null
+                || !endDate.isBefore(startDate);
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/CreateRecurringSettlementResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/CreateRecurringSettlementResponse.java
@@ -1,0 +1,34 @@
+package org.teamsai.saibackend.domain.settlement.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.teamsai.saibackend.domain.settlement.type.CycleRule;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateRecurringSettlementResponse {
+
+    private Long recurringSettlementId;
+
+    private Long firstSettlementId;
+
+    private SettlementType settlementType;
+
+    private String title;
+
+    private CycleRule cycleRule;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementDetailResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementDetailResponse.java
@@ -11,6 +11,8 @@ public record SettlementDetailResponse(
         String settlementStatus,
         String splitType,
         LocalDate dueDate,
+        LocalDate startDate,
+        LocalDate endDate,
         LocalDateTime createdAt,
         String role
 ) {

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
@@ -13,6 +13,8 @@ public record SettlementListResponse(
         String splitType,
         String settlementStatus,
         LocalDate dueDate,
+        LocalDate startDate,
+        LocalDate endDate,
         @JsonIgnore LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/RecurringSettlementManagementMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/mapper/RecurringSettlementManagementMapper.java
@@ -1,0 +1,9 @@
+package org.teamsai.saibackend.domain.settlement.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+
+@Mapper
+public interface RecurringSettlementManagementMapper {
+    int insert(RecurringSettlementDTO recurringSettlement);
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementService.java
@@ -1,0 +1,110 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateRecurringSettlementRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateRecurringSettlementResponse;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementManagementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+import org.teamsai.saibackend.domain.settlement.type.SplitType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RecurringSettlementService {
+    private final RecurringSettlementManagementMapper recurringSettlementManagementMapper;
+
+    private final SettlementMapper settlementMapper;
+
+    private final RecurringSettlementValidator recurringSettlementValidator;
+
+    private final SettlementAmountCalculator settlementAmountCalculator;
+
+    private final SettlementParticipantRegistrationService participantRegistrationService;
+
+    private final SettlementAccountService settlementAccountService;
+
+    @Transactional
+    public CreateRecurringSettlementResponse create(
+            Long ownerId, CreateRecurringSettlementRequest request
+    ){
+        recurringSettlementValidator.validateCreateRequest(request);
+
+        BigDecimal perPersonAmount =
+                settlementAmountCalculator.calculateEqualAmount(
+                        request.getTotalAmount(),
+                        request.getParticipants().size()
+                );
+
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        RecurringSettlementDTO recurringSettlement =
+                RecurringSettlementDTO.builder()
+                        .ownerId(ownerId)
+                        .settlementCategory(request.getSettlementCategory())
+                        .title(request.getTitle())
+                        .splitType(SplitType.EQUAL)
+                        .totalAmount(request.getTotalAmount())
+                        .cycleRule(request.getCycleRule())
+                        .startDate(request.getStartDate())
+                        .endDate(request.getEndDate())
+                        .createdAt(createdAt)
+                        .build();
+        int recurringInserted = recurringSettlementManagementMapper.insert(
+                recurringSettlement
+        );
+
+        if(recurringInserted != 1){
+            throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
+        }
+
+        SettlementDTO firstSettlement =
+                SettlementDTO.builder()
+                        .recurringSettlementId(recurringSettlement.getRecurringSettlementId())
+                        .ownerId(ownerId)
+                        .settlementType(SettlementType.RECURRING)
+                        .settlementStatus(SettlementStatus.IN_PROGRESS)
+                        .settlementCategory(request.getSettlementCategory())
+                        .title(request.getTitle())
+                        .splitType(SplitType.EQUAL)
+                        .totalAmount(request.getTotalAmount())
+                        .dueDate(null)
+                        .cycleDate(request.getStartDate())
+                        .createdAt(createdAt)
+                        .build();
+
+        int settlementInserted =
+                settlementMapper.insertSettlement(firstSettlement);
+
+        if(settlementInserted != 1){
+            throw SettlementErrorCode.SETTLEMENT_CREATE_FAILED.toException();
+        }
+
+        participantRegistrationService.registerParticipants(
+                ownerId,firstSettlement.getSettlementId(),request.getParticipants(),perPersonAmount
+        );
+
+        settlementAccountService.selectAccount(
+                ownerId, firstSettlement.getSettlementId(), request.getLinkedAccountId());
+
+        return CreateRecurringSettlementResponse.builder()
+                .recurringSettlementId(recurringSettlement.getRecurringSettlementId())
+                .firstSettlementId(firstSettlement.getSettlementId())
+                .settlementType(firstSettlement.getSettlementType())
+                .title(firstSettlement.getTitle())
+                .cycleRule(recurringSettlement.getCycleRule())
+                .startDate(recurringSettlement.getStartDate())
+                .endDate(recurringSettlement.getEndDate())
+                .createdAt(createdAt)
+                .build();
+
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementValidator.java
@@ -1,0 +1,27 @@
+package org.teamsai.saibackend.domain.settlement.service;
+
+import org.springframework.stereotype.Component;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateRecurringSettlementRequest;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementParticipantRequest;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class RecurringSettlementValidator {
+
+    public void validateCreateRequest(CreateRecurringSettlementRequest request){
+        if(request == null){
+            throw SettlementErrorCode.INVALID_SETTLEMENT_REQUEST.toException();
+        }
+
+        Set<String> userTokens = new HashSet<>();
+
+        for(CreateSettlementParticipantRequest participant : request.getParticipants()){
+            if(participant == null || participant.getUserToken() == null || participant.getUserToken().isBlank()){
+                throw  SettlementErrorCode.INVALID_SETTLEMENT_PARTICIPANT.toException();
+            }
+        }
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementValidator.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/service/RecurringSettlementValidator.java
@@ -18,9 +18,17 @@ public class RecurringSettlementValidator {
 
         Set<String> userTokens = new HashSet<>();
 
-        for(CreateSettlementParticipantRequest participant : request.getParticipants()){
-            if(participant == null || participant.getUserToken() == null || participant.getUserToken().isBlank()){
-                throw  SettlementErrorCode.INVALID_SETTLEMENT_PARTICIPANT.toException();
+        for (CreateSettlementParticipantRequest participant : request.getParticipants()) {
+            if (
+                    participant == null ||
+                            participant.getUserToken() == null ||
+                            participant.getUserToken().isBlank()
+            ) {
+                throw SettlementErrorCode.INVALID_SETTLEMENT_PARTICIPANT.toException();
+            }
+
+            if (!userTokens.add(participant.getUserToken())) {
+                throw SettlementErrorCode.DUPLICATE_SETTLEMENT_PARTICIPANT.toException();
             }
         }
     }

--- a/src/main/resources/mapper/settlement/RecurringSettlementManagementMapper.xml
+++ b/src/main/resources/mapper/settlement/RecurringSettlementManagementMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementManagementMapper">
+
+    <insert id="insert"
+            useGeneratedKeys="true"
+            keyProperty="recurringSettlementId">
+
+        INSERT INTO recurring_settlement (
+            owner_id,
+            settlement_category,
+            title,
+            split_type,
+            total_amount,
+            cycle_rule,
+            start_date,
+            end_date,
+            created_at
+        )
+        VALUES (
+            #{ownerId},
+            #{settlementCategory},
+            #{title},
+            #{splitType},
+            #{totalAmount},
+            #{cycleRule},
+            #{startDate},
+            #{endDate},
+            #{createdAt}
+        )
+
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -116,8 +116,7 @@
         s.title AS title,
 
         CASE
-        WHEN s.owner_id = #{userId}
-        THEN 'OWNER'
+        WHEN s.owner_id = #{userId} THEN 'OWNER'
         ELSE 'MEMBER'
         END AS role,
 
@@ -126,6 +125,8 @@
         s.split_type AS splitType,
         s.settlement_status AS settlementStatus,
         s.due_date AS dueDate,
+        rs.start_date AS startDate,
+        rs.end_date AS endDate,
         s.created_at AS createdAt
 
         FROM settlement s
@@ -134,6 +135,9 @@
         ON sp.settlement_id = s.settlement_id
         AND sp.user_id = #{userId}
         AND sp.participant_status = 'ACTIVE'
+
+        LEFT JOIN recurring_settlement rs
+        ON rs.recurring_settlement_id = s.recurring_settlement_id
 
         WHERE
         s.owner_id = #{userId}
@@ -153,15 +157,13 @@
         s.settlement_status AS settlementStatus,
         s.split_type AS splitType,
         s.due_date AS dueDate,
+        rs.start_date AS startDate,
+        rs.end_date AS endDate,
         s.created_at AS createdAt,
 
         CASE
-        WHEN s.owner_id = #{userId}
-        THEN 'OWNER'
-
-        WHEN sp.participant_id IS NOT NULL
-        THEN 'MEMBER'
-
+        WHEN s.owner_id = #{userId} THEN 'OWNER'
+        WHEN sp.participant_id IS NOT NULL THEN 'MEMBER'
         ELSE 'NONE'
         END AS role
 
@@ -171,6 +173,9 @@
         ON sp.settlement_id = s.settlement_id
         AND sp.user_id = #{userId}
         AND sp.participant_status = 'ACTIVE'
+
+        LEFT JOIN recurring_settlement rs
+        ON rs.recurring_settlement_id = s.recurring_settlement_id
 
         WHERE s.settlement_id = #{settlementId}
 

--- a/src/main/resources/static/js/settlement/settlement-create.js
+++ b/src/main/resources/static/js/settlement/settlement-create.js
@@ -8,41 +8,151 @@ document.addEventListener("DOMContentLoaded", () => {
     const dueDateInput = document.getElementById("due-date");
     const totalAmountInput = document.getElementById("total-amount");
     const settlementAccountSelect = document.getElementById("settlement-account");
-    const summaryAccount = document.getElementById("summary-account");
+
     const participantTokenInput = document.getElementById("participant-token");
     const lookupParticipantButton = document.getElementById("lookup-participant-button");
     const participantChips = document.getElementById("participant-chips");
     const participantEmptyMessage = document.getElementById("participant-empty-message");
+    const ownerChip = document.getElementById("owner-chip");
 
+    const cycleRuleSelect = document.getElementById("cycle-rule");
+    const recurringStartDateInput = document.getElementById("recurring-start-date");
+    const recurringEndDateInput = document.getElementById("recurring-end-date");
+    const sharedDateSection = document.getElementById("shared-date-section");
+    const recurringSettingSection = document.getElementById("recurring-setting-section");
+
+    const tabs = document.querySelectorAll(".settlement-type-tabs .type-tab");
+    const sharedTab = tabs[0];
+    const recurringTab = tabs[1];
+
+    const createDescription = document.querySelector(".create-heading p");
+    const summaryHeader = document.querySelector(".summary-header");
     const summaryTitle = document.getElementById("summary-title");
     const summaryCategory = document.getElementById("summary-category");
     const summaryDueDate = document.getElementById("summary-due-date");
+    const summaryDueDateLabel = summaryDueDate?.closest("div")?.querySelector("dt");
     const summarySplitType = document.getElementById("summary-split-type");
     const summaryTotalAmount = document.getElementById("summary-total-amount");
     const summaryParticipantCount = document.getElementById("summary-participant-count");
     const summaryPerPersonAmount = document.getElementById("summary-per-person-amount");
-    const ownerChip = document.getElementById("owner-chip");
+    const summaryAccount = document.getElementById("summary-account");
+
     const selectedParticipants = new Map();
 
+    const categoryOptions = {
+        SHARED: [
+            ["", "선택해 주세요"],
+            ["여행", "여행"],
+            ["생활비", "생활비"],
+            ["회식", "회식"],
+            ["공동구매", "공동구매"],
+            ["모임", "모임"],
+            ["기타", "기타"]
+        ],
+        RECURRING: [
+            ["", "선택해 주세요"],
+            ["OTT·구독", "OTT·구독"],
+            ["정기회비", "정기회비"],
+            ["공과금", "공과금"],
+            ["공동생활비", "공동생활비"],
+            ["간병·가족비용", "간병·가족비용"],
+            ["교육·스터디", "교육·스터디"],
+            ["정기공동구매", "정기공동구매"],
+            ["기타", "기타"]
+        ]
+    };
+
+    let settlementType = "SHARED";
+    let submitting = false;
+
     setMinimumDueDate();
+    bindSettlementTabs();
     bindSummary();
     bindChoiceCards();
     bindTotalAmount();
     bindParticipantLookup();
     bindSettlementAccount();
+    bindRecurringDates();
     updateParticipantView();
+    changeSettlementType("SHARED");
     loadCurrentUser();
     loadLinkedAccounts();
 
-    form.addEventListener("submit", submitSharedSettlement);
+    form.addEventListener("submit", submitSettlement);
 
     function setMinimumDueDate() {
         const today = new Date();
         const year = today.getFullYear();
         const month = String(today.getMonth() + 1).padStart(2, "0");
         const day = String(today.getDate()).padStart(2, "0");
-
         dueDateInput.min = `${year}-${month}-${day}`;
+    }
+
+    function bindSettlementTabs() {
+        sharedTab.addEventListener("click", () => changeSettlementType("SHARED"));
+        recurringTab.addEventListener("click", () => changeSettlementType("RECURRING"));
+    }
+
+    function changeSettlementType(type) {
+        settlementType = type;
+        const shared = type === "SHARED";
+
+        sharedTab.classList.toggle("active", shared);
+        recurringTab.classList.toggle("active", !shared);
+        sharedTab.setAttribute("aria-selected", String(shared));
+        recurringTab.setAttribute("aria-selected", String(!shared));
+
+        sharedDateSection.hidden = !shared;
+        recurringSettingSection.hidden = shared;
+
+        dueDateInput.required = shared;
+        cycleRuleSelect.required = !shared;
+        recurringStartDateInput.required = !shared;
+
+        clearError("dueDate");
+        clearError("cycleRule");
+        clearError("startDate");
+        clearError("endDate");
+
+        updateFormByType();
+        updateSubmitButton();
+    }
+
+    function updateFormByType() {
+        const shared = settlementType === "SHARED";
+
+        categorySelect.innerHTML = categoryOptions[settlementType]
+            .map(([value, label]) => `<option value="${value}">${label}</option>`)
+            .join("");
+
+        categorySelect.value = "";
+        summaryCategory.textContent = "선택 전";
+
+        if (shared) {
+            titleInput.placeholder = "예: 제주 여행 경비";
+            summaryHeader.textContent = "공동 정산 요약";
+            summaryDueDateLabel.textContent = "정산 마감일";
+
+            if (createDescription) {
+                createDescription.textContent =
+                    "총 금액과 참여자를 선택하면 참여자별 납부 예정 금액을 균등하게 계산합니다.";
+            }
+
+            summaryDueDate.textContent =
+                formatDate(dueDateInput.value) || "선택 전";
+        } else {
+            titleInput.placeholder = "예: 부모님 간병비 월 분담";
+            summaryHeader.textContent = "정기 정산 요약";
+            summaryDueDateLabel.textContent = "정기 시작일";
+
+            if (createDescription) {
+                createDescription.textContent =
+                    "구독료, 회비, 공과금, 간병비처럼 반복되는 공동 비용을 정기적으로 관리합니다.";
+            }
+
+            summaryDueDate.textContent =
+                formatDate(recurringStartDateInput.value) || "선택 전";
+        }
     }
 
     function bindSummary() {
@@ -56,10 +166,12 @@ document.addEventListener("DOMContentLoaded", () => {
         });
 
         dueDateInput.addEventListener("change", () => {
-            summaryDueDate.textContent = formatDate(dueDateInput.value) || "선택 전";
+            if (settlementType === "SHARED") {
+                summaryDueDate.textContent = formatDate(dueDateInput.value) || "선택 전";
+            }
         });
 
-        document.querySelectorAll('input[name="splitType"]').forEach((radio) => {
+        document.querySelectorAll('input[name="splitType"]').forEach(radio => {
             radio.addEventListener("change", () => {
                 summarySplitType.textContent =
                     radio.value === "CUSTOM" ? "직접 설정" : "균등 분배";
@@ -67,16 +179,33 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
+    function bindRecurringDates() {
+        recurringStartDateInput.addEventListener("change", () => {
+            recurringEndDateInput.min = recurringStartDateInput.value || "";
+
+            if (
+                recurringEndDateInput.value &&
+                recurringStartDateInput.value &&
+                recurringEndDateInput.value < recurringStartDateInput.value
+            ) {
+                recurringEndDateInput.value = "";
+            }
+
+            if (settlementType === "RECURRING") {
+                summaryDueDate.textContent =
+                    formatDate(recurringStartDateInput.value) || "선택 전";
+            }
+        });
+    }
+
     function bindChoiceCards() {
-        document.querySelectorAll(".choice-card").forEach((card) => {
+        document.querySelectorAll(".choice-card").forEach(card => {
             card.addEventListener("click", () => {
                 const radio = card.querySelector('input[type="radio"]');
 
-                if (!radio || radio.disabled) {
-                    return;
-                }
+                if (!radio || radio.disabled) return;
 
-                document.querySelectorAll(".choice-card").forEach((item) => {
+                document.querySelectorAll(".choice-card").forEach(item => {
                     item.classList.remove("selected");
                 });
 
@@ -90,7 +219,6 @@ document.addEventListener("DOMContentLoaded", () => {
     function bindTotalAmount() {
         totalAmountInput.addEventListener("input", () => {
             const rawAmount = extractAmount(totalAmountInput.value).slice(0, 13);
-
             totalAmountInput.value = formatAmountInput(rawAmount);
             updateAmountSummary();
         });
@@ -99,11 +227,8 @@ document.addEventListener("DOMContentLoaded", () => {
     function bindParticipantLookup() {
         lookupParticipantButton.addEventListener("click", lookupAndAddParticipant);
 
-        participantTokenInput.addEventListener("keydown", (event) => {
-            if (event.key !== "Enter") {
-                return;
-            }
-
+        participantTokenInput.addEventListener("keydown", event => {
+            if (event.key !== "Enter") return;
             event.preventDefault();
             lookupAndAddParticipant();
         });
@@ -143,24 +268,18 @@ document.addEventListener("DOMContentLoaded", () => {
                 );
             }
 
-            const normalizedParticipant = normalizeLookupUser(
-                responseBody,
-                userToken
-            );
+            const participant = normalizeLookupUser(responseBody, userToken);
 
-            if (selectedParticipants.has(normalizedParticipant.userToken)) {
+            if (selectedParticipants.has(participant.userToken)) {
                 setError("participantLookup", "이미 추가한 참여자입니다.");
                 return;
             }
 
-            selectedParticipants.set(
-                normalizedParticipant.userToken,
-                normalizedParticipant
-            );
-
+            selectedParticipants.set(participant.userToken, participant);
             participantTokenInput.value = "";
             updateParticipantView();
-            showToast(`${normalizedParticipant.name} 님을 참여자로 추가했습니다.`);
+
+            showToast(`${participant.name} 님을 참여자로 추가했습니다.`);
         } catch (error) {
             setError(
                 "participantLookup",
@@ -170,57 +289,38 @@ document.addEventListener("DOMContentLoaded", () => {
             setParticipantLookupLoading(false);
         }
     }
+
     async function loadLinkedAccounts() {
         try {
-            const response = await authFetch(
-                "/api/linked-accounts",
-                {
-                    method: "GET",
-                    headers: {
-                        "Accept": "application/json"
-                    }
-                }
-            );
+            const response = await authFetch("/api/linked-accounts", {
+                method: "GET",
+                headers: { "Accept": "application/json" }
+            });
 
             if (!response.ok) {
-                throw new Error(
-                    "연동 계좌를 불러오지 못했습니다."
-                );
+                throw new Error("연동 계좌를 불러오지 못했습니다.");
             }
 
             const responseBody = await readJsonSafely(response);
-
-            const accounts =
-                responseBody?.data ??
-                responseBody ??
-                [];
+            const accounts = responseBody?.data ?? responseBody ?? [];
 
             settlementAccountSelect.innerHTML =
                 '<option value="">계좌를 선택해 주세요</option>';
 
-            accounts.forEach((account) => {
-                const option =
-                    document.createElement("option");
+            accounts.forEach(account => {
+                const option = document.createElement("option");
 
-                option.value =
-                    account.linkedAccountId;
-
+                option.value = account.linkedAccountId;
                 option.textContent = [
                     account.bankName,
                     account.accountAlias,
                     account.maskedAccountNumber
-                ]
-                    .filter(Boolean)
-                    .join(" ");
+                ].filter(Boolean).join(" ");
 
                 settlementAccountSelect.appendChild(option);
             });
-
         } catch (error) {
-            console.error(
-                "연동 계좌 조회 실패",
-                error
-            );
+            console.error("연동 계좌 조회 실패", error);
         }
     }
 
@@ -235,9 +335,9 @@ document.addEventListener("DOMContentLoaded", () => {
     function updateParticipantView() {
         participantChips
             .querySelectorAll(".participant-chip.removable")
-            .forEach((chip) => chip.remove());
+            .forEach(chip => chip.remove());
 
-        selectedParticipants.forEach((participant) => {
+        selectedParticipants.forEach(participant => {
             const chip = document.createElement("span");
             chip.className = "participant-chip removable";
             chip.dataset.userToken = participant.userToken;
@@ -258,6 +358,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 `${participant.name} 참여자에서 제거`
             );
             removeButton.textContent = "×";
+
             removeButton.addEventListener("click", () => {
                 selectedParticipants.delete(participant.userToken);
                 updateParticipantView();
@@ -278,29 +379,29 @@ document.addEventListener("DOMContentLoaded", () => {
         const rawAmount = extractAmount(totalAmountInput.value);
         const totalAmount = rawAmount ? Number(rawAmount) : 0;
 
-        summaryTotalAmount.textContent = totalAmount > 0
-            ? `${totalAmount.toLocaleString("ko-KR")}원`
-            : "입력 전";
+        summaryTotalAmount.textContent =
+            totalAmount > 0
+                ? `${totalAmount.toLocaleString("ko-KR")}원`
+                : "입력 전";
 
         const participantCount = selectedParticipants.size + 1;
-        const perPersonAmount = totalAmount > 0
-            ? Math.floor(totalAmount / participantCount)
-            : 0;
 
-        summaryPerPersonAmount.textContent = perPersonAmount > 0
-            ? `${perPersonAmount.toLocaleString("ko-KR")}원`
-            : "계산 전";
+        const perPersonAmount =
+            totalAmount > 0
+                ? Math.floor(totalAmount / participantCount)
+                : 0;
+
+        summaryPerPersonAmount.textContent =
+            perPersonAmount > 0
+                ? `${perPersonAmount.toLocaleString("ko-KR")}원`
+                : "계산 전";
     }
 
     async function loadCurrentUser() {
         try {
-            const response = await authFetch(
-                "/api/users/me"
-            );
+            const response = await authFetch("/api/users/me");
 
-            if (!response.ok) {
-                return;
-            }
+            if (!response.ok) return;
 
             const user = await response.json();
             const name = user.name || user.userName;
@@ -313,32 +414,34 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    function bindSettlementAccount() {
+        settlementAccountSelect.addEventListener("change", () => {
+            const selectedOption =
+                settlementAccountSelect.options[settlementAccountSelect.selectedIndex];
+
+            summaryAccount.textContent =
+                settlementAccountSelect.value
+                    ? selectedOption.text
+                    : "아직 설정되지 않음";
+        });
+    }
+
+    function submitSettlement(event) {
+        if (settlementType === "RECURRING") {
+            submitRecurringSettlement(event);
+        } else {
+            submitSharedSettlement(event);
+        }
+    }
+
     async function submitSharedSettlement(event) {
         event.preventDefault();
         clearErrors();
 
-        const rawTotalAmount = extractAmount(totalAmountInput.value);
+        const payload = buildCommonPayload();
+        payload.dueDate = dueDateInput.value;
 
-        const payload = {
-            settlementCategory: categorySelect.value,
-            title: titleInput.value.trim(),
-            dueDate: dueDateInput.value,
-            totalAmount: rawTotalAmount
-                ? Number(rawTotalAmount)
-                : null,
-
-            linkedAccountId: settlementAccountSelect.value
-                ? Number(settlementAccountSelect.value)
-                : null,
-
-            participants:
-                Array.from(selectedParticipants.values())
-                    .map((participant) => ({
-                        userToken: participant.userToken
-                    }))
-        };
-
-        if (!validate(payload)) {
+        if (!validateShared(payload)) {
             showToast("필수 입력값을 확인해 주세요.", true);
             return;
         }
@@ -346,19 +449,13 @@ document.addEventListener("DOMContentLoaded", () => {
         setSubmitting(true);
 
         try {
-            const response = await authFetch(
-                "/api/settlements/shared",
-                {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify(payload)
-                }
-            );
+            const response = await authFetch("/api/settlements/shared", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload)
+            });
 
-            const responseBody =
-                await readJsonSafely(response);
+            const responseBody = await readJsonSafely(response);
 
             if (!response.ok) {
                 throw new Error(
@@ -368,35 +465,160 @@ document.addEventListener("DOMContentLoaded", () => {
                 );
             }
 
-            const recentSettlement = {
-                ...responseBody,
-                settlementCategory:
-                    payload.settlementCategory,
-                splitType: "EQUAL",
-                dueDate: payload.dueDate,
-                totalAmount: payload.totalAmount,
-                participantCount:
-                    payload.participants.length + 1,
-                linkedAccountId:payload.linkedAccountId
-            };
-
             sessionStorage.setItem(
                 "recentCreatedSettlement",
-                JSON.stringify(recentSettlement)
+                JSON.stringify({
+                    ...responseBody,
+                    settlementCategory: payload.settlementCategory,
+                    splitType: "EQUAL",
+                    dueDate: payload.dueDate,
+                    totalAmount: payload.totalAmount,
+                    participantCount: payload.participants.length + 1,
+                    linkedAccountId: payload.linkedAccountId
+                })
             );
 
             window.location.href =
-                `/settlements?created=${encodeURIComponent(
-                    responseBody.settlementId
-                )}`;
+                `/settlements?created=${encodeURIComponent(responseBody.settlementId)}`;
         } catch (error) {
-            showToast(error.message || "요청 처리 중 오류가 발생했습니다.", true);
+            showToast(
+                error.message || "요청 처리 중 오류가 발생했습니다.",
+                true
+            );
         } finally {
             setSubmitting(false);
         }
     }
 
-    function validate(payload) {
+    async function submitRecurringSettlement(event) {
+        event.preventDefault();
+        clearErrors();
+
+        const payload = {
+            ...buildCommonPayload(),
+            cycleRule: cycleRuleSelect.value,
+            startDate: recurringStartDateInput.value,
+            endDate: recurringEndDateInput.value || null
+        };
+
+        if (!validateRecurring(payload)) {
+            showToast("필수 입력값을 확인해 주세요.", true);
+            return;
+        }
+
+        setSubmitting(true);
+
+        try {
+            const response = await authFetch("/api/settlements/recurring", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload)
+            });
+
+            const responseBody = await readJsonSafely(response);
+
+            if (!response.ok) {
+                throw new Error(
+                    getValidationMessage(responseBody) ||
+                    responseBody?.message ||
+                    "정기정산 생성에 실패했습니다."
+                );
+            }
+
+            const settlementId =
+                responseBody?.firstSettlementId ??
+                responseBody?.settlementId;
+
+            sessionStorage.setItem(
+                "recentCreatedSettlement",
+                JSON.stringify({
+                    ...responseBody,
+                    settlementId,
+                    settlementType: "RECURRING",
+                    settlementCategory: payload.settlementCategory,
+                    splitType: "EQUAL",
+                    dueDate: null,
+                    cycleDate: payload.startDate,
+                    cycleRule: payload.cycleRule,
+                    startDate: payload.startDate,
+                    endDate: payload.endDate,
+                    totalAmount: payload.totalAmount,
+                    participantCount: payload.participants.length + 1,
+                    linkedAccountId: payload.linkedAccountId
+                })
+            );
+
+            window.location.href = settlementId
+                ? `/settlements?created=${encodeURIComponent(settlementId)}`
+                : "/settlements";
+        } catch (error) {
+            showToast(
+                error.message || "정기정산 생성 중 오류가 발생했습니다.",
+                true
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    function buildCommonPayload() {
+        const rawTotalAmount = extractAmount(totalAmountInput.value);
+
+        return {
+            settlementCategory: categorySelect.value,
+            title: titleInput.value.trim(),
+            totalAmount: rawTotalAmount ? Number(rawTotalAmount) : null,
+            linkedAccountId: settlementAccountSelect.value
+                ? Number(settlementAccountSelect.value)
+                : null,
+            participants: Array.from(selectedParticipants.values()).map(
+                participant => ({
+                    userToken: participant.userToken
+                })
+            )
+        };
+    }
+
+    function validateShared(payload) {
+        let valid = validateCommon(payload);
+
+        if (!payload.dueDate) {
+            setError("dueDate", "정산 마감일을 입력해 주세요.");
+            valid = false;
+        } else if (payload.dueDate < dueDateInput.min) {
+            setError("dueDate", "정산 마감일은 오늘 이후여야 합니다.");
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    function validateRecurring(payload) {
+        let valid = validateCommon(payload);
+
+        if (!payload.cycleRule) {
+            setError("cycleRule", "반복 주기를 선택해 주세요.");
+            valid = false;
+        }
+
+        if (!payload.startDate) {
+            setError("startDate", "시작일을 입력해 주세요.");
+            valid = false;
+        }
+
+        if (
+            payload.startDate &&
+            payload.endDate &&
+            payload.endDate < payload.startDate
+        ) {
+            setError("endDate", "종료일은 시작일보다 빠를 수 없습니다.");
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    function validateCommon(payload) {
         let valid = true;
 
         if (!payload.title) {
@@ -409,14 +631,6 @@ document.addEventListener("DOMContentLoaded", () => {
             valid = false;
         }
 
-        if (!payload.dueDate) {
-            setError("dueDate", "정산 마감일을 입력해 주세요.");
-            valid = false;
-        } else if (payload.dueDate < dueDateInput.min) {
-            setError("dueDate", "정산 마감일은 오늘 이후여야 합니다.");
-            valid = false;
-        }
-
         if (
             payload.totalAmount === null ||
             !Number.isInteger(payload.totalAmount) ||
@@ -426,7 +640,10 @@ document.addEventListener("DOMContentLoaded", () => {
             valid = false;
         }
 
-        if (!Array.isArray(payload.participants) || payload.participants.length === 0) {
+        if (
+            !Array.isArray(payload.participants) ||
+            payload.participants.length === 0
+        ) {
             setError("participants", "참여자를 한 명 이상 추가해 주세요.");
             valid = false;
         }
@@ -449,27 +666,26 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function formatAmountInput(rawAmount) {
-        if (!rawAmount) {
-            return "";
-        }
-
-        return Number(rawAmount).toLocaleString("ko-KR");
+        return rawAmount
+            ? Number(rawAmount).toLocaleString("ko-KR")
+            : "";
     }
 
-    function setParticipantLookupLoading(isLoading) {
-        lookupParticipantButton.disabled = isLoading;
-        participantTokenInput.disabled = isLoading;
-        lookupParticipantButton.textContent = isLoading
-            ? "조회 중..."
-            : "조회 후 추가";
+    function setParticipantLookupLoading(loading) {
+        lookupParticipantButton.disabled = loading;
+        participantTokenInput.disabled = loading;
+        lookupParticipantButton.textContent =
+            loading ? "조회 중..." : "조회 후 추가";
     }
 
     function setError(fieldName, message) {
-        const errorElement =
-            document.querySelector(`[data-error-for="${fieldName}"]`);
+        const element =
+            document.querySelector(
+                `[data-error-for="${fieldName}"]`
+            );
 
-        if (errorElement) {
-            errorElement.textContent = message;
+        if (element) {
+            element.textContent = message;
         }
     }
 
@@ -478,25 +694,36 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function clearErrors() {
-        document.querySelectorAll(".field-error").forEach((element) => {
+        document.querySelectorAll(".field-error").forEach(element => {
             element.textContent = "";
         });
     }
 
-    function setSubmitting(isSubmitting) {
-        submitButton.disabled = isSubmitting;
-        submitButton.textContent = isSubmitting
+    function setSubmitting(value) {
+        submitting = value;
+        submitButton.disabled = value;
+        updateSubmitButton();
+    }
+
+    function updateSubmitButton() {
+        submitButton.textContent = submitting
             ? "생성 중..."
-            : "공동정산 생성";
+            : settlementType === "RECURRING"
+                ? "정기정산 생성"
+                : "공동정산 생성";
     }
 
     function getValidationMessage(body) {
-        if (!body) {
-            return null;
-        }
+        if (!body) return null;
 
-        if (Array.isArray(body.errors) && body.errors.length > 0) {
-            return body.errors[0].message || body.errors[0].defaultMessage;
+        if (
+            Array.isArray(body.errors) &&
+            body.errors.length > 0
+        ) {
+            return (
+                body.errors[0].message ||
+                body.errors[0].defaultMessage
+            );
         }
 
         return null;
@@ -505,9 +732,7 @@ document.addEventListener("DOMContentLoaded", () => {
     async function readJsonSafely(response) {
         const text = await response.text();
 
-        if (!text) {
-            return null;
-        }
+        if (!text) return null;
 
         try {
             return JSON.parse(text);
@@ -516,12 +741,8 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-
-
     function formatDate(value) {
-        if (!value) {
-            return "";
-        }
+        if (!value) return "";
 
         const [year, month, day] = value.split("-");
         return `${year}.${month}.${day}`;
@@ -533,25 +754,9 @@ document.addEventListener("DOMContentLoaded", () => {
         toast.classList.add("visible");
 
         window.clearTimeout(showToast.timer);
+
         showToast.timer = window.setTimeout(() => {
             toast.classList.remove("visible");
         }, 3000);
-    }
-
-    function bindSettlementAccount() {
-        settlementAccountSelect.addEventListener(
-            "change",
-            () => {
-                const selectedOption =
-                    settlementAccountSelect.options[
-                        settlementAccountSelect.selectedIndex
-                    ];
-
-                summaryAccount.textContent =
-                    settlementAccountSelect.value
-                        ? selectedOption.text
-                        : "아직 설정되지 않음";
-            }
-        );
     }
 });

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -97,14 +97,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
         setText("settlement-title", detail.title || "이름 없는 정산");
         setText("settlement-category", detail.settlementCategory || "-");
-        setText("created-at", formatDate(detail.createdAt));
         setText("split-type", getSplitTypeText(detail.splitType));
         setText("settlement-status-badge", getSettlementStatusText(detail.settlementStatus));
         setText("settlement-role-badge", getRoleText(detail.role));
 
         const typeBadge = document.getElementById("settlement-type-badge");
         if (typeBadge) {
-            typeBadge.textContent = detail.settlementType === "RECURRING" ? "정기정산" : "공동정산";
+            typeBadge.textContent = recurring ? "정기정산" : "공동정산";
         }
 
         const sharedDateInfo = document.getElementById("shared-date-info");
@@ -112,15 +111,23 @@ document.addEventListener("DOMContentLoaded", () => {
         const recurringEndInfo = document.getElementById("recurring-end-info");
         const recurringDateDivider = document.getElementById("recurring-date-divider");
 
-        if (sharedDateInfo) sharedDateInfo.hidden = recurring;
-        if (recurringStartInfo) recurringStartInfo.hidden = !recurring;
-        if (recurringEndInfo) recurringEndInfo.hidden = !recurring;
-        if (recurringDateDivider) recurringDateDivider.hidden = !recurring;
-
         if (recurring) {
+            if (sharedDateInfo) sharedDateInfo.style.display = "none";
+            if (recurringStartInfo) recurringStartInfo.style.display = "";
+            if (recurringEndInfo) recurringEndInfo.style.display = "";
+            if (recurringDateDivider) recurringDateDivider.style.display = "";
+
             setText("recurring-start-date", formatDate(detail.startDate));
-            setText("recurring-end-date", detail.endDate ? formatDate(detail.endDate) : "종료일 없음");
+            setText(
+                "recurring-end-date",
+                detail.endDate ? formatDate(detail.endDate) : "종료일 없음"
+            );
         } else {
+            if (sharedDateInfo) sharedDateInfo.style.display = "";
+            if (recurringStartInfo) recurringStartInfo.style.display = "none";
+            if (recurringEndInfo) recurringEndInfo.style.display = "none";
+            if (recurringDateDivider) recurringDateDivider.style.display = "none";
+
             setText("due-date", formatDate(detail.dueDate));
         }
 

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -1,70 +1,31 @@
 document.addEventListener("DOMContentLoaded", () => {
     const settlementId = getSettlementIdFromPath();
-
     const toast = document.getElementById("toast");
     const closeButton = document.getElementById("close-button");
     const syncButton = document.getElementById("sync-button");
     const refreshButton = document.getElementById("refresh-button");
-    const changeAccountButton =
-        document.getElementById("change-account-button");
+    const changeAccountButton = document.getElementById("change-account-button");
 
     if (!settlementId) {
-        showToast(
-            "정산 ID를 확인할 수 없습니다.",
-            true
-        );
+        showToast("정산 ID를 확인할 수 없습니다.", true);
         return;
     }
 
     loadPage();
 
-    if (refreshButton) {
-        refreshButton.addEventListener(
-            "click",
-            loadPage
-        );
-    }
-
-    if (closeButton) {
-        closeButton.addEventListener(
-            "click",
-            closeSettlement
-        );
-    }
-
-    if (syncButton) {
-        syncButton.addEventListener(
-            "click",
-            syncTransactions
-        );
-    }
+    if (refreshButton) refreshButton.addEventListener("click", loadPage);
+    if (closeButton) closeButton.addEventListener("click", closeSettlement);
+    if (syncButton) syncButton.addEventListener("click", syncTransactions);
 
     async function syncTransactions() {
         try {
             syncButton.disabled = true;
-
-            const result = await requestJson(
-                "/api/transactions/sync",
-                {
-                    method: "POST"
-                }
-            );
-
-            showToast(
-                `동기화 완료: 자동반영 ${result.appliedCount}건, 확인필요
-              ${result.needsCheckCount}건, 미매칭 ${result.unmatchedCount}건`
-            );
-
+            const result = await requestJson("/api/transactions/sync", { method: "POST" });
+            showToast(`동기화 완료: 자동반영 ${result.appliedCount}건, 확인필요 ${result.needsCheckCount}건, 미매칭 ${result.unmatchedCount}건`);
             await loadPage();
-
         } catch (error) {
             console.error("거래내역 동기화 실패:", error);
-
-            showToast(
-                error.message || "거래내역 동기화에 실패했습니다.",
-                true
-            );
-
+            showToast(error.message || "거래내역 동기화에 실패했습니다.", true);
         } finally {
             syncButton.disabled = false;
         }
@@ -73,804 +34,336 @@ document.addEventListener("DOMContentLoaded", () => {
     async function loadPage() {
         try {
             setLoading(true);
-
-            const [
-                detail,
-                paymentStatus
-            ] = await Promise.all([
-                requestJson(
-                    `/api/settlements/${settlementId}`
-                ),
-                requestJson(
-                    `/api/settlements/${settlementId}/payment-status`
-                )
+            const [detail, paymentStatus] = await Promise.all([
+                requestJson(`/api/settlements/${settlementId}`),
+                requestJson(`/api/settlements/${settlementId}/payment-status`)
             ]);
 
             renderDetail(detail);
             renderPaymentStatus(paymentStatus);
-
             await loadSettlementAccount();
 
-            const syncTime =
-                document.getElementById(
-                    "sync-time"
-                );
-
-            if (syncTime) {
-                syncTime.textContent =
-                    formatDateTime(new Date());
-            }
-
+            const syncTime = document.getElementById("sync-time");
+            if (syncTime) syncTime.textContent = formatDateTime(new Date());
         } catch (error) {
-            console.error(
-                "정산 상세 조회 실패:",
-                error
-            );
-
-            showToast(
-                error.message ||
-                "정산 상세 정보를 불러오지 못했습니다.",
-                true
-            );
-
+            console.error("정산 상세 조회 실패:", error);
+            showToast(error.message || "정산 상세 정보를 불러오지 못했습니다.", true);
         } finally {
             setLoading(false);
         }
     }
+
     async function loadSettlementAccount() {
         try {
-            const account =
-                await requestSettlementAccount();
-
-            renderSettlementAccount(
-                account
-            );
-
+            const account = await requestSettlementAccount();
+            renderSettlementAccount(account);
         } catch (error) {
-            console.error(
-                "수취 계좌 조회 실패:",
-                error
-            );
-
+            console.error("수취 계좌 조회 실패:", error);
             renderSettlementAccount(null);
         }
     }
 
     async function requestSettlementAccount() {
-        const response =
-            await authFetch(
-                `/api/settlements/${settlementId}/account`,
-                {
-                    method: "GET"
-                }
-            );
+        const response = await authFetch(`/api/settlements/${settlementId}/account`, { method: "GET" });
 
-        if (response.status === 403) {
-            throw new Error(
-                "수취 계좌 조회 권한이 없습니다."
-            );
-        }
-
-        if (response.status === 404) {
-            return null;
-        }
-
-        if (!response.ok) {
-            throw new Error(
-                "수취 계좌 조회에 실패했습니다."
-            );
-        }
+        if (response.status === 403) throw new Error("수취 계좌 조회 권한이 없습니다.");
+        if (response.status === 404) return null;
+        if (!response.ok) throw new Error("수취 계좌 조회에 실패했습니다.");
 
         return response.json();
     }
-    async function requestJson(
-        url,
-        options = {}
-    ) {
-        const response =
-            await authFetch(
-                url,
-                options
-            );
 
-        if (response.status === 403) {
-            throw new Error(
-                "해당 정산을 조회할 권한이 없습니다."
-            );
-        }
+    async function requestJson(url, options = {}) {
+        const response = await authFetch(url, options);
 
-        if (response.status === 404) {
-            throw new Error(
-                "정산을 찾을 수 없습니다."
-            );
-        }
+        if (response.status === 403) throw new Error("해당 정산을 조회할 권한이 없습니다.");
+        if (response.status === 404) throw new Error("정산을 찾을 수 없습니다.");
 
         if (!response.ok) {
-            let message =
-                "요청 처리에 실패했습니다.";
-
+            let message = "요청 처리에 실패했습니다.";
             try {
-                const body =
-                    await response.json();
-
-                message =
-                    body.message ||
-                    message;
-
-            } catch (error) {
-            }
-
+                const body = await response.json();
+                message = body.message || message;
+            } catch (error) {}
             throw new Error(message);
         }
 
-        if (response.status === 204) {
-            return null;
-        }
-
+        if (response.status === 204) return null;
         return response.json();
     }
 
     function renderDetail(detail) {
-        setText(
-            "settlement-title",
-            detail.title ||
-            "이름 없는 정산"
-        );
+        const recurring = detail.settlementType === "RECURRING";
 
-        setText(
-            "settlement-category",
-            detail.settlementCategory ||
-            "-"
-        );
+        setText("settlement-title", detail.title || "이름 없는 정산");
+        setText("settlement-category", detail.settlementCategory || "-");
+        setText("created-at", formatDate(detail.createdAt));
+        setText("split-type", getSplitTypeText(detail.splitType));
+        setText("settlement-status-badge", getSettlementStatusText(detail.settlementStatus));
+        setText("settlement-role-badge", getRoleText(detail.role));
 
-        setText(
-            "due-date",
-            formatDate(
-                detail.dueDate
-            )
-        );
+        const typeBadge = document.getElementById("settlement-type-badge");
+        if (typeBadge) {
+            typeBadge.textContent = detail.settlementType === "RECURRING" ? "정기정산" : "공동정산";
+        }
 
-        setText(
-            "created-at",
-            formatDate(
-                detail.createdAt
-            )
-        );
+        const sharedDateInfo = document.getElementById("shared-date-info");
+        const recurringStartInfo = document.getElementById("recurring-start-info");
+        const recurringEndInfo = document.getElementById("recurring-end-info");
+        const recurringDateDivider = document.getElementById("recurring-date-divider");
 
-        setText(
-            "split-type",
-            getSplitTypeText(
-                detail.splitType
-            )
-        );
+        if (sharedDateInfo) sharedDateInfo.hidden = recurring;
+        if (recurringStartInfo) recurringStartInfo.hidden = !recurring;
+        if (recurringEndInfo) recurringEndInfo.hidden = !recurring;
+        if (recurringDateDivider) recurringDateDivider.hidden = !recurring;
 
-        setText(
-            "settlement-status-badge",
-            getSettlementStatusText(
-                detail.settlementStatus
-            )
-        );
-
-        setText(
-            "settlement-role-badge",
-            getRoleText(
-                detail.role
-            )
-        );
+        if (recurring) {
+            setText("recurring-start-date", formatDate(detail.startDate));
+            setText("recurring-end-date", detail.endDate ? formatDate(detail.endDate) : "종료일 없음");
+        } else {
+            setText("due-date", formatDate(detail.dueDate));
+        }
 
         if (closeButton) {
-            closeButton.hidden =
-                detail.role !== "OWNER";
-
-            closeButton.disabled =
-                detail.settlementStatus ===
-                "CLOSED";
+            closeButton.hidden = detail.role !== "OWNER";
+            closeButton.disabled = detail.settlementStatus === "CLOSED";
         }
     }
+
     function renderPaymentStatus(status) {
-        setText(
-            "total-expected-amount",
-            formatMoney(status.totalExpectedAmount)
-        );
+        setText("total-expected-amount", formatMoney(status.totalExpectedAmount));
+        setText("total-paid-amount", formatMoney(status.totalPaidAmount));
+        setText("total-remaining-amount", formatMoney(status.totalRemainingAmount));
 
-        setText(
-            "total-paid-amount",
-            formatMoney(status.totalPaidAmount)
-        );
+        const progressRate = normalizeRate(status.progressRate);
+        setText("amount-progress-rate", `${progressRate}%`);
 
-        setText(
-            "total-remaining-amount",
-            formatMoney(status.totalRemainingAmount)
-        );
+        const progressBar = document.getElementById("progress-bar");
+        if (progressBar) progressBar.style.width = `${progressRate}%`;
 
-        const progressRate =
-            normalizeRate(status.progressRate);
+        const obligations = Array.isArray(status.obligations) ? status.obligations : [];
+        const totalCount = obligations.length;
+        const paidCount = obligations.filter(obligation => obligation.paymentStatus === "PAID").length;
 
-        setText(
-            "amount-progress-rate",
-            `${progressRate}%`
-        );
+        setText("completed-target-count", paidCount);
+        setText("total-target-count", totalCount);
+        setText("participant-count", totalCount);
 
-        const progressBar =
-            document.getElementById("progress-bar");
+        const participantProgressRate = totalCount === 0 ? 0 : Math.round((paidCount / totalCount) * 100);
+        setText("target-completion-rate", `${participantProgressRate}%`);
+        setText("attention-count", "0명");
 
-        if (progressBar) {
-            progressBar.style.width =
-                `${progressRate}%`;
-        }
+        renderParticipants(obligations);
+        renderParticipantAvatars(obligations);
 
-        const obligations =
-            Array.isArray(status.obligations)
-                ? status.obligations
-                : [];
-
-        const totalCount =
-            obligations.length;
-
-        const paidCount =
-            obligations.filter(
-                obligation =>
-                    obligation.paymentStatus === "PAID"
-            ).length;
-
-        setText(
-            "completed-target-count",
-            paidCount
-        );
-
-        setText(
-            "total-target-count",
-            totalCount
-        );
-
-        setText(
-            "participant-count",
-            totalCount
-        );
-
-        const participantProgressRate =
-            totalCount === 0
-                ? 0
-                : Math.round(
-                    (paidCount / totalCount) * 100
-                );
-
-        setText(
-            "target-completion-rate",
-            `${participantProgressRate}%`
-        );
-
-
-        setText(
-            "attention-count",
-            "0명"
-        );
-
-        renderParticipants(
-            obligations
-        );
-
-        renderParticipantAvatars(
-            obligations
-        );
-
-        if (closeButton) {
-            closeButton.disabled =
-                !status.closable;
-        }
+        if (closeButton) closeButton.disabled = !status.closable;
     }
 
     function renderSettlementAccount(account) {
         if (!account) {
-            setText(
-                "bank-name",
-                "수취 계좌"
-            );
-
-            setText(
-                "masked-account-number",
-                "계좌 정보 없음"
-            );
-
-            setText(
-                "account-holder-name",
-                "-"
-            );
-
+            setText("bank-name", "수취 계좌");
+            setText("masked-account-number", "계좌 정보 없음");
+            setText("account-holder-name", "-");
             return;
         }
 
-        setText(
-            "bank-name",
-            account.bankName || "수취 계좌"
-        );
-
-        setText(
-            "masked-account-number",
-            account.maskedAccountNumber ||
-            "계좌 정보 없음"
-        );
-
-        setText(
-            "account-holder-name",
-            account.accountHolderName || "-"
-        );
+        setText("bank-name", account.bankName || "수취 계좌");
+        setText("masked-account-number", account.maskedAccountNumber || "계좌 정보 없음");
+        setText("account-holder-name", account.accountHolderName || "-");
     }
+
     function renderParticipants(obligations) {
-        const tableBody =
-            document.getElementById(
-                "payment-table-body"
-            );
+        const tableBody = document.getElementById("payment-table-body");
+        const emptyState = document.getElementById("empty-participants");
 
-        const emptyState =
-            document.getElementById(
-                "empty-participants"
-            );
-
-        if (!tableBody) {
-            return;
-        }
+        if (!tableBody) return;
 
         tableBody.innerHTML = "";
 
         if (obligations.length === 0) {
-            if (emptyState) {
-                emptyState.hidden = false;
-            }
-
+            if (emptyState) emptyState.hidden = false;
             return;
         }
 
-        if (emptyState) {
-            emptyState.hidden = true;
-        }
+        if (emptyState) emptyState.hidden = true;
 
-        obligations.forEach(
-            obligation => {
+        obligations.forEach(obligation => {
+            const row = document.createElement("tr");
 
-                const row =
-                    document.createElement("tr");
-
-                row.innerHTML = `
+            row.innerHTML = `
                 <td class="name-cell">
-                    ${escapeHtml(
-                    obligation.participantName ||
-                    `참여자 #${obligation.participantId}`
-                )}
+                    ${escapeHtml(obligation.participantName || `참여자 #${obligation.participantId}`)}
                 </td>
-
+                <td>${formatMoney(obligation.expectedAmount)}원</td>
+                <td>${formatMoney(obligation.paidAmount)}원</td>
+                <td>${formatMoney(obligation.remainingAmount)}원</td>
+                <td>-</td>
+                <td>${createPaymentStatusChip(obligation.paymentStatus)}</td>
                 <td>
-                    ${formatMoney(
-                    obligation.expectedAmount
-                )}원
-                </td>
-
-                <td>
-                    ${formatMoney(
-                    obligation.paidAmount
-                )}원
-                </td>
-
-                <td>
-                    ${formatMoney(
-                    obligation.remainingAmount
-                )}원
-                </td>
-
-                <td>
-                    -
-                </td>
-
-                <td>
-                    ${createPaymentStatusChip(
-                    obligation.paymentStatus
-                )}
-                </td>
-
-                <td>
-                    <button
-                        class="manage-button"
-                        type="button"
-                        disabled
-                    >
-                        -
-                    </button>
+                    <button class="manage-button" type="button" disabled>-</button>
                 </td>
             `;
 
-                tableBody.appendChild(row);
-            }
-        );
+            tableBody.appendChild(row);
+        });
     }
 
-    function renderParticipantAvatars(
-        obligations
-    ) {
-        const container =
-            document.getElementById(
-                "participant-avatar-list"
-            );
-
-        if (!container) {
-            return;
-        }
+    function renderParticipantAvatars(obligations) {
+        const container = document.getElementById("participant-avatar-list");
+        if (!container) return;
 
         container.innerHTML = "";
 
         if (obligations.length === 0) {
             container.innerHTML = `
-            <div class="participant-avatar">
-                <small>
-                    참여자가 없습니다.
-                </small>
-            </div>
-        `;
-
+                <div class="participant-avatar">
+                    <small>참여자가 없습니다.</small>
+                </div>
+            `;
             return;
         }
 
-        obligations
-            .slice(0, 6)
-            .forEach(
-                obligation => {
+        obligations.slice(0, 6).forEach(obligation => {
+            const item = document.createElement("div");
+            item.className = "participant-avatar";
 
-                    const item =
-                        document.createElement(
-                            "div"
-                        );
+            item.innerHTML = `
+                <div class="avatar-circle">◎</div>
+                <strong>${escapeHtml(obligation.participantName || `참여자 #${obligation.participantId}`)}</strong>
+                <small>${escapeHtml(getPaymentStatusText(obligation.paymentStatus))}</small>
+            `;
 
-                    item.className =
-                        "participant-avatar";
-
-                    item.innerHTML = `
-                    <div class="avatar-circle">
-                        ◎
-                    </div>
-
-                    <strong>
-                        ${escapeHtml(
-                            obligation.participantName ||
-                            `참여자 #${obligation.participantId}`
-                    )}
-                    </strong>
-
-                    <small>
-                        ${escapeHtml(
-                        getPaymentStatusText(
-                            obligation.paymentStatus
-                        )
-                    )}
-                    </small>
-                `;
-
-                    container.appendChild(
-                        item
-                    );
-                }
-            );
+            container.appendChild(item);
+        });
     }
-
 
     async function closeSettlement() {
-        if (
-            !window.confirm(
-                "이 정산을 마감하시겠습니까?"
-            )
-        ) {
-            return;
-        }
+        if (!window.confirm("이 정산을 마감하시겠습니까?")) return;
 
         try {
-            if (closeButton) {
-                closeButton.disabled =
-                    true;
-            }
-
-            await requestJson(
-                `/api/settlements/${settlementId}/close`,
-                {
-                    method: "POST"
-                }
-            );
-
-            showToast(
-                "정산이 마감되었습니다."
-            );
-
+            if (closeButton) closeButton.disabled = true;
+            await requestJson(`/api/settlements/${settlementId}/close`, { method: "POST" });
+            showToast("정산이 마감되었습니다.");
             await loadPage();
-
         } catch (error) {
-            console.error(
-                "정산 마감 실패:",
-                error
-            );
-
-            showToast(
-                error.message ||
-                "정산 마감에 실패했습니다.",
-                true
-            );
-
+            console.error("정산 마감 실패:", error);
+            showToast(error.message || "정산 마감에 실패했습니다.", true);
         } finally {
-            if (closeButton) {
-                closeButton.disabled =
-                    false;
-            }
+            if (closeButton) closeButton.disabled = false;
         }
     }
 
-    function createPaymentStatusChip(
-        status
-    ) {
-        if (status === "PAID") {
-            return `
-                <span
-                    class="status-chip status-paid"
-                >
-                    ● 입금 완료
-                </span>
-            `;
-        }
-
-        if (
-            status ===
-            "PARTIALLY_PAID"
-        ) {
-            return `
-                <span
-                    class="status-chip status-partial"
-                >
-                    ● 일부 입금
-                </span>
-            `;
-        }
-
-        return `
-            <span
-                class="status-chip status-unpaid"
-            >
-                ● 미입금
-            </span>
-        `;
+    function createPaymentStatusChip(status) {
+        if (status === "PAID") return `<span class="status-chip status-paid">● 입금 완료</span>`;
+        if (status === "PARTIALLY_PAID") return `<span class="status-chip status-partial">● 일부 입금</span>`;
+        return `<span class="status-chip status-unpaid">● 미입금</span>`;
     }
 
-    function getPaymentStatusText(
-        status
-    ) {
+    function getPaymentStatusText(status) {
         switch (status) {
-            case "PAID":
-                return "입금 완료";
-
-            case "PARTIALLY_PAID":
-                return "일부 입금";
-
-            case "UNPAID":
-                return "미입금";
-
-            default:
-                return "-";
+            case "PAID": return "입금 완료";
+            case "PARTIALLY_PAID": return "일부 입금";
+            case "UNPAID": return "미입금";
+            default: return "-";
         }
     }
 
-    function getSettlementStatusText(
-        status
-    ) {
+    function getSettlementStatusText(status) {
         switch (status) {
-            case "IN_PROGRESS":
-                return "진행중";
-
-            case "CLOSED":
-                return "완료";
-
-            case "CANCELLED":
-                return "취소";
-
-            default:
-                return "-";
+            case "IN_PROGRESS": return "진행중";
+            case "CLOSED": return "완료";
+            case "CANCELLED": return "취소";
+            default: return "-";
         }
     }
 
-    function getSplitTypeText(
-        splitType
-    ) {
+    function getSplitTypeText(splitType) {
         switch (splitType) {
-            case "EQUAL":
-                return "균등";
-
-            case "CUSTOM":
-                return "직접 설정";
-
-            default:
-                return "-";
+            case "EQUAL": return "균등";
+            case "CUSTOM": return "직접 설정";
+            default: return "-";
         }
     }
 
     function getRoleText(role) {
         switch (role) {
-            case "OWNER":
-                return "정산자";
-
-            case "MEMBER":
-                return "참여자";
-
-            default:
-                return "-";
+            case "OWNER": return "정산자";
+            case "MEMBER": return "참여자";
+            default: return "-";
         }
     }
 
     function getSettlementIdFromPath() {
-        const match =
-            window.location.pathname.match(
-                /^\/settlements\/(\d+)\/?$/
-            );
-
-        return match
-            ? match[1]
-            : null;
+        const match = window.location.pathname.match(/^\/settlements\/(\d+)\/?$/);
+        return match ? match[1] : null;
     }
 
     function normalizeRate(value) {
-        const number =
-            Number(value || 0);
-
-        if (!Number.isFinite(number)) {
-            return 0;
-        }
-
-        return Math.max(
-            0,
-            Math.min(
-                100,
-                Math.round(
-                    number * 100
-                ) / 100
-            )
-        );
+        const number = Number(value || 0);
+        if (!Number.isFinite(number)) return 0;
+        return Math.max(0, Math.min(100, Math.round(number * 100) / 100));
     }
 
     function formatMoney(value) {
-        const number =
-            Number(value || 0);
-
-        if (!Number.isFinite(number)) {
-            return "0";
-        }
-
-        return new Intl.NumberFormat(
-            "ko-KR"
-        ).format(number);
+        const number = Number(value || 0);
+        if (!Number.isFinite(number)) return "0";
+        return new Intl.NumberFormat("ko-KR").format(number);
     }
 
     function formatDate(value) {
-        if (!value) {
-            return "-";
-        }
+        if (!value) return "-";
 
-        const parts =
-            String(value)
-                .split("T")[0]
-                .split("-");
-
-        if (parts.length !== 3) {
-            return String(value);
-        }
+        const parts = String(value).split("T")[0].split("-");
+        if (parts.length !== 3) return String(value);
 
         return `${parts[0]}.${parts[1]}.${parts[2]}`;
     }
 
     function formatDateTime(value) {
-        if (!value) {
-            return "-";
-        }
+        if (!value) return "-";
 
-        const date =
-            value instanceof Date
-                ? value
-                : new Date(value);
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) return String(value);
 
-        if (
-            Number.isNaN(
-                date.getTime()
-            )
-        ) {
-            return String(value);
-        }
-
-        return new Intl.DateTimeFormat(
-            "ko-KR",
-            {
-                year: "numeric",
-                month: "2-digit",
-                day: "2-digit",
-                hour: "2-digit",
-                minute: "2-digit"
-            }
-        ).format(date);
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit"
+        }).format(date);
     }
 
-    function setText(
-        id,
-        value
-    ) {
-        const element =
-            document.getElementById(id);
-
-        if (element) {
-            element.textContent =
-                value;
-        }
+    function setText(id, value) {
+        const element = document.getElementById(id);
+        if (element) element.textContent = value;
     }
 
     function escapeHtml(value) {
         return String(value)
-            .replaceAll(
-                "&",
-                "&amp;"
-            )
-            .replaceAll(
-                "<",
-                "&lt;"
-            )
-            .replaceAll(
-                ">",
-                "&gt;"
-            )
-            .replaceAll(
-                '"',
-                "&quot;"
-            )
-            .replaceAll(
-                "'",
-                "&#039;"
-            );
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#039;");
     }
 
     function setLoading(loading) {
-        if (!refreshButton) {
-            return;
-        }
-
-        refreshButton.disabled =
-            loading;
-
-        refreshButton.textContent =
-            loading
-                ? "불러오는 중..."
-                : "↻ 새로고침";
+        if (!refreshButton) return;
+        refreshButton.disabled = loading;
+        refreshButton.textContent = loading ? "불러오는 중..." : "↻ 새로고침";
     }
 
-    function showToast(
-        message,
-        isError = false
-    ) {
-        if (!toast) {
-            return;
-        }
+    function showToast(message, isError = false) {
+        if (!toast) return;
 
-        toast.textContent =
-            message;
+        toast.textContent = message;
+        toast.classList.toggle("error", isError);
+        toast.classList.add("visible");
 
-        toast.classList.toggle(
-            "error",
-            isError
-        );
-
-        toast.classList.add(
-            "visible"
-        );
-
-        window.clearTimeout(
-            showToast.timer
-        );
-
-        showToast.timer =
-            window.setTimeout(
-                () => {
-                    toast.classList.remove(
-                        "visible"
-                    );
-                },
-                3000
-            );
+        window.clearTimeout(showToast.timer);
+        showToast.timer = window.setTimeout(() => {
+            toast.classList.remove("visible");
+        }, 3000);
     }
 });

--- a/src/main/resources/static/js/settlement/settlement-list.js
+++ b/src/main/resources/static/js/settlement/settlement-list.js
@@ -124,7 +124,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const roleText =
             settlement.role === "OWNER" ? "정산자" : "참여자";
-
+        const scheduleText =
+            settlement.settlementType === "RECURRING"
+                ? formatPeriod(settlement.startDate, settlement.endDate)
+                : formatDate(settlement.dueDate);
         row.innerHTML = `
             <div class="settlement-name">
                 <span class="type-badge">${escapeHtml(typeText)}</span>
@@ -134,7 +137,7 @@ document.addEventListener("DOMContentLoaded", () => {
             <span>${escapeHtml(settlement.settlementCategory || "-")}</span>
             <span class="split-badge">${escapeHtml(splitText)}</span>
             <span class="status-badge">${escapeHtml(statusText)}</span>
-            <span>${escapeHtml(formatDate(settlement.dueDate))}</span>
+            <span>${escapeHtml(scheduleText)}</span>
             <a
                 class="detail-link"
                 href="/settlements/${settlement.settlementId}"
@@ -209,7 +212,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const settlementId = params.get("created");
 
         if (settlementId) {
-            showToast(`공동정산 #${settlementId}이 생성되었습니다.`);
+            showToast(`정산 #${settlementId}이 생성되었습니다.`);
 
             const cleanUrl =
                 window.location.pathname + window.location.hash;
@@ -225,6 +228,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const [year, month, day] = value.split("-");
         return `${year}.${month}.${day}`;
+    }
+
+    function formatPeriod(startDate, endDate) {
+        if (!startDate) return "-";
+        if (!endDate) return `${formatDate(startDate)} ~ 계속`;
+        return `${formatDate(startDate)} ~ ${formatDate(endDate)}`;
     }
 
     function escapeHtml(value) {

--- a/src/main/resources/templates/settlement/settlement-create.html
+++ b/src/main/resources/templates/settlement/settlement-create.html
@@ -44,10 +44,7 @@
 
     <div class="settlement-type-tabs" role="tablist">
         <button class="type-tab active" type="button" role="tab" aria-selected="true">공동정산</button>
-        <button class="type-tab disabled" type="button" role="tab" aria-selected="false" disabled>
-            정기정산
-            <span>준비 중</span>
-        </button>
+        <button class="type-tab active" type="button" role="tab" aria-selected="false">정기정산</button>
     </div>
 
     <div class="create-layout">
@@ -88,7 +85,7 @@
                 </div>
             </section>
 
-            <section class="form-card">
+            <section id="shared-date-section" class="form-card">
                 <div class="card-title">
                     <span class="card-icon">□</span>
                     <h2>정산 마감일</h2>
@@ -99,6 +96,70 @@
                     <input id="due-date" name="dueDate" type="date" required>
                     <small class="field-error" data-error-for="dueDate"></small>
                 </label>
+            </section>
+            <section
+                    id="recurring-setting-section"
+                    class="form-card"
+                    hidden>
+
+                <div class="card-title">
+                    <span class="card-icon">↻</span>
+                    <h2>정기정산 설정</h2>
+                </div>
+
+                <div class="field-grid two-column">
+
+                    <label class="form-field">
+                        <span>반복 주기 <em>(필수)</em></span>
+
+                        <select
+                                id="cycle-rule"
+                                name="cycleRule">
+
+                            <option value="">선택해 주세요</option>
+                            <option value="DAILY">매일</option>
+                            <option value="WEEKLY">매주</option>
+                            <option value="MONTHLY">매월</option>
+                            <option value="YEARLY">매년</option>
+
+                        </select>
+
+                        <small
+                                class="field-error"
+                                data-error-for="cycleRule">
+                        </small>
+                    </label>
+
+                    <label class="form-field">
+                        <span>시작일 <em>(필수)</em></span>
+
+                        <input
+                                id="recurring-start-date"
+                                name="startDate"
+                                type="date">
+
+                        <small
+                                class="field-error"
+                                data-error-for="startDate">
+                        </small>
+                    </label>
+
+                    <label class="form-field">
+                        <span>종료일</span>
+
+                        <input
+                                id="recurring-end-date"
+                                name="endDate"
+                                type="date">
+
+                        <small
+                                class="field-error"
+                                data-error-for="endDate">
+                        </small>
+                    </label>
+
+                </div>
+
             </section>
 
             <section class="form-card">

--- a/src/main/resources/templates/settlement/settlement-detail.html
+++ b/src/main/resources/templates/settlement/settlement-detail.html
@@ -27,6 +27,7 @@
       <div class="heading-badges">
         <span id="settlement-status-badge" class="badge badge-progress">진행중</span>
         <span id="settlement-role-badge" class="badge badge-role">정산자</span>
+        <span id="settlement-type-badge" class="badge"></span>
       </div>
       <h1 id="settlement-title">정산 상세</h1>
     </div>
@@ -58,13 +59,29 @@
   </section>
 
   <section class="meta-card">
-    <div class="meta-item"><span>생성일</span><strong id="created-at">-</strong></div>
+    <div id="shared-date-info" class="meta-item">
+      <span>마감일</span>
+      <strong id="due-date">-</strong>
+    </div>
+    <div id="recurring-start-info" class="meta-item" hidden>
+      <span>시작일</span>
+      <strong id="recurring-start-date">-</strong>
+    </div>
+    <div id="recurring-date-divider" class="meta-divider" hidden></div>
+    <div id="recurring-end-info" class="meta-item" hidden>
+      <span>종료일</span>
+      <strong id="recurring-end-date">-</strong>
+    </div>
     <div class="meta-divider"></div>
-    <div class="meta-item"><span>마감일</span><strong id="due-date">-</strong></div>
+    <div class="meta-item meta-grow">
+      <span>정산 목적</span>
+      <strong id="settlement-category">-</strong>
+    </div>
     <div class="meta-divider"></div>
-    <div class="meta-item meta-grow"><span>정산 목적</span><strong id="settlement-category">-</strong></div>
-    <div class="meta-divider"></div>
-    <div class="meta-item"><span>참여 인원</span><strong><span id="participant-count">0</span>명</strong></div>
+    <div class="meta-item">
+      <span>참여 인원</span>
+      <strong><span id="participant-count">0</span>명</strong>
+    </div>
   </section>
 
   <div class="detail-grid">

--- a/src/main/resources/templates/settlement/settlement-detail.html
+++ b/src/main/resources/templates/settlement/settlement-detail.html
@@ -63,21 +63,28 @@
       <span>마감일</span>
       <strong id="due-date">-</strong>
     </div>
-    <div id="recurring-start-info" class="meta-item" hidden>
+
+    <div id="recurring-start-info" class="meta-item" style="display:none;">
       <span>시작일</span>
       <strong id="recurring-start-date">-</strong>
     </div>
-    <div id="recurring-date-divider" class="meta-divider" hidden></div>
-    <div id="recurring-end-info" class="meta-item" hidden>
+
+    <div id="recurring-date-divider" class="meta-divider" style="display:none;"></div>
+
+    <div id="recurring-end-info" class="meta-item" style="display:none;">
       <span>종료일</span>
       <strong id="recurring-end-date">-</strong>
     </div>
+
     <div class="meta-divider"></div>
+
     <div class="meta-item meta-grow">
       <span>정산 목적</span>
       <strong id="settlement-category">-</strong>
     </div>
+
     <div class="meta-divider"></div>
+
     <div class="meta-item">
       <span>참여 인원</span>
       <strong><span id="participant-count">0</span>명</strong>

--- a/src/main/resources/templates/settlement/settlement-list.html
+++ b/src/main/resources/templates/settlement/settlement-list.html
@@ -90,7 +90,7 @@
             <span>구분</span>
             <span>분배 방식</span>
             <span>상태</span>
-            <span>마감일</span>
+            <span>일정</span>
             <span>상세</span>
         </div>
 

--- a/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
@@ -382,7 +382,9 @@ class IntegrationDashboardServiceTest {
     private SettlementListResponse settlement(
             Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
     ) {
-        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, createdAt);
+        return new SettlementListResponse(
+                id, title, role, "ETC", "SHARED", "EQUAL", status, dueDate, null, null, createdAt
+        );
     }
 
     private SettlementPaymentStatusResponse paymentStatus(

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementServiceTest.java
@@ -1,0 +1,514 @@
+package org.teamsai.saibackend.domain.settlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.teamsai.saibackend.domain.settlement.dto.RecurringSettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.SettlementDTO;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateRecurringSettlementRequest;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementParticipantRequest;
+import org.teamsai.saibackend.domain.settlement.dto.response.CreateRecurringSettlementResponse;
+import org.teamsai.saibackend.domain.settlement.exception.SettlementErrorCode;
+import org.teamsai.saibackend.domain.settlement.mapper.RecurringSettlementManagementMapper;
+import org.teamsai.saibackend.domain.settlement.mapper.SettlementMapper;
+import org.teamsai.saibackend.domain.settlement.service.*;
+import org.teamsai.saibackend.domain.settlement.type.CycleRule;
+import org.teamsai.saibackend.domain.settlement.type.SettlementStatus;
+import org.teamsai.saibackend.domain.settlement.type.SettlementType;
+import org.teamsai.saibackend.domain.settlement.type.SplitType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RecurringSettlementService 단위 테스트")
+class RecurringSettlementServiceTest {
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long RECURRING_SETTLEMENT_ID = 10L;
+    private static final Long FIRST_SETTLEMENT_ID = 100L;
+    private static final Long LINKED_ACCOUNT_ID = 5L;
+
+    @Mock
+    private RecurringSettlementManagementMapper recurringSettlementManagementMapper;
+
+    @Mock
+    private SettlementMapper settlementMapper;
+
+    @Mock
+    private RecurringSettlementValidator recurringSettlementValidator;
+
+    @Mock
+    private SettlementAmountCalculator settlementAmountCalculator;
+
+    @Mock
+    private SettlementParticipantRegistrationService participantRegistrationService;
+
+    @Mock
+    private SettlementAccountService settlementAccountService;
+
+    @InjectMocks
+    private RecurringSettlementService recurringSettlementService;
+
+    @Test
+    @DisplayName("정기정산 생성 시 정기 설정과 최초 회차를 생성한다")
+    void createRecurringSettlementSuccess() {
+        CreateRecurringSettlementRequest request = createRequest();
+
+        BigDecimal perPersonAmount = new BigDecimal("150000");
+
+        given(settlementAmountCalculator.calculateEqualAmount(
+                request.getTotalAmount(),
+                request.getParticipants().size()
+        )).willReturn(perPersonAmount);
+
+        given(recurringSettlementManagementMapper.insert(
+                any(RecurringSettlementDTO.class)
+        )).willAnswer(invocation -> {
+            RecurringSettlementDTO recurring = invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(
+                    recurring,
+                    "recurringSettlementId",
+                    RECURRING_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        given(settlementMapper.insertSettlement(
+                any(SettlementDTO.class)
+        )).willAnswer(invocation -> {
+            SettlementDTO settlement = invocation.getArgument(0);
+            settlement.setSettlementId(FIRST_SETTLEMENT_ID);
+            return 1;
+        });
+
+        CreateRecurringSettlementResponse response =
+                recurringSettlementService.create(
+                        OWNER_ID,
+                        request
+                );
+
+        ArgumentCaptor<RecurringSettlementDTO> recurringCaptor =
+                ArgumentCaptor.forClass(RecurringSettlementDTO.class);
+
+        ArgumentCaptor<SettlementDTO> settlementCaptor =
+                ArgumentCaptor.forClass(SettlementDTO.class);
+
+        then(recurringSettlementValidator)
+                .should()
+                .validateCreateRequest(request);
+
+        then(settlementAmountCalculator)
+                .should()
+                .calculateEqualAmount(
+                        request.getTotalAmount(),
+                        request.getParticipants().size()
+                );
+
+        then(recurringSettlementManagementMapper)
+                .should()
+                .insert(recurringCaptor.capture());
+
+        RecurringSettlementDTO savedRecurring =
+                recurringCaptor.getValue();
+
+        assertThat(savedRecurring.getOwnerId())
+                .isEqualTo(OWNER_ID);
+
+        assertThat(savedRecurring.getSettlementCategory())
+                .isEqualTo("OTT·구독");
+
+        assertThat(savedRecurring.getTitle())
+                .isEqualTo("넷플릭스 구독");
+
+        assertThat(savedRecurring.getSplitType())
+                .isEqualTo(SplitType.EQUAL);
+
+        assertThat(savedRecurring.getTotalAmount())
+                .isEqualByComparingTo("450000");
+
+        assertThat(savedRecurring.getCycleRule())
+                .isEqualTo(CycleRule.MONTHLY);
+
+        assertThat(savedRecurring.getStartDate())
+                .isEqualTo(LocalDate.of(2026, 8, 17));
+
+        assertThat(savedRecurring.getEndDate())
+                .isEqualTo(LocalDate.of(2027, 8, 17));
+
+        then(settlementMapper)
+                .should()
+                .insertSettlement(
+                        settlementCaptor.capture()
+                );
+
+        SettlementDTO firstSettlement =
+                settlementCaptor.getValue();
+
+        assertThat(firstSettlement.getRecurringSettlementId())
+                .isEqualTo(RECURRING_SETTLEMENT_ID);
+
+        assertThat(firstSettlement.getOwnerId())
+                .isEqualTo(OWNER_ID);
+
+        assertThat(firstSettlement.getSettlementType())
+                .isEqualTo(SettlementType.RECURRING);
+
+        assertThat(firstSettlement.getSettlementStatus())
+                .isEqualTo(SettlementStatus.IN_PROGRESS);
+
+        assertThat(firstSettlement.getSettlementCategory())
+                .isEqualTo("OTT·구독");
+
+        assertThat(firstSettlement.getTitle())
+                .isEqualTo("넷플릭스 구독");
+
+        assertThat(firstSettlement.getSplitType())
+                .isEqualTo(SplitType.EQUAL);
+
+        assertThat(firstSettlement.getTotalAmount())
+                .isEqualByComparingTo("450000");
+
+        assertThat(firstSettlement.getCycleDate())
+                .isEqualTo(LocalDate.of(2026, 8, 17));
+
+        assertThat(firstSettlement.getDueDate())
+                .isNull();
+
+        then(participantRegistrationService)
+                .should()
+                .registerParticipants(
+                        OWNER_ID,
+                        FIRST_SETTLEMENT_ID,
+                        request.getParticipants(),
+                        perPersonAmount
+                );
+
+        then(settlementAccountService)
+                .should()
+                .selectAccount(
+                        OWNER_ID,
+                        FIRST_SETTLEMENT_ID,
+                        LINKED_ACCOUNT_ID
+                );
+
+        assertThat(response.getRecurringSettlementId())
+                .isEqualTo(RECURRING_SETTLEMENT_ID);
+
+        assertThat(response.getFirstSettlementId())
+                .isEqualTo(FIRST_SETTLEMENT_ID);
+
+        assertThat(response.getSettlementType())
+                .isEqualTo(SettlementType.RECURRING);
+
+        assertThat(response.getCycleRule())
+                .isEqualTo(CycleRule.MONTHLY);
+
+        assertThat(response.getStartDate())
+                .isEqualTo(LocalDate.of(2026, 8, 17));
+
+        assertThat(response.getEndDate())
+                .isEqualTo(LocalDate.of(2027, 8, 17));
+    }
+
+    @Test
+    @DisplayName("정기정산 설정 저장에 실패하면 최초 회차를 생성하지 않는다")
+    void createFailsWhenRecurringSettlementInsertFails() {
+        CreateRecurringSettlementRequest request =
+                createRequest();
+
+        given(settlementAmountCalculator.calculateEqualAmount(
+                request.getTotalAmount(),
+                request.getParticipants().size()
+        )).willReturn(
+                new BigDecimal("150000")
+        );
+
+        given(recurringSettlementManagementMapper.insert(
+                any(RecurringSettlementDTO.class)
+        )).willReturn(0);
+
+        assertThatThrownBy(() ->
+                recurringSettlementService.create(
+                        OWNER_ID,
+                        request
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        SettlementErrorCode.SETTLEMENT_CREATE_FAILED
+                                )
+        );
+
+        verifyNoInteractions(
+                settlementMapper,
+                participantRegistrationService,
+                settlementAccountService
+        );
+    }
+
+    @Test
+    @DisplayName("최초 회차 생성에 실패하면 참여자와 수취 계좌를 생성하지 않는다")
+    void createFailsWhenFirstSettlementInsertFails() {
+        CreateRecurringSettlementRequest request =
+                createRequest();
+
+        given(settlementAmountCalculator.calculateEqualAmount(
+                request.getTotalAmount(),
+                request.getParticipants().size()
+        )).willReturn(
+                new BigDecimal("150000")
+        );
+
+        given(recurringSettlementManagementMapper.insert(
+                any(RecurringSettlementDTO.class)
+        )).willAnswer(invocation -> {
+            RecurringSettlementDTO recurring =
+                    invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(
+                    recurring,
+                    "recurringSettlementId",
+                    RECURRING_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        given(settlementMapper.insertSettlement(
+                any(SettlementDTO.class)
+        )).willReturn(0);
+
+        assertThatThrownBy(() ->
+                recurringSettlementService.create(
+                        OWNER_ID,
+                        request
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        SettlementErrorCode.SETTLEMENT_CREATE_FAILED
+                                )
+        );
+
+        verifyNoInteractions(
+                participantRegistrationService,
+                settlementAccountService
+        );
+    }
+
+    @Test
+    @DisplayName("정기정산 요청 검증에 실패하면 어떤 데이터도 생성하지 않는다")
+    void createFailsWhenValidationFails() {
+        CreateRecurringSettlementRequest request =
+                createRequest();
+
+        willThrow(
+                SettlementErrorCode
+                        .DUPLICATE_SETTLEMENT_PARTICIPANT
+                        .toException()
+        )
+                .given(recurringSettlementValidator)
+                .validateCreateRequest(request);
+
+        assertThatThrownBy(() ->
+                recurringSettlementService.create(
+                        OWNER_ID,
+                        request
+                )
+        ).isInstanceOf(DomainException.class);
+
+        verifyNoInteractions(
+                settlementAmountCalculator,
+                recurringSettlementManagementMapper,
+                settlementMapper,
+                participantRegistrationService,
+                settlementAccountService
+        );
+    }
+
+    @Test
+    @DisplayName("참여자 등록 시 공동정산과 동일한 균등 분배 금액을 전달한다")
+    void usesSharedSettlementAmountCalculationPolicy() {
+        CreateRecurringSettlementRequest request =
+                createRequest();
+
+        BigDecimal expectedAmount =
+                new BigDecimal("150000");
+
+        given(settlementAmountCalculator.calculateEqualAmount(
+                new BigDecimal("450000"),
+                2
+        )).willReturn(expectedAmount);
+
+        given(recurringSettlementManagementMapper.insert(
+                any(RecurringSettlementDTO.class)
+        )).willAnswer(invocation -> {
+            RecurringSettlementDTO recurring =
+                    invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(
+                    recurring,
+                    "recurringSettlementId",
+                    RECURRING_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        given(settlementMapper.insertSettlement(
+                any(SettlementDTO.class)
+        )).willAnswer(invocation -> {
+            SettlementDTO settlement =
+                    invocation.getArgument(0);
+
+            settlement.setSettlementId(
+                    FIRST_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        recurringSettlementService.create(
+                OWNER_ID,
+                request
+        );
+
+        then(settlementAmountCalculator)
+                .should()
+                .calculateEqualAmount(
+                        new BigDecimal("450000"),
+                        2
+                );
+
+        then(participantRegistrationService)
+                .should()
+                .registerParticipants(
+                        OWNER_ID,
+                        FIRST_SETTLEMENT_ID,
+                        request.getParticipants(),
+                        expectedAmount
+                );
+    }
+
+    @Test
+    @DisplayName("수취 계좌 설정 실패 시 예외를 그대로 전달한다")
+    void createFailsWhenSettlementAccountCreationFails() {
+        CreateRecurringSettlementRequest request =
+                createRequest();
+
+        BigDecimal perPersonAmount =
+                new BigDecimal("150000");
+
+        given(settlementAmountCalculator.calculateEqualAmount(
+                request.getTotalAmount(),
+                request.getParticipants().size()
+        )).willReturn(perPersonAmount);
+
+        given(recurringSettlementManagementMapper.insert(
+                any(RecurringSettlementDTO.class)
+        )).willAnswer(invocation -> {
+            RecurringSettlementDTO recurring =
+                    invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(
+                    recurring,
+                    "recurringSettlementId",
+                    RECURRING_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        given(settlementMapper.insertSettlement(
+                any(SettlementDTO.class)
+        )).willAnswer(invocation -> {
+            SettlementDTO settlement =
+                    invocation.getArgument(0);
+
+            settlement.setSettlementId(
+                    FIRST_SETTLEMENT_ID
+            );
+
+            return 1;
+        });
+
+        given(settlementAccountService.selectAccount(
+                OWNER_ID,
+                FIRST_SETTLEMENT_ID,
+                LINKED_ACCOUNT_ID
+        )).willThrow(
+                SettlementErrorCode
+                        .SETTLEMENT_ACCOUNT_CREATE_FAILED
+                        .toException()
+        );
+
+        assertThatThrownBy(() ->
+                recurringSettlementService.create(
+                        OWNER_ID,
+                        request
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        SettlementErrorCode.SETTLEMENT_ACCOUNT_CREATE_FAILED
+                                )
+        );
+
+        then(participantRegistrationService)
+                .should()
+                .registerParticipants(
+                        OWNER_ID,
+                        FIRST_SETTLEMENT_ID,
+                        request.getParticipants(),
+                        perPersonAmount
+                );
+    }
+
+    private CreateRecurringSettlementRequest createRequest() {
+        return CreateRecurringSettlementRequest.builder()
+                .settlementCategory("OTT·구독")
+                .title("넷플릭스 구독")
+                .totalAmount(new BigDecimal("450000"))
+                .cycleRule(CycleRule.MONTHLY)
+                .startDate(LocalDate.of(2026, 8, 17))
+                .endDate(LocalDate.of(2027, 8, 17))
+                .linkedAccountId(LINKED_ACCOUNT_ID)
+                .participants(List.of(
+                        participant("SAI_USER_A"),
+                        participant("SAI_USER_B")
+                ))
+                .build();
+    }
+
+    private CreateSettlementParticipantRequest participant(
+            String userToken
+    ) {
+        return CreateSettlementParticipantRequest.builder()
+                .userToken(userToken)
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementValidatorTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/RecurringSettlementValidatorTest.java
@@ -1,0 +1,40 @@
+package org.teamsai.saibackend.domain.settlement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateRecurringSettlementRequest;
+import org.teamsai.saibackend.domain.settlement.dto.request.CreateSettlementParticipantRequest;
+import org.teamsai.saibackend.domain.settlement.service.RecurringSettlementValidator;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RecurringSettlementValidator 단위 테스트")
+class RecurringSettlementValidatorTest {
+
+    private final RecurringSettlementValidator validator =
+            new RecurringSettlementValidator();
+
+    @Test
+    @DisplayName("동일한 참여자를 중복 선택하면 예외가 발생한다")
+    void rejectsDuplicateParticipants() {
+        CreateRecurringSettlementRequest request =
+                CreateRecurringSettlementRequest.builder()
+                        .participants(List.of(
+                                participant("SAI_USER_A"),
+                                participant("SAI_USER_A")
+                        ))
+                        .build();
+
+        assertThatThrownBy(() ->
+                validator.validateCreateRequest(request)
+        ).isInstanceOf(DomainException.class);
+    }
+
+    private CreateSettlementParticipantRequest participant(String userToken) {
+        return CreateSettlementParticipantRequest.builder()
+                .userToken(userToken)
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/SettlementQueryServiceTest.java
@@ -233,7 +233,6 @@ class SettlementQueryServiceTest {
     private SettlementDetailResponse createDetail(
             String role
     ) {
-
         return new SettlementDetailResponse(
                 SETTLEMENT_ID,
                 "테스트 정산",
@@ -241,8 +240,9 @@ class SettlementQueryServiceTest {
                 "SHARED",
                 "IN_PROGRESS",
                 "EQUAL",
-                LocalDate.now()
-                        .plusDays(7),
+                LocalDate.now().plusDays(7),
+                null,
+                null,
                 LocalDateTime.now(),
                 role
         );


### PR DESCRIPTION
<!-- dev 머지 시 아래 사용, prod 머지 시 삭제 -->

## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #153 

## 🛠 작업 사항
- 정기정산 생성 기능 구현
- 정기정산 주기/시작일/종료일 설정 추가
- 정기정산 생성 시 최초 정산 회차 생성
- 기존 참여자 등록·균등 분배·납부의무·수취계좌 로직 재사용
- 정산 생성 화면에 공동정산/정기정산 탭 분리
- 정기정산용 카테고리 및 입력 예시 적용
- 정산 목록/상세에 공동정산·정기정산 구분 표시
- 공동정산은 마감일, 정기정산은 시작일·종료일 표시
- 목록/상세 조회 Response 및 Mapper 정기정산 기간 정보 반영
- RecurringSettlementService 단위 테스트 추가 및 기존 테스트 수정

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

- 정기 정산 최초 생성에 대한 pr 입니다. 이후 정기 정산 자동 생성은 해당 이슈 #144 에서 다룹니다.
