### PR TITLE
feat(#143) : 거래동기화 및 매칭 검토 화면 연동

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/contract/controller/ContractAccountQueryController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/controller/ContractAccountQueryController.java
@@ -1,0 +1,50 @@
+package org.teamsai.saibackend.domain.contract.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountResponse;
+import org.teamsai.saibackend.domain.contract.service.ContractAccountService;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
+
+@Tag(
+        name = "차용증 연동계좌 조회 API",
+        description = "차용증에 연결된 현재 수취 계좌를 조회합니다."
+)
+@RestController
+@RequiredArgsConstructor
+public class ContractAccountQueryController {
+
+    private final ContractAccountService contractAccountService;
+
+    @Operation(
+            summary = "차용증 현재 연동계좌 조회",
+            description = "로그인한 채권자가 차용증에 연결한 활성 연동계좌를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "차용증 조회 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "차용증 또는 활성 계좌 없음")
+    })
+    @GetMapping("/api/contracts/{contractId}/account")
+    public ResponseEntity<LinkedBankAccountResponse> getCurrentAccount(
+            @PathVariable Long contractId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                contractAccountService.getCurrentAccount(
+                        contractId,
+                        userDetails.getUserId()
+                )
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/contract/service/ContractAccountService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/service/ContractAccountService.java
@@ -16,6 +16,7 @@ import org.teamsai.saibackend.domain.contract.mapper.LoanContractMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,35 @@ public class ContractAccountService {
         return linkedBankAccountService.getLinkedAccounts(userId).stream()
                 .filter(account -> ConnectionStatus.AVAILABLE.name().equals(account.connectionStatus()))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public LinkedBankAccountResponse getCurrentAccount(
+            Long contractId,
+            Long userId
+    ) {
+        LoanContractResponse contract = findContract(contractId);
+        validateCreditor(contract, userId);
+
+        ContractAccountDTO contractAccount = contractAccountMapper
+                .findActiveAccountByContractId(contractId)
+                .stream()
+                .findFirst()
+                .orElseThrow(
+                        LoanContractErrorCode.CONTRACT_ACCOUNT_NOT_FOUND
+                                ::toException
+                );
+
+        return linkedBankAccountService.getLinkedAccounts(userId).stream()
+                .filter(account -> Objects.equals(
+                        account.linkedAccountId(),
+                        contractAccount.getLinkedAccountId()
+                ))
+                .findFirst()
+                .orElseThrow(
+                        LoanContractErrorCode.INVALID_LINKED_ACCOUNT
+                                ::toException
+                );
     }
 
     @Transactional
@@ -76,17 +106,29 @@ public class ContractAccountService {
     }
 
     private void validateContractOwner(Long contractId, Long userId) {
-        LoanContractResponse contract = loanContractMapper.findContractById(contractId)
-                .orElseThrow(LoanContractErrorCode.CONTRACT_NOT_FOUND::toException);
-
-        if (!contract.getCreditorId().equals(userId)) {
-            throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
-        }
+        LoanContractResponse contract = findContract(contractId);
+        validateCreditor(contract, userId);
 
 
         if (contract.getStatus() == ContractStatus.COMPLETED) {
             throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
 
+        }
+    }
+
+    private LoanContractResponse findContract(Long contractId) {
+        return loanContractMapper.findContractById(contractId)
+                .orElseThrow(
+                        LoanContractErrorCode.CONTRACT_NOT_FOUND::toException
+                );
+    }
+
+    private void validateCreditor(
+            LoanContractResponse contract,
+            Long userId
+    ) {
+        if (!Objects.equals(contract.getCreditorId(), userId)) {
+            throw LoanContractErrorCode.CONTRACT_ACCESS_DENIED.toException();
         }
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/contractdashboard/service/DashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdashboard/service/DashboardService.java
@@ -51,7 +51,7 @@ public class DashboardService {
     private BigDecimal calculateTotalRemaining(List<RepaymentScheduleDTO> schedules) {
         return schedules.stream()
                 .filter(s -> s.getStatus() == RepaymentScheduleStatus.PENDING)
-                .map(RepaymentScheduleDTO::getTotalPaymentDue)
+                .map(this::getRemainingPaymentAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
@@ -60,7 +60,7 @@ public class DashboardService {
         return schedules.stream()
                 .filter(s -> s.getStatus() == RepaymentScheduleStatus.PENDING
                         && YearMonth.from(s.getDueDate()).equals(thisMonth))
-                .map(RepaymentScheduleDTO::getTotalPaymentDue)
+                .map(this::getRemainingPaymentAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
@@ -68,8 +68,13 @@ public class DashboardService {
         return schedules.stream()
                 .filter(s -> s.getStatus() == RepaymentScheduleStatus.PENDING
                         && YearMonth.from(s.getDueDate()).equals(targetMonth))
-                .map(RepaymentScheduleDTO::getTotalPaymentDue)
+                .map(this::getRemainingPaymentAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal getRemainingPaymentAmount(RepaymentScheduleDTO schedule) {
+        return Optional.ofNullable(schedule.getRemainingPaymentAmount())
+                .orElse(schedule.getTotalPaymentDue());
     }
 
     private DashboardPaymentStatus determinePaymentStatus(BigDecimal totalRemaining, BigDecimal thisMonthDue) {
@@ -117,7 +122,9 @@ public class DashboardService {
         DashboardPaymentStatus paymentStatus = determinePaymentStatus(totalRemaining, thisMonthDue);
         Optional<RepaymentScheduleDTO> nearestSchedule = findNearestSchedule(schedules);
         LocalDate nearestDueDate = nearestSchedule.map(RepaymentScheduleDTO::getDueDate).orElse(null);
-        BigDecimal nextDueAmount = nearestSchedule.map(RepaymentScheduleDTO::getTotalPaymentDue).orElse(null);
+        BigDecimal nextDueAmount = nearestSchedule
+                .map(this::getRemainingPaymentAmount)
+                .orElse(null);
 
         return DashboardContractRowResponse.builder()
                 .contractId(contract.getContractId())

--- a/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/dto/RepaymentScheduleDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractrepaymentschedule/dto/RepaymentScheduleDTO.java
@@ -22,6 +22,7 @@ public class RepaymentScheduleDTO {
     private BigDecimal principalDue;
     private BigDecimal interestDue;
     private BigDecimal totalPaymentDue;
+    private BigDecimal remainingPaymentAmount;
     private BigDecimal remainingPrincipal;
     private RepaymentScheduleStatus status;
     private LocalDateTime paidAt;

--- a/src/main/java/org/teamsai/saibackend/domain/matching/controller/BankTransactionMatchingReviewQueryController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/controller/BankTransactionMatchingReviewQueryController.java
@@ -1,0 +1,58 @@
+package org.teamsai.saibackend.domain.matching.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewSearchCondition;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewListQueryService;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.transaction.dto.response.PageResponse;
+import org.teamsai.saibackend.global.security.CustomUserDetails;
+
+@Tag(
+        name = "은행 거래 매칭 검토 조회 API",
+        description = "확인이 필요한 입금 거래와 매칭 후보를 화면 범위별로 조회합니다."
+)
+@RestController
+@RequiredArgsConstructor
+public class BankTransactionMatchingReviewQueryController {
+
+    private final BankTransactionMatchingReviewListQueryService queryService;
+
+    @Operation(
+            summary = "매칭 검토 목록 조회",
+            description = "거래내역 또는 알림 검토 채널에 해당하는 NEEDS_CHECK 입금 거래를 페이지로 조회합니다."
+    )
+    @GetMapping("/api/matching-reviews")
+    public ResponseEntity<PageResponse<BankTransactionMatchingReviewResponse>>
+    getMatchingReviews(
+            @RequestParam MatchingReviewChannel reviewChannel,
+            @RequestParam(required = false) MatchingTargetType targetType,
+            @RequestParam(required = false) Long aggregateId,
+            @RequestParam(defaultValue = "0") long page,
+            @RequestParam(defaultValue = "20") long size,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MatchingReviewSearchCondition condition =
+                new MatchingReviewSearchCondition(
+                        reviewChannel,
+                        targetType,
+                        aggregateId,
+                        page,
+                        size
+                );
+
+        return ResponseEntity.ok(
+                queryService.getReviews(userDetails.getUserId(), condition)
+        );
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
@@ -21,6 +21,7 @@ public class BankTransactionMatchCandidateQueryDTO {
     private MatchingTargetType targetType;
     private Long targetId;
     private Long aggregateId;
+    private String targetName;
     private String participantName;
     private BigDecimal expectedRemainingAmount;
     private MatchingAmountType amountMatchType;

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/BankTransactionMatchCandidateQueryDTO.java
@@ -20,6 +20,7 @@ public class BankTransactionMatchCandidateQueryDTO {
     private Long bankTransactionId;
     private MatchingTargetType targetType;
     private Long targetId;
+    private Long aggregateId;
     private String participantName;
     private BigDecimal expectedRemainingAmount;
     private MatchingAmountType amountMatchType;

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewSearchCondition.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewSearchCondition.java
@@ -1,0 +1,38 @@
+package org.teamsai.saibackend.domain.matching.dto.request;
+
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+
+public record MatchingReviewSearchCondition(
+        MatchingReviewChannel reviewChannel,
+        MatchingTargetType targetType,
+        Long aggregateId,
+        long page,
+        long size
+) {
+
+    public MatchingReviewSearchCondition {
+        if (reviewChannel == null
+                || aggregateId != null && (aggregateId <= 0 || targetType == null)
+                || reviewChannel == MatchingReviewChannel.NOTIFICATION
+                && (targetType != null || aggregateId != null)) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        if (page < 0) {
+            page = 0;
+        }
+        if (size <= 0 || size > 100) {
+            size = 20;
+        }
+    }
+
+    public long offset() {
+        return page * size;
+    }
+
+    public boolean isNotificationChannel() {
+        return reviewChannel == MatchingReviewChannel.NOTIFICATION;
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
@@ -10,6 +10,7 @@ public record BankTransactionMatchCandidateResponse(
         Long matchCandidateId,
         MatchingTargetType targetType,
         Long targetId,
+        Long aggregateId,
         String participantName,
         BigDecimal expectedRemainingAmount,
         MatchingAmountType amountMatchType
@@ -22,6 +23,7 @@ public record BankTransactionMatchCandidateResponse(
                 candidate.getMatchCandidateId(),
                 candidate.getTargetType(),
                 candidate.getTargetId(),
+                candidate.getAggregateId(),
                 candidate.getParticipantName(),
                 candidate.getExpectedRemainingAmount(),
                 candidate.getAmountMatchType()

--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/response/BankTransactionMatchCandidateResponse.java
@@ -11,6 +11,7 @@ public record BankTransactionMatchCandidateResponse(
         MatchingTargetType targetType,
         Long targetId,
         Long aggregateId,
+        String targetName,
         String participantName,
         BigDecimal expectedRemainingAmount,
         MatchingAmountType amountMatchType
@@ -24,6 +25,7 @@ public record BankTransactionMatchCandidateResponse(
                 candidate.getTargetType(),
                 candidate.getTargetId(),
                 candidate.getAggregateId(),
+                candidate.getTargetName(),
                 candidate.getParticipantName(),
                 candidate.getExpectedRemainingAmount(),
                 candidate.getAmountMatchType()

--- a/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchCandidateMapper.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
 import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,6 +26,13 @@ public interface BankTransactionMatchCandidateMapper {
     List<BankTransactionMatchCandidateQueryDTO>
     findAllForReviewByBankTransactionId(
             @Param("bankTransactionId") Long bankTransactionId
+    );
+
+    List<BankTransactionMatchCandidateQueryDTO>
+    findAllForReviewByBankTransactionIds(
+            @Param("bankTransactionIds") List<Long> bankTransactionIds,
+            @Param("targetType") MatchingTargetType targetType,
+            @Param("aggregateId") Long aggregateId
     );
 
     Optional<BankTransactionMatchCandidateDTO>

--- a/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchingReviewQueryMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/mapper/BankTransactionMatchingReviewQueryMapper.java
@@ -1,0 +1,22 @@
+package org.teamsai.saibackend.domain.matching.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewSearchCondition;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+
+import java.util.List;
+
+@Mapper
+public interface BankTransactionMatchingReviewQueryMapper {
+
+    List<BankTransactionDTO> search(
+            @Param("userId") Long userId,
+            @Param("condition") MatchingReviewSearchCondition condition
+    );
+
+    long count(
+            @Param("userId") Long userId,
+            @Param("condition") MatchingReviewSearchCondition condition
+    );
+}

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingService.java
@@ -6,6 +6,7 @@ import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
 
@@ -22,7 +23,17 @@ public class BankMatchingService {
             Long userId,
             Long linkedAccountId
     ) {
+        return execute(userId, linkedAccountId, null, null);
+    }
+
+    public AutoMatchingExecutionResult execute(
+            Long userId,
+            Long linkedAccountId,
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
         validateLinkedAccountId(linkedAccountId);
+        validateMatchingScope(targetType, aggregateId);
 
         List<BankTransactionDTO> bankTransactions =
                 bankTransactionService.findPendingDepositsByLinkedAccountId(
@@ -37,13 +48,25 @@ public class BankMatchingService {
                 processTransactions(
                         userId,
                         linkedAccountId,
-                        bankTransactions
+                        bankTransactions,
+                        targetType,
+                        aggregateId
                 )
         );
     }
 
     private void validateLinkedAccountId(Long linkedAccountId) {
         if (linkedAccountId == null || linkedAccountId <= 0) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+    }
+
+    private void validateMatchingScope(
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
+        if ((targetType == null) != (aggregateId == null)
+                || aggregateId != null && aggregateId <= 0) {
             throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
         }
     }
@@ -63,14 +86,25 @@ public class BankMatchingService {
     private List<AutoMatchingTransactionResult> processTransactions(
             Long userId,
             Long linkedAccountId,
-            List<BankTransactionDTO> bankTransactions
+            List<BankTransactionDTO> bankTransactions,
+            MatchingTargetType targetType,
+            Long aggregateId
     ) {
         return bankTransactions.stream()
-                .map(bankTransaction -> transactionService.process(
-                        userId,
-                        linkedAccountId,
-                        bankTransaction
-                ))
+                .map(bankTransaction -> targetType == null
+                        ? transactionService.process(
+                                userId,
+                                linkedAccountId,
+                                bankTransaction
+                        )
+                        : transactionService.process(
+                                userId,
+                                linkedAccountId,
+                                bankTransaction,
+                                targetType,
+                                aggregateId
+                        ))
+                .filter(java.util.Objects::nonNull)
                 .toList();
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
@@ -38,6 +38,17 @@ public class BankMatchingTransactionService {
             Long linkedAccountId,
             BankTransactionDTO bankTransaction
     ) {
+        return process(userId, linkedAccountId, bankTransaction, null, null);
+    }
+
+    @Transactional
+    public AutoMatchingTransactionResult process(
+            Long userId,
+            Long linkedAccountId,
+            BankTransactionDTO bankTransaction,
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
         BankTransactionDTO lockedTransaction =
                 bankTransactionService
                         .findByIdAndLinkedAccountIdForUpdate(
@@ -54,7 +65,16 @@ public class BankMatchingTransactionService {
         }
 
         AutoMatchingTransactionResult result =
-                processMatching(linkedAccountId, lockedTransaction);
+                processMatching(
+                        linkedAccountId,
+                        lockedTransaction,
+                        targetType,
+                        aggregateId
+                );
+
+        if (result == null) {
+            return null;
+        }
 
         createMatchingReviewNotificationIfRequired(
                 userId,
@@ -126,9 +146,14 @@ public class BankMatchingTransactionService {
 
     private AutoMatchingTransactionResult processMatching(
             Long linkedAccountId,
-            BankTransactionDTO bankTransaction
+            BankTransactionDTO bankTransaction,
+            MatchingTargetType targetType,
+            Long aggregateId
     ) {
         if (!hasMatchableCounterpartyName(bankTransaction)) {
+            if (targetType != null) {
+                return null;
+            }
             return new AutoMatchingTransactionResult(
                     bankTransaction.getBankTransactionId(),
                     AutoMatchingProcessStatus.UNMATCHED
@@ -138,11 +163,16 @@ public class BankMatchingTransactionService {
         MatchingTransaction matchingTransaction =
                 toMatchingTransaction(bankTransaction);
 
-        List<MatchingCandidate> candidates =
-                paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
-                        linkedAccountId,
-                        matchingTransaction.transactionAt()
-                );
+        List<MatchingCandidate> candidates = findCandidates(
+                linkedAccountId,
+                matchingTransaction,
+                targetType,
+                aggregateId
+        );
+
+        if (targetType != null && candidates.isEmpty()) {
+            return null;
+        }
 
         AutoMatchingExecutionResult matchingResult =
                 autoMatchingService.execute(
@@ -155,6 +185,27 @@ public class BankMatchingTransactionService {
         }
 
         return matchingResult.transactionResults().get(0);
+    }
+
+    private List<MatchingCandidate> findCandidates(
+            Long linkedAccountId,
+            MatchingTransaction transaction,
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
+        if (targetType == null) {
+            return paymentObligationMapper.findMatchCandidatesByLinkedAccountId(
+                    linkedAccountId,
+                    transaction.transactionAt()
+            );
+        }
+
+        return paymentObligationMapper.findMatchCandidatesByLinkedAccountIdAndTarget(
+                linkedAccountId,
+                transaction.transactionAt(),
+                targetType,
+                aggregateId
+        );
     }
 
     private boolean hasMatchableCounterpartyName(

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchCandidateService.java
@@ -10,6 +10,7 @@ import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchCandida
 import org.teamsai.saibackend.domain.matching.model.EvaluatedMatchingCandidate;
 import org.teamsai.saibackend.domain.matching.type.MatchingCandidateInvalidationReason;
 import org.teamsai.saibackend.domain.matching.type.MatchingCandidateStatus;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -67,6 +68,26 @@ public class BankTransactionMatchCandidateService {
 
         return candidateMapper.findAllForReviewByBankTransactionId(
                 bankTransactionId
+        );
+    }
+
+    public List<BankTransactionMatchCandidateQueryDTO>
+    findAllForReviewByBankTransactionIds(
+            List<Long> bankTransactionIds,
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
+        if (bankTransactionIds == null
+                || bankTransactionIds.isEmpty()
+                || bankTransactionIds.stream()
+                .anyMatch(id -> id == null || id <= 0)) {
+            throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
+        }
+
+        return candidateMapper.findAllForReviewByBankTransactionIds(
+                bankTransactionIds,
+                targetType,
+                aggregateId
         );
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewListQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewListQueryService.java
@@ -1,0 +1,105 @@
+package org.teamsai.saibackend.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewSearchCondition;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchCandidateResponse;
+import org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse;
+import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchingReviewQueryMapper;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.dto.response.BankTransactionDetailResponse;
+import org.teamsai.saibackend.domain.transaction.dto.response.PageResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BankTransactionMatchingReviewListQueryService {
+
+    private final BankTransactionMatchingReviewQueryMapper reviewQueryMapper;
+    private final BankTransactionMatchCandidateService candidateService;
+
+    public PageResponse<BankTransactionMatchingReviewResponse> getReviews(
+            Long userId,
+            MatchingReviewSearchCondition condition
+    ) {
+        List<BankTransactionDTO> transactions =
+                reviewQueryMapper.search(userId, condition);
+        long totalCount = reviewQueryMapper.count(userId, condition);
+
+        if (transactions.isEmpty()) {
+            return PageResponse.of(
+                    List.of(),
+                    condition.page(),
+                    condition.size(),
+                    totalCount
+            );
+        }
+
+        List<Long> transactionIds = transactions.stream()
+                .map(BankTransactionDTO::getBankTransactionId)
+                .toList();
+
+        Map<Long, List<BankTransactionMatchCandidateQueryDTO>> candidatesByTransaction =
+                candidateService.findAllForReviewByBankTransactionIds(
+                                transactionIds,
+                                condition.targetType(),
+                                condition.aggregateId()
+                        ).stream()
+                        .collect(Collectors.groupingBy(
+                                BankTransactionMatchCandidateQueryDTO::getBankTransactionId
+                        ));
+
+        List<BankTransactionMatchingReviewResponse> content = transactions.stream()
+                .map(transaction -> toResponse(
+                        transaction,
+                        candidatesByTransaction.getOrDefault(
+                                transaction.getBankTransactionId(),
+                                List.of()
+                        )
+                ))
+                .toList();
+
+        return PageResponse.of(
+                content,
+                condition.page(),
+                condition.size(),
+                totalCount
+        );
+    }
+
+    private BankTransactionMatchingReviewResponse toResponse(
+            BankTransactionDTO transaction,
+            List<BankTransactionMatchCandidateQueryDTO> candidates
+    ) {
+        return new BankTransactionMatchingReviewResponse(
+                BankTransactionDetailResponse.from(transaction),
+                determineReviewChannel(candidates),
+                candidates.stream()
+                        .map(BankTransactionMatchCandidateResponse::from)
+                        .toList()
+        );
+    }
+
+    private MatchingReviewChannel determineReviewChannel(
+            List<BankTransactionMatchCandidateQueryDTO> candidates
+    ) {
+        boolean hasSettlement = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.SETTLEMENT);
+        boolean hasLoan = candidates.stream()
+                .anyMatch(candidate -> candidate.getTargetType()
+                        == MatchingTargetType.LOAN);
+
+        return hasSettlement && hasLoan
+                ? MatchingReviewChannel.NOTIFICATION
+                : MatchingReviewChannel.TRANSACTION_HISTORY;
+    }
+}

--- a/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
+++ b/src/main/java/org/teamsai/saibackend/domain/payment/mapper/PaymentObligationMapper.java
@@ -3,6 +3,7 @@ package org.teamsai.saibackend.domain.payment.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.dto.PaymentObligationDTO;
 import org.teamsai.saibackend.domain.payment.type.PaymentStatus;
 
@@ -21,9 +22,23 @@ public interface PaymentObligationMapper {
             @Param("paymentStatus") PaymentStatus paymentStatus
     );
 
-    List<MatchingCandidate> findMatchCandidatesByLinkedAccountId(
+    default List<MatchingCandidate> findMatchCandidatesByLinkedAccountId(
             @Param("linkedAccountId") Long linkedAccountId,
             @Param("transactionAt") LocalDateTime transactionAt
+    ) {
+        return findMatchCandidatesByLinkedAccountIdAndTarget(
+                linkedAccountId,
+                transactionAt,
+                null,
+                null
+        );
+    }
+
+    List<MatchingCandidate> findMatchCandidatesByLinkedAccountIdAndTarget(
+            @Param("linkedAccountId") Long linkedAccountId,
+            @Param("transactionAt") LocalDateTime transactionAt,
+            @Param("targetType") MatchingTargetType targetType,
+            @Param("aggregateId") Long aggregateId
     );
 
     int insert(PaymentObligationDTO paymentObligation);
@@ -35,4 +50,3 @@ public interface PaymentObligationMapper {
 
     int clearOverdueSince(@Param("paymentObligationId") Long paymentObligationId);
 }
-

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/controller/TransactionSyncController.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/controller/TransactionSyncController.java
@@ -7,8 +7,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
 import org.teamsai.saibackend.domain.transaction.service.TransactionSyncFacade;
 import org.teamsai.saibackend.global.security.CustomUserDetails;
@@ -24,10 +26,17 @@ public class TransactionSyncController {
     @PostMapping("/api/linked-accounts/{linkedAccountId}/sync")
     public ResponseEntity<AutoMatchingExecutionResult> sync(
             @PathVariable Long linkedAccountId,
+            @RequestParam(required = false) MatchingTargetType targetType,
+            @RequestParam(required = false) Long aggregateId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return ResponseEntity.ok(
-                transactionSyncFacade.syncAndMatch(userDetails.getUserId(), linkedAccountId)
+                transactionSyncFacade.syncAndMatch(
+                        userDetails.getUserId(),
+                        linkedAccountId,
+                        targetType,
+                        aggregateId
+                )
         );
     }
 

--- a/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
+++ b/src/main/java/org/teamsai/saibackend/domain/transaction/service/TransactionSyncFacade.java
@@ -7,6 +7,7 @@ import org.teamsai.saibackend.domain.account.dto.response.LinkedBankAccountRespo
 import org.teamsai.saibackend.domain.account.service.LinkedBankAccountService;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.service.BankMatchingService;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.transaction.dto.response.TransactionSyncAllResponse;
 import org.teamsai.saibackend.domain.transaction.dto.response.AccountSyncFailureResponse;
 import org.teamsai.saibackend.global.exception.DomainException;
@@ -26,6 +27,21 @@ public class TransactionSyncFacade {
     public AutoMatchingExecutionResult syncAndMatch(Long userId, Long linkedAccountId) {
         transactionSyncService.syncTransactions(userId, linkedAccountId);
         return bankMatchingService.execute(userId, linkedAccountId);
+    }
+
+    public AutoMatchingExecutionResult syncAndMatch(
+            Long userId,
+            Long linkedAccountId,
+            MatchingTargetType targetType,
+            Long aggregateId
+    ) {
+        transactionSyncService.syncTransactions(userId, linkedAccountId);
+        return bankMatchingService.execute(
+                userId,
+                linkedAccountId,
+                targetType,
+                aggregateId
+        );
     }
 
     public TransactionSyncAllResponse syncAll(Long userId){

--- a/src/main/resources/db/03_contractchange.sql
+++ b/src/main/resources/db/03_contractchange.sql
@@ -40,7 +40,7 @@ ALTER TABLE loan_contract_change_request
     MODIFY COLUMN new_repayment_type VARCHAR(30) NULL;
 
 ALTER TABLE loan_contract_change_request
-    ADD COLUMN requester_signature VARCHAR(255) NULL AFTER return_reason;
+    ADD COLUMN IF NOT EXISTS requester_signature VARCHAR(255) NULL AFTER return_reason;
 
 ALTER TABLE loan_contract_change_request
 DROP CONSTRAINT IF EXISTS status;

--- a/src/main/resources/mapper/contract/ContractAccountMapper.xml
+++ b/src/main/resources/mapper/contract/ContractAccountMapper.xml
@@ -50,6 +50,9 @@
         FROM contract_account
         WHERE contract_id = #{contractId}
         AND account_status = 'ACTIVE'
+        ORDER BY selected_at DESC,
+                 contract_account_id DESC
+        LIMIT 1
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/contractrepaymentschedule/RepaymentScheduleMapper.xml
+++ b/src/main/resources/mapper/contractrepaymentschedule/RepaymentScheduleMapper.xml
@@ -48,6 +48,16 @@
             principal_due         AS principalDue,
             interest_due          AS interestDue,
             total_payment_due     AS totalPaymentDue,
+            GREATEST(
+                total_payment_due - COALESCE((
+                    SELECT SUM(pr.amount)
+                    FROM payment_record pr
+                    WHERE pr.payment_target_type = 'LOAN'
+                    AND pr.target_id = repayment_schedule.schedule_id
+                    AND pr.record_status = 'CONFIRMED'
+                ), 0),
+                0
+            ) AS remainingPaymentAmount,
             remaining_principal   AS remainingPrincipal,
             status,
             paid_at               AS paidAt,

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -213,7 +213,16 @@
     <select id="findByIdAndBankTransactionId"
             resultMap="BankTransactionMatchCandidateResultMap">
         SELECT
-        <include refid="BankTransactionMatchCandidateColumns"/>
+        mc.match_candidate_id,
+        mc.bank_transaction_id,
+        mc.target_type,
+        mc.target_id,
+        mc.expected_remaining_amount,
+        mc.amount_match_type,
+        mc.candidate_status,
+        mc.invalidated_at,
+        mc.invalidation_reason,
+        mc.created_at
         FROM bank_transaction_match_candidate mc
         JOIN bank_transaction bt
             ON bt.bank_transaction_id = mc.bank_transaction_id

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -36,6 +36,7 @@
                 column="target_type"
                 javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
         <result property="targetId" column="target_id"/>
+        <result property="aggregateId" column="aggregate_id"/>
         <result property="participantName" column="participant_name"/>
         <result property="expectedRemainingAmount"
                 column="expected_remaining_amount"/>
@@ -100,6 +101,12 @@
             mc.bank_transaction_id,
             mc.target_type,
             mc.target_id,
+            CASE
+                WHEN mc.target_type = 'SETTLEMENT'
+                    THEN participant.settlement_id
+                WHEN mc.target_type = 'LOAN'
+                    THEN schedule.contract_id
+            END AS aggregate_id,
             COALESCE(settlement_user.name, debtor.name)
                 AS participant_name,
             mc.expected_remaining_amount,
@@ -133,6 +140,63 @@
         WHERE match_candidate_id = #{matchCandidateId}
         AND bank_transaction_id = #{bankTransactionId}
         AND candidate_status = 'AVAILABLE'
+    </select>
+
+    <select id="findAllForReviewByBankTransactionIds"
+            resultMap="BankTransactionMatchCandidateQueryResultMap">
+        SELECT
+            mc.match_candidate_id,
+            mc.bank_transaction_id,
+            mc.target_type,
+            mc.target_id,
+            CASE
+                WHEN mc.target_type = 'SETTLEMENT'
+                    THEN participant.settlement_id
+                WHEN mc.target_type = 'LOAN'
+                    THEN schedule.contract_id
+            END AS aggregate_id,
+            COALESCE(settlement_user.name, debtor.name)
+                AS participant_name,
+            mc.expected_remaining_amount,
+            mc.amount_match_type,
+            mc.created_at
+        FROM bank_transaction_match_candidate mc
+        LEFT JOIN payment_obligation obligation
+            ON mc.target_type = 'SETTLEMENT'
+            AND obligation.payment_obligation_id = mc.target_id
+        LEFT JOIN settlement_participant participant
+            ON participant.participant_id = obligation.participant_id
+        LEFT JOIN users settlement_user
+            ON settlement_user.user_id = participant.user_id
+        LEFT JOIN repayment_schedule schedule
+            ON mc.target_type = 'LOAN'
+            AND schedule.schedule_id = mc.target_id
+        LEFT JOIN loan_contract contract
+            ON contract.contract_id = schedule.contract_id
+        LEFT JOIN users debtor
+            ON debtor.user_id = contract.debtor_id
+        WHERE mc.bank_transaction_id IN
+        <foreach collection="bankTransactionIds"
+                 item="bankTransactionId"
+                 open="("
+                 separator=","
+                 close=")">
+            #{bankTransactionId}
+        </foreach>
+        AND mc.candidate_status = 'AVAILABLE'
+        <if test="targetType != null">
+            AND mc.target_type = #{targetType}
+        </if>
+        <if test="aggregateId != null">
+            AND CASE
+                WHEN mc.target_type = 'SETTLEMENT'
+                    THEN participant.settlement_id
+                WHEN mc.target_type = 'LOAN'
+                    THEN schedule.contract_id
+                END = #{aggregateId}
+        </if>
+        ORDER BY mc.bank_transaction_id ASC,
+                 mc.match_candidate_id ASC
     </select>
 
     <update id="invalidate">

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -87,17 +87,6 @@
         END
     </sql>
 
-    <sql id="CurrentAmountMatchType">
-        CASE
-            WHEN bt.amount = (<include refid="CurrentRemainingAmount"/>)
-                THEN 'EXACT'
-            WHEN bt.amount &lt; (<include refid="CurrentRemainingAmount"/>)
-                THEN 'PARTIAL'
-            WHEN bt.amount &gt; (<include refid="CurrentRemainingAmount"/>)
-                THEN 'EXCESS'
-        END
-    </sql>
-
     <insert id="insertAll">
         INSERT INTO bank_transaction_match_candidate (
             bank_transaction_id,
@@ -150,10 +139,8 @@
                 AS target_name,
             COALESCE(settlement_user.name, debtor.name)
                 AS participant_name,
-            <include refid="CurrentRemainingAmount"/>
-                AS expected_remaining_amount,
-            <include refid="CurrentAmountMatchType"/>
-                AS amount_match_type,
+            mc.expected_remaining_amount,
+            mc.amount_match_type,
             mc.created_at
         FROM bank_transaction_match_candidate mc
         JOIN bank_transaction bt
@@ -180,6 +167,7 @@
             (
                 mc.target_type = 'SETTLEMENT'
                 AND obligation.obligation_status = 'ACTIVE'
+                AND participant.participant_status = 'ACTIVE'
                 AND settlement.settlement_status = 'IN_PROGRESS'
                 AND obligation.expected_amount > COALESCE((
                     SELECT SUM(pr.amount)
@@ -288,10 +276,8 @@
                 AS target_name,
             COALESCE(settlement_user.name, debtor.name)
                 AS participant_name,
-            <include refid="CurrentRemainingAmount"/>
-                AS expected_remaining_amount,
-            <include refid="CurrentAmountMatchType"/>
-                AS amount_match_type,
+            mc.expected_remaining_amount,
+            mc.amount_match_type,
             mc.created_at
         FROM bank_transaction_match_candidate mc
         JOIN bank_transaction bt
@@ -325,6 +311,7 @@
             (
                 mc.target_type = 'SETTLEMENT'
                 AND obligation.obligation_status = 'ACTIVE'
+                AND participant.participant_status = 'ACTIVE'
                 AND settlement.settlement_status = 'IN_PROGRESS'
                 AND obligation.expected_amount > COALESCE((
                     SELECT SUM(pr.amount)

--- a/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchCandidateMapper.xml
@@ -37,6 +37,7 @@
                 javaType="org.teamsai.saibackend.domain.matching.type.MatchingTargetType"/>
         <result property="targetId" column="target_id"/>
         <result property="aggregateId" column="aggregate_id"/>
+        <result property="targetName" column="target_name"/>
         <result property="participantName" column="participant_name"/>
         <result property="expectedRemainingAmount"
                 column="expected_remaining_amount"/>
@@ -57,6 +58,44 @@
         invalidated_at,
         invalidation_reason,
         created_at
+    </sql>
+
+    <sql id="CurrentRemainingAmount">
+        CASE
+            WHEN mc.target_type = 'SETTLEMENT'
+                THEN GREATEST(
+                    obligation.expected_amount - COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'SETTLEMENT'
+                        AND pr.target_id = obligation.payment_obligation_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0),
+                    0
+                )
+            WHEN mc.target_type = 'LOAN'
+                THEN GREATEST(
+                    schedule.total_payment_due - COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'LOAN'
+                        AND pr.target_id = schedule.schedule_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0),
+                    0
+                )
+        END
+    </sql>
+
+    <sql id="CurrentAmountMatchType">
+        CASE
+            WHEN bt.amount = (<include refid="CurrentRemainingAmount"/>)
+                THEN 'EXACT'
+            WHEN bt.amount &lt; (<include refid="CurrentRemainingAmount"/>)
+                THEN 'PARTIAL'
+            WHEN bt.amount &gt; (<include refid="CurrentRemainingAmount"/>)
+                THEN 'EXCESS'
+        END
     </sql>
 
     <insert id="insertAll">
@@ -107,17 +146,25 @@
                 WHEN mc.target_type = 'LOAN'
                     THEN schedule.contract_id
             END AS aggregate_id,
+            COALESCE(settlement.title, contract.contract_alias)
+                AS target_name,
             COALESCE(settlement_user.name, debtor.name)
                 AS participant_name,
-            mc.expected_remaining_amount,
-            mc.amount_match_type,
+            <include refid="CurrentRemainingAmount"/>
+                AS expected_remaining_amount,
+            <include refid="CurrentAmountMatchType"/>
+                AS amount_match_type,
             mc.created_at
         FROM bank_transaction_match_candidate mc
+        JOIN bank_transaction bt
+            ON bt.bank_transaction_id = mc.bank_transaction_id
         LEFT JOIN payment_obligation obligation
             ON mc.target_type = 'SETTLEMENT'
             AND obligation.payment_obligation_id = mc.target_id
         LEFT JOIN settlement_participant participant
             ON participant.participant_id = obligation.participant_id
+        LEFT JOIN settlement settlement
+            ON settlement.settlement_id = participant.settlement_id
         LEFT JOIN users settlement_user
             ON settlement_user.user_id = participant.user_id
         LEFT JOIN repayment_schedule schedule
@@ -129,6 +176,37 @@
             ON debtor.user_id = contract.debtor_id
         WHERE mc.bank_transaction_id = #{bankTransactionId}
         AND mc.candidate_status = 'AVAILABLE'
+        AND (
+            (
+                mc.target_type = 'SETTLEMENT'
+                AND obligation.obligation_status = 'ACTIVE'
+                AND settlement.settlement_status = 'IN_PROGRESS'
+                AND obligation.expected_amount > COALESCE((
+                    SELECT SUM(pr.amount)
+                    FROM payment_record pr
+                    WHERE pr.payment_target_type = 'SETTLEMENT'
+                    AND pr.target_id = obligation.payment_obligation_id
+                    AND pr.record_status = 'CONFIRMED'
+                ), 0)
+            )
+            OR (
+                mc.target_type = 'LOAN'
+                AND schedule.status = 'PENDING'
+                AND schedule.total_payment_due > COALESCE((
+                    SELECT SUM(pr.amount)
+                    FROM payment_record pr
+                    WHERE pr.payment_target_type = 'LOAN'
+                    AND pr.target_id = schedule.schedule_id
+                    AND pr.record_status = 'CONFIRMED'
+                ), 0)
+            )
+        )
+        AND bt.amount &gt;= (
+            <include refid="CurrentRemainingAmount"/>
+        ) * 0.10
+        AND bt.amount &lt;= (
+            <include refid="CurrentRemainingAmount"/>
+        ) * 1.10
         ORDER BY mc.match_candidate_id ASC
     </select>
 
@@ -136,10 +214,52 @@
             resultMap="BankTransactionMatchCandidateResultMap">
         SELECT
         <include refid="BankTransactionMatchCandidateColumns"/>
-        FROM bank_transaction_match_candidate
-        WHERE match_candidate_id = #{matchCandidateId}
-        AND bank_transaction_id = #{bankTransactionId}
-        AND candidate_status = 'AVAILABLE'
+        FROM bank_transaction_match_candidate mc
+        JOIN bank_transaction bt
+            ON bt.bank_transaction_id = mc.bank_transaction_id
+        WHERE mc.match_candidate_id = #{matchCandidateId}
+        AND mc.bank_transaction_id = #{bankTransactionId}
+        AND mc.candidate_status = 'AVAILABLE'
+        AND (
+            (
+                mc.target_type = 'SETTLEMENT'
+                AND EXISTS (
+                    SELECT 1
+                    FROM payment_obligation po
+                    JOIN settlement_participant sp
+                        ON sp.participant_id = po.participant_id
+                    JOIN settlement s
+                        ON s.settlement_id = sp.settlement_id
+                    WHERE po.payment_obligation_id = mc.target_id
+                    AND po.obligation_status = 'ACTIVE'
+                    AND sp.participant_status = 'ACTIVE'
+                    AND s.settlement_status = 'IN_PROGRESS'
+                    AND po.expected_amount > COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'SETTLEMENT'
+                        AND pr.target_id = po.payment_obligation_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0)
+                )
+            )
+            OR (
+                mc.target_type = 'LOAN'
+                AND EXISTS (
+                    SELECT 1
+                    FROM repayment_schedule rs
+                    WHERE rs.schedule_id = mc.target_id
+                    AND rs.status = 'PENDING'
+                    AND rs.total_payment_due > COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'LOAN'
+                        AND pr.target_id = rs.schedule_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0)
+                )
+            )
+        )
     </select>
 
     <select id="findAllForReviewByBankTransactionIds"
@@ -155,17 +275,25 @@
                 WHEN mc.target_type = 'LOAN'
                     THEN schedule.contract_id
             END AS aggregate_id,
+            COALESCE(settlement.title, contract.contract_alias)
+                AS target_name,
             COALESCE(settlement_user.name, debtor.name)
                 AS participant_name,
-            mc.expected_remaining_amount,
-            mc.amount_match_type,
+            <include refid="CurrentRemainingAmount"/>
+                AS expected_remaining_amount,
+            <include refid="CurrentAmountMatchType"/>
+                AS amount_match_type,
             mc.created_at
         FROM bank_transaction_match_candidate mc
+        JOIN bank_transaction bt
+            ON bt.bank_transaction_id = mc.bank_transaction_id
         LEFT JOIN payment_obligation obligation
             ON mc.target_type = 'SETTLEMENT'
             AND obligation.payment_obligation_id = mc.target_id
         LEFT JOIN settlement_participant participant
             ON participant.participant_id = obligation.participant_id
+        LEFT JOIN settlement settlement
+            ON settlement.settlement_id = participant.settlement_id
         LEFT JOIN users settlement_user
             ON settlement_user.user_id = participant.user_id
         LEFT JOIN repayment_schedule schedule
@@ -184,6 +312,37 @@
             #{bankTransactionId}
         </foreach>
         AND mc.candidate_status = 'AVAILABLE'
+        AND (
+            (
+                mc.target_type = 'SETTLEMENT'
+                AND obligation.obligation_status = 'ACTIVE'
+                AND settlement.settlement_status = 'IN_PROGRESS'
+                AND obligation.expected_amount > COALESCE((
+                    SELECT SUM(pr.amount)
+                    FROM payment_record pr
+                    WHERE pr.payment_target_type = 'SETTLEMENT'
+                    AND pr.target_id = obligation.payment_obligation_id
+                    AND pr.record_status = 'CONFIRMED'
+                ), 0)
+            )
+            OR (
+                mc.target_type = 'LOAN'
+                AND schedule.status = 'PENDING'
+                AND schedule.total_payment_due > COALESCE((
+                    SELECT SUM(pr.amount)
+                    FROM payment_record pr
+                    WHERE pr.payment_target_type = 'LOAN'
+                    AND pr.target_id = schedule.schedule_id
+                    AND pr.record_status = 'CONFIRMED'
+                ), 0)
+            )
+        )
+        AND bt.amount &gt;= (
+            <include refid="CurrentRemainingAmount"/>
+        ) * 0.10
+        AND bt.amount &lt;= (
+            <include refid="CurrentRemainingAmount"/>
+        ) * 1.10
         <if test="targetType != null">
             AND mc.target_type = #{targetType}
         </if>

--- a/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
@@ -19,6 +19,85 @@
         <result property="syncedAt" column="synced_at"/>
     </resultMap>
 
+    <sql id="ReviewCandidateValidity">
+        AND (
+            (
+                available_candidate.target_type = 'SETTLEMENT'
+                AND EXISTS (
+                    SELECT 1
+                    FROM payment_obligation review_obligation
+                    JOIN settlement_participant review_participant
+                        ON review_participant.participant_id = review_obligation.participant_id
+                    JOIN settlement review_settlement
+                        ON review_settlement.settlement_id = review_participant.settlement_id
+                    WHERE review_obligation.payment_obligation_id = available_candidate.target_id
+                    AND review_obligation.obligation_status = 'ACTIVE'
+                    AND review_participant.participant_status = 'ACTIVE'
+                    AND review_settlement.settlement_status = 'IN_PROGRESS'
+                    AND review_obligation.expected_amount > COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'SETTLEMENT'
+                        AND pr.target_id = review_obligation.payment_obligation_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0)
+                    AND bt.amount &gt;= (
+                        review_obligation.expected_amount - COALESCE((
+                            SELECT SUM(pr.amount)
+                            FROM payment_record pr
+                            WHERE pr.payment_target_type = 'SETTLEMENT'
+                            AND pr.target_id = review_obligation.payment_obligation_id
+                            AND pr.record_status = 'CONFIRMED'
+                        ), 0)
+                    ) * 0.10
+                    AND bt.amount &lt;= (
+                        review_obligation.expected_amount - COALESCE((
+                            SELECT SUM(pr.amount)
+                            FROM payment_record pr
+                            WHERE pr.payment_target_type = 'SETTLEMENT'
+                            AND pr.target_id = review_obligation.payment_obligation_id
+                            AND pr.record_status = 'CONFIRMED'
+                        ), 0)
+                    ) * 1.10
+                )
+            )
+            OR (
+                available_candidate.target_type = 'LOAN'
+                AND EXISTS (
+                    SELECT 1
+                    FROM repayment_schedule review_schedule
+                    WHERE review_schedule.schedule_id = available_candidate.target_id
+                    AND review_schedule.status = 'PENDING'
+                    AND review_schedule.total_payment_due > COALESCE((
+                        SELECT SUM(pr.amount)
+                        FROM payment_record pr
+                        WHERE pr.payment_target_type = 'LOAN'
+                        AND pr.target_id = review_schedule.schedule_id
+                        AND pr.record_status = 'CONFIRMED'
+                    ), 0)
+                    AND bt.amount &gt;= (
+                        review_schedule.total_payment_due - COALESCE((
+                            SELECT SUM(pr.amount)
+                            FROM payment_record pr
+                            WHERE pr.payment_target_type = 'LOAN'
+                            AND pr.target_id = review_schedule.schedule_id
+                            AND pr.record_status = 'CONFIRMED'
+                        ), 0)
+                    ) * 0.10
+                    AND bt.amount &lt;= (
+                        review_schedule.total_payment_due - COALESCE((
+                            SELECT SUM(pr.amount)
+                            FROM payment_record pr
+                            WHERE pr.payment_target_type = 'LOAN'
+                            AND pr.target_id = review_schedule.schedule_id
+                            AND pr.record_status = 'CONFIRMED'
+                        ), 0)
+                    ) * 1.10
+                )
+            )
+        )
+    </sql>
+
     <sql id="ReviewSearchCondition">
         FROM bank_transaction bt
         INNER JOIN linked_bank_account account
@@ -32,69 +111,76 @@
             FROM bank_transaction_match_candidate available_candidate
             WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
             AND available_candidate.candidate_status = 'AVAILABLE'
+            <include refid="ReviewCandidateValidity"/>
         )
         <choose>
             <when test="condition.notificationChannel">
                 AND EXISTS (
                     SELECT 1
-                    FROM bank_transaction_match_candidate settlement_candidate
-                    WHERE settlement_candidate.bank_transaction_id = bt.bank_transaction_id
-                    AND settlement_candidate.candidate_status = 'AVAILABLE'
-                    AND settlement_candidate.target_type = 'SETTLEMENT'
+                    FROM bank_transaction_match_candidate available_candidate
+                    WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                    AND available_candidate.candidate_status = 'AVAILABLE'
+                    AND available_candidate.target_type = 'SETTLEMENT'
+                    <include refid="ReviewCandidateValidity"/>
                 )
                 AND EXISTS (
                     SELECT 1
-                    FROM bank_transaction_match_candidate loan_candidate
-                    WHERE loan_candidate.bank_transaction_id = bt.bank_transaction_id
-                    AND loan_candidate.candidate_status = 'AVAILABLE'
-                    AND loan_candidate.target_type = 'LOAN'
+                    FROM bank_transaction_match_candidate available_candidate
+                    WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                    AND available_candidate.candidate_status = 'AVAILABLE'
+                    AND available_candidate.target_type = 'LOAN'
+                    <include refid="ReviewCandidateValidity"/>
                 )
             </when>
             <otherwise>
                 AND NOT (
                     EXISTS (
                         SELECT 1
-                        FROM bank_transaction_match_candidate settlement_candidate
-                        WHERE settlement_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND settlement_candidate.candidate_status = 'AVAILABLE'
-                        AND settlement_candidate.target_type = 'SETTLEMENT'
+                        FROM bank_transaction_match_candidate available_candidate
+                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND available_candidate.candidate_status = 'AVAILABLE'
+                        AND available_candidate.target_type = 'SETTLEMENT'
+                        <include refid="ReviewCandidateValidity"/>
                     )
                     AND EXISTS (
                         SELECT 1
-                        FROM bank_transaction_match_candidate loan_candidate
-                        WHERE loan_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND loan_candidate.candidate_status = 'AVAILABLE'
-                        AND loan_candidate.target_type = 'LOAN'
+                        FROM bank_transaction_match_candidate available_candidate
+                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND available_candidate.candidate_status = 'AVAILABLE'
+                        AND available_candidate.target_type = 'LOAN'
+                        <include refid="ReviewCandidateValidity"/>
                     )
                 )
                 <if test="condition.targetType != null">
                     AND EXISTS (
                         SELECT 1
-                        FROM bank_transaction_match_candidate domain_candidate
-                        WHERE domain_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND domain_candidate.candidate_status = 'AVAILABLE'
-                        AND domain_candidate.target_type = #{condition.targetType}
+                        FROM bank_transaction_match_candidate available_candidate
+                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND available_candidate.candidate_status = 'AVAILABLE'
+                        AND available_candidate.target_type = #{condition.targetType}
+                        <include refid="ReviewCandidateValidity"/>
                     )
                 </if>
                 <if test="condition.aggregateId != null">
                     AND EXISTS (
                         SELECT 1
-                        FROM bank_transaction_match_candidate aggregate_candidate
+                        FROM bank_transaction_match_candidate available_candidate
                         LEFT JOIN payment_obligation obligation
-                            ON aggregate_candidate.target_type = 'SETTLEMENT'
-                            AND obligation.payment_obligation_id = aggregate_candidate.target_id
+                            ON available_candidate.target_type = 'SETTLEMENT'
+                            AND obligation.payment_obligation_id = available_candidate.target_id
                         LEFT JOIN settlement_participant participant
                             ON participant.participant_id = obligation.participant_id
                         LEFT JOIN repayment_schedule schedule
-                            ON aggregate_candidate.target_type = 'LOAN'
-                            AND schedule.schedule_id = aggregate_candidate.target_id
-                        WHERE aggregate_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND aggregate_candidate.candidate_status = 'AVAILABLE'
-                        AND aggregate_candidate.target_type = #{condition.targetType}
+                            ON available_candidate.target_type = 'LOAN'
+                            AND schedule.schedule_id = available_candidate.target_id
+                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND available_candidate.candidate_status = 'AVAILABLE'
+                        AND available_candidate.target_type = #{condition.targetType}
+                        <include refid="ReviewCandidateValidity"/>
                         AND CASE
-                            WHEN aggregate_candidate.target_type = 'SETTLEMENT'
+                            WHEN available_candidate.target_type = 'SETTLEMENT'
                                 THEN participant.settlement_id
-                            WHEN aggregate_candidate.target_type = 'LOAN'
+                            WHEN available_candidate.target_type = 'LOAN'
                                 THEN schedule.contract_id
                             END = #{condition.aggregateId}
                     )

--- a/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchingReviewQueryMapper">
+
+    <resultMap id="BankTransactionResultMap"
+               type="org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO">
+        <id property="bankTransactionId" column="bank_transaction_id"/>
+        <result property="linkedAccountId" column="linked_account_id"/>
+        <result property="externalTransactionId" column="external_transaction_id"/>
+        <result property="amount" column="amount"/>
+        <result property="transactionType" column="transaction_type"/>
+        <result property="processingStatus" column="processing_status"/>
+        <result property="transactionAt" column="transaction_at"/>
+        <result property="counterpartyName" column="counterparty_name"/>
+        <result property="memo" column="memo"/>
+        <result property="syncedAt" column="synced_at"/>
+    </resultMap>
+
+    <sql id="ReviewSearchCondition">
+        FROM bank_transaction bt
+        INNER JOIN linked_bank_account account
+            ON account.linked_account_id = bt.linked_account_id
+        WHERE account.user_id = #{userId}
+        AND account.connection_status = 'AVAILABLE'
+        AND bt.processing_status = 'NEEDS_CHECK'
+        AND bt.transaction_type = 'DEPOSIT'
+        AND EXISTS (
+            SELECT 1
+            FROM bank_transaction_match_candidate available_candidate
+            WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
+            AND available_candidate.candidate_status = 'AVAILABLE'
+        )
+        <choose>
+            <when test="condition.notificationChannel">
+                AND EXISTS (
+                    SELECT 1
+                    FROM bank_transaction_match_candidate settlement_candidate
+                    WHERE settlement_candidate.bank_transaction_id = bt.bank_transaction_id
+                    AND settlement_candidate.candidate_status = 'AVAILABLE'
+                    AND settlement_candidate.target_type = 'SETTLEMENT'
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM bank_transaction_match_candidate loan_candidate
+                    WHERE loan_candidate.bank_transaction_id = bt.bank_transaction_id
+                    AND loan_candidate.candidate_status = 'AVAILABLE'
+                    AND loan_candidate.target_type = 'LOAN'
+                )
+            </when>
+            <otherwise>
+                AND NOT (
+                    EXISTS (
+                        SELECT 1
+                        FROM bank_transaction_match_candidate settlement_candidate
+                        WHERE settlement_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND settlement_candidate.candidate_status = 'AVAILABLE'
+                        AND settlement_candidate.target_type = 'SETTLEMENT'
+                    )
+                    AND EXISTS (
+                        SELECT 1
+                        FROM bank_transaction_match_candidate loan_candidate
+                        WHERE loan_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND loan_candidate.candidate_status = 'AVAILABLE'
+                        AND loan_candidate.target_type = 'LOAN'
+                    )
+                )
+                <if test="condition.targetType != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM bank_transaction_match_candidate domain_candidate
+                        WHERE domain_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND domain_candidate.candidate_status = 'AVAILABLE'
+                        AND domain_candidate.target_type = #{condition.targetType}
+                    )
+                </if>
+                <if test="condition.aggregateId != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM bank_transaction_match_candidate aggregate_candidate
+                        LEFT JOIN payment_obligation obligation
+                            ON aggregate_candidate.target_type = 'SETTLEMENT'
+                            AND obligation.payment_obligation_id = aggregate_candidate.target_id
+                        LEFT JOIN settlement_participant participant
+                            ON participant.participant_id = obligation.participant_id
+                        LEFT JOIN repayment_schedule schedule
+                            ON aggregate_candidate.target_type = 'LOAN'
+                            AND schedule.schedule_id = aggregate_candidate.target_id
+                        WHERE aggregate_candidate.bank_transaction_id = bt.bank_transaction_id
+                        AND aggregate_candidate.candidate_status = 'AVAILABLE'
+                        AND aggregate_candidate.target_type = #{condition.targetType}
+                        AND CASE
+                            WHEN aggregate_candidate.target_type = 'SETTLEMENT'
+                                THEN participant.settlement_id
+                            WHEN aggregate_candidate.target_type = 'LOAN'
+                                THEN schedule.contract_id
+                            END = #{condition.aggregateId}
+                    )
+                </if>
+            </otherwise>
+        </choose>
+    </sql>
+
+    <select id="search" resultMap="BankTransactionResultMap">
+        SELECT
+            bt.bank_transaction_id,
+            bt.linked_account_id,
+            bt.external_transaction_id,
+            bt.amount,
+            bt.transaction_type,
+            bt.processing_status,
+            bt.transaction_at,
+            bt.counterparty_name,
+            bt.memo,
+            bt.synced_at
+        <include refid="ReviewSearchCondition"/>
+        ORDER BY bt.transaction_at DESC,
+                 bt.bank_transaction_id DESC
+        LIMIT #{condition.size}
+        OFFSET #{condition.offset}
+    </select>
+
+    <select id="count" resultType="long">
+        SELECT COUNT(*)
+        <include refid="ReviewSearchCondition"/>
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -55,7 +55,15 @@
 
     <select id="findMatchCandidatesByLinkedAccountId"
             resultMap="MatchingCandidateResultMap">
+        <include refid="findMatchCandidatesQuery"/>
+    </select>
 
+    <select id="findMatchCandidatesByLinkedAccountIdAndTarget"
+            resultMap="MatchingCandidateResultMap">
+        <include refid="findMatchCandidatesQuery"/>
+    </select>
+
+    <sql id="findMatchCandidatesQuery">
         SELECT
         'SETTLEMENT' AS target_type,
         po.payment_obligation_id AS target_id,
@@ -87,6 +95,10 @@
         AND po.obligation_status = 'ACTIVE'
         AND po.payment_status != 'PAID'
         AND sp.participant_status = 'ACTIVE'
+        <if test="targetType != null and aggregateId != null">
+        AND #{targetType} = 'SETTLEMENT'
+        AND s.settlement_id = #{aggregateId}
+        </if>
         GROUP BY
         po.payment_obligation_id,
         po.participant_id,
@@ -126,6 +138,10 @@
         AND lc.created_at &lt;= #{transactionAt}
         AND rs.created_at &lt;= #{transactionAt}
         AND rs.status = 'PENDING'
+        <if test="targetType != null and aggregateId != null">
+        AND #{targetType} = 'LOAN'
+        AND lc.contract_id = #{aggregateId}
+        </if>
         AND NOT EXISTS (
         SELECT 1
         FROM repayment_schedule earlier
@@ -141,7 +157,7 @@
         HAVING
         rs.total_payment_due - COALESCE(SUM(pr.amount), 0) &gt; 0
 
-    </select>
+    </sql>
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="paymentObligationId">
         INSERT INTO payment_obligation (

--- a/src/main/resources/mapper/payment/PaymentObligationMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentObligationMapper.xml
@@ -53,11 +53,6 @@
         WHERE payment_obligation_id = #{paymentObligationId}
     </update>
 
-    <select id="findMatchCandidatesByLinkedAccountId"
-            resultMap="MatchingCandidateResultMap">
-        <include refid="findMatchCandidatesQuery"/>
-    </select>
-
     <select id="findMatchCandidatesByLinkedAccountIdAndTarget"
             resultMap="MatchingCandidateResultMap">
         <include refid="findMatchCandidatesQuery"/>

--- a/src/main/resources/static/css/matching/matching-review-modal.css
+++ b/src/main/resources/static/css/matching/matching-review-modal.css
@@ -1,0 +1,413 @@
+.matching-review-overlay,
+.matching-review-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: grid;
+    place-items: center;
+    padding: 34px;
+    background: rgba(11, 20, 17, 0.58);
+    backdrop-filter: blur(4px);
+}
+
+.matching-review-confirm-overlay {
+    z-index: 1010;
+}
+
+.matching-review-overlay[hidden],
+.matching-review-confirm-overlay[hidden] {
+    display: none;
+}
+
+body.matching-review-scroll-locked {
+    overflow: hidden;
+}
+
+.matching-review-modal,
+.matching-review-confirm,
+.matching-review-modal * ,
+.matching-review-confirm * {
+    box-sizing: border-box;
+}
+
+.matching-review-modal {
+    width: min(940px, 100%);
+    max-height: calc(100vh - 68px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 16px;
+    background: #ffffff;
+    color: #18231f;
+    box-shadow: 0 24px 70px rgba(8, 25, 18, 0.25);
+    font-family: Pretendard, "Noto Sans KR", "Apple SD Gothic Neo", system-ui, sans-serif;
+}
+
+.matching-review-modal__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 26px 28px 20px;
+    border-bottom: 1px solid #d9e0dd;
+}
+
+.matching-review-modal__header h2 {
+    margin: 0;
+    font-size: 25px;
+}
+
+.matching-review-modal__header p {
+    margin: 8px 0 0;
+    color: #0f8a5f;
+    font-weight: 700;
+}
+
+.matching-review-icon-button {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: #34404d;
+    font-size: 30px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.matching-review-icon-button:hover {
+    background: #f0f3f2;
+}
+
+.matching-review-message {
+    margin: 16px 20px 0;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background: #eef9f5;
+    color: #056347;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.matching-review-message.is-error {
+    background: #fff0f0;
+    color: #a23d3d;
+}
+
+.matching-review-modal__body {
+    min-height: 180px;
+    padding: 20px;
+    overflow-y: auto;
+    background: #f8faf9;
+}
+
+.matching-review-empty,
+.matching-review-loading {
+    display: grid;
+    min-height: 180px;
+    place-items: center;
+    padding: 32px;
+    color: #66706c;
+    text-align: center;
+}
+
+.matching-review-card {
+    margin-bottom: 16px;
+    overflow: hidden;
+    border: 1px solid #d9e0dd;
+    border-radius: 12px;
+    background: #ffffff;
+}
+
+.matching-review-card:last-child {
+    margin-bottom: 0;
+}
+
+.matching-review-card__header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 18px;
+    padding: 18px 20px;
+    border-bottom: 1px solid #d9e0dd;
+}
+
+.matching-review-card__amount {
+    font-size: 20px;
+    font-weight: 800;
+}
+
+.matching-review-card__meta {
+    color: #66706c;
+    font-size: 14px;
+}
+
+.matching-review-card__badges {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 7px;
+}
+
+.matching-review-badge {
+    display: inline-flex;
+    padding: 5px 9px;
+    border-radius: 6px;
+    background: #f0f3f2;
+    color: #50605a;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.matching-review-badge--warning {
+    background: #fff3e9;
+    color: #b45b19;
+}
+
+.matching-review-badge--settlement {
+    background: #e9f3ff;
+    color: #1478d4;
+}
+
+.matching-review-badge--loan {
+    background: #f2edff;
+    color: #6941c6;
+}
+
+.matching-review-card__content {
+    padding: 16px 18px 18px;
+}
+
+.matching-review-card__instruction {
+    margin: 0 0 12px;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.matching-review-candidates {
+    display: grid;
+    gap: 8px;
+}
+
+.matching-review-candidate {
+    display: grid;
+    grid-template-columns: 24px minmax(180px, 1fr) 140px 120px;
+    align-items: center;
+    gap: 12px;
+    min-height: 72px;
+    padding: 12px 14px;
+    border: 1px solid #d9e0dd;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.matching-review-candidate:hover {
+    border-color: #9fcdbd;
+}
+
+.matching-review-candidate.is-selected {
+    border-color: #0f8a5f;
+    background: #eef9f5;
+}
+
+.matching-review-candidate input {
+    width: 18px;
+    height: 18px;
+    accent-color: #0f8a5f;
+}
+
+.matching-review-candidate__main,
+.matching-review-candidate__money,
+.matching-review-candidate__difference {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.matching-review-candidate small {
+    color: #66706c;
+}
+
+.matching-review-candidate__difference {
+    align-items: flex-end;
+    color: #0f8a5f;
+    font-weight: 800;
+}
+
+.matching-review-candidate__difference.is-short {
+    color: #a23d3d;
+}
+
+.matching-review-card__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1.35fr;
+    gap: 10px;
+    margin-top: 14px;
+}
+
+.matching-review-button {
+    min-height: 42px;
+    padding: 0 18px;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    font: inherit;
+    font-weight: 800;
+    cursor: pointer;
+}
+
+.matching-review-button--ghost {
+    background: #ffffff;
+    color: #0f8a5f;
+}
+
+.matching-review-button--secondary {
+    border-color: #9cb9ae;
+    background: #ffffff;
+    color: #355f50;
+}
+
+.matching-review-button--primary {
+    background: #0f8a5f;
+    color: #ffffff;
+}
+
+.matching-review-button--primary:hover {
+    background: #056347;
+}
+
+.matching-review-button--danger {
+    background: #a23d3d;
+    color: #ffffff;
+}
+
+.matching-review-button:disabled {
+    background: #e8ecea;
+    color: #a8b0ad;
+    cursor: not-allowed;
+}
+
+.matching-review-card--result {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 20px;
+    border-color: #b8dfd1;
+    background: #eef9f5;
+}
+
+.matching-review-card--result.is-unmatched {
+    border-color: #e7c9c9;
+    background: #fff7f7;
+}
+
+.matching-review-result-icon {
+    display: grid;
+    width: 40px;
+    height: 40px;
+    flex: 0 0 auto;
+    place-items: center;
+    border: 2px solid #0f8a5f;
+    border-radius: 50%;
+    color: #0f8a5f;
+    font-size: 22px;
+}
+
+.matching-review-card--result.is-unmatched .matching-review-result-icon {
+    border-color: #a23d3d;
+    color: #a23d3d;
+}
+
+.matching-review-card--result h3,
+.matching-review-card--result p {
+    margin: 0;
+}
+
+.matching-review-card--result p {
+    margin-top: 6px;
+    color: #50605a;
+}
+
+.matching-review-modal__footer {
+    padding: 14px 20px;
+    border-top: 1px solid #d9e0dd;
+    text-align: center;
+}
+
+.matching-review-confirm {
+    width: min(460px, 100%);
+    padding: 30px;
+    border-radius: 14px;
+    background: #ffffff;
+    color: #18231f;
+    box-shadow: 0 24px 70px rgba(8, 25, 18, 0.25);
+    text-align: center;
+    font-family: Pretendard, "Noto Sans KR", "Apple SD Gothic Neo", system-ui, sans-serif;
+}
+
+.matching-review-confirm h3 {
+    margin: 0 0 14px;
+    font-size: 23px;
+}
+
+.matching-review-confirm p {
+    margin: 0 0 8px;
+}
+
+.matching-review-confirm small {
+    color: #66706c;
+}
+
+.matching-review-confirm__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-top: 24px;
+}
+
+@media (max-width: 720px) {
+    .matching-review-overlay {
+        padding: 0;
+        place-items: stretch;
+    }
+
+    .matching-review-modal {
+        max-height: 100vh;
+        border-radius: 0;
+    }
+
+    .matching-review-modal__header {
+        padding: 20px;
+    }
+
+    .matching-review-modal__body {
+        padding: 12px;
+    }
+
+    .matching-review-card__header {
+        grid-template-columns: 1fr auto;
+    }
+
+    .matching-review-card__meta {
+        grid-column: 1 / -1;
+    }
+
+    .matching-review-candidate {
+        grid-template-columns: 24px 1fr;
+    }
+
+    .matching-review-candidate__money,
+    .matching-review-candidate__difference {
+        grid-column: 2;
+        align-items: flex-start;
+    }
+
+    .matching-review-card__actions {
+        grid-template-columns: 1fr;
+    }
+
+    .matching-review-card__actions .matching-review-button--primary {
+        grid-row: 1;
+    }
+}

--- a/src/main/resources/static/js/contractdashboard/contract-dashboard.js
+++ b/src/main/resources/static/js/contractdashboard/contract-dashboard.js
@@ -163,6 +163,11 @@ async function syncTransactions() {
 
         // 상환 금액과 납부 상태를 다시 조회한다.
         fetchDashboard();
+
+        await MatchingReviewModal.open({
+            reviewChannel: 'TRANSACTION_HISTORY',
+            targetType: 'LOAN'
+        });
     } catch (error) {
         console.error('거래내역 동기화 실패:', error);
 
@@ -204,3 +209,5 @@ function escapeHtml(str) {
 }
 
 fetchDashboard();
+
+document.addEventListener('matching-review:closed', fetchDashboard);

--- a/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
+++ b/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
@@ -1,7 +1,9 @@
 const contractId = document.getElementById('contractId').value;
+const syncTransactionButton = document.getElementById('btnSyncTransaction');
 
 let allSchedules = [];
 let currentPage = 1;
+let currentLinkedAccountId = null;
 const PAGE_SIZE = 5;
 
 const REPAYMENT_TYPE_LABELS = {
@@ -15,6 +17,69 @@ const CONTRACT_STATUS_LABELS = {
     PENDING: '서명대기',
     COMPLETED: '진행중'
 };
+
+initializeContractSync();
+
+async function initializeContractSync() {
+    try {
+        const response = await authFetch(`/api/contracts/${contractId}/account`);
+        if (!response.ok) {
+            return;
+        }
+        const account = await response.json();
+        currentLinkedAccountId = account.linkedAccountId;
+        syncTransactionButton.disabled = !currentLinkedAccountId;
+    } catch (error) {
+        console.error('차용증 연동계좌 조회 실패:', error);
+    }
+}
+
+syncTransactionButton.addEventListener('click', syncContractTransactions);
+
+async function syncContractTransactions() {
+    if (!currentLinkedAccountId) {
+        return;
+    }
+
+    const originalText = syncTransactionButton.textContent;
+    try {
+        syncTransactionButton.disabled = true;
+        syncTransactionButton.textContent = '동기화 중...';
+
+        const response = await authFetch(
+            `/api/linked-accounts/${currentLinkedAccountId}/sync`,
+            { method: 'POST' }
+        );
+        const result = await readJsonSafely(response);
+        if (!response.ok) {
+            throw new Error(result?.message || '거래내역 동기화에 실패했습니다.');
+        }
+
+        await MatchingReviewModal.open({
+            reviewChannel: 'TRANSACTION_HISTORY',
+            targetType: 'LOAN',
+            aggregateId: contractId
+        });
+    } catch (error) {
+        console.error('차용증 거래 동기화 실패:', error);
+        alert(error.message || '거래내역 동기화에 실패했습니다.');
+    } finally {
+        syncTransactionButton.disabled = false;
+        syncTransactionButton.textContent = originalText;
+    }
+}
+
+async function readJsonSafely(response) {
+    const text = await response.text();
+    if (!text) {
+        return null;
+    }
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
 
 Promise.all([
     authFetch(
@@ -122,4 +187,8 @@ function formatDateTimeKorean(dateString) {
 
 document.getElementById('btnViewContract').addEventListener('click', function () {
     window.location.href = `/contracts/${contractId}/contract-detail`;
+});
+
+document.addEventListener('matching-review:closed', () => {
+    window.location.reload();
 });

--- a/src/main/resources/static/js/matching/matching-review-modal.js
+++ b/src/main/resources/static/js/matching/matching-review-modal.js
@@ -2,6 +2,7 @@
     "use strict";
 
     const PAGE_SIZE = 20;
+    const LOADING_MESSAGE_DELAY_MS = 300;
     const state = {
         options: null,
         page: 0,
@@ -12,10 +13,12 @@
         pendingRejectTransactionId: null,
         lastFocusedElement: null,
         hasServerChanges: false,
+        hasLoaded: false,
         loading: false
     };
 
     let elements;
+    let loadingTimer = null;
 
     function initialize() {
         if (elements) {
@@ -63,8 +66,8 @@
             transaction: null
         };
         resetState();
-        showModal();
         await loadPage(false);
+        showModal();
     }
 
     async function openTransaction(options) {
@@ -82,11 +85,12 @@
             }
         };
         resetState();
-        showModal();
         await loadTransaction();
+        showModal();
     }
 
     function resetState() {
+        clearLoadingTimer();
         state.page = 0;
         state.totalCount = 0;
         state.transactions = [];
@@ -94,6 +98,7 @@
         state.resultStates.clear();
         state.pendingRejectTransactionId = null;
         state.hasServerChanges = false;
+        state.hasLoaded = false;
         hideMessage();
     }
 
@@ -102,13 +107,13 @@
         elements.overlay.hidden = false;
         document.body.classList.add("matching-review-scroll-locked");
         elements.closeButton.focus();
-        renderLoading();
     }
 
     function close() {
         if (!elements) {
             return;
         }
+        clearLoadingTimer();
         elements.overlay.hidden = true;
         elements.confirmOverlay.hidden = true;
         document.body.classList.remove("matching-review-scroll-locked");
@@ -127,7 +132,7 @@
         state.loading = true;
         elements.moreButton.disabled = true;
         if (!append) {
-            renderLoading();
+            scheduleLoadingMessage();
         }
 
         try {
@@ -154,6 +159,7 @@
                 : body.content || [];
             state.totalCount = Number(body.totalCount || 0);
             state.page = Number(body.page || 0) + 1;
+            state.hasLoaded = true;
             render();
         } catch (error) {
             console.error("매칭 검토 목록 조회 실패", error);
@@ -166,6 +172,7 @@
 
     async function loadTransaction() {
         const { linkedAccountId, bankTransactionId } = state.options.transaction;
+        scheduleLoadingMessage();
         try {
             const response = await authFetch(
                 `/api/linked-accounts/${linkedAccountId}/transactions/${bankTransactionId}/match-candidates`
@@ -176,6 +183,7 @@
             }
             state.transactions = [body];
             state.totalCount = 1;
+            state.hasLoaded = true;
             render();
         } catch (error) {
             console.error("매칭 검토 조회 실패", error);
@@ -184,16 +192,40 @@
     }
 
     function renderLoading() {
+        clearLoadingTimer();
         elements.list.innerHTML = '<div class="matching-review-loading">확인 필요 거래를 불러오는 중입니다.</div>';
         elements.footer.hidden = true;
     }
 
+    function scheduleLoadingMessage() {
+        clearLoadingTimer();
+        loadingTimer = window.setTimeout(() => {
+            loadingTimer = null;
+            if (state.loading && !state.hasLoaded) {
+                renderLoading();
+            }
+        }, LOADING_MESSAGE_DELAY_MS);
+    }
+
+    function clearLoadingTimer() {
+        if (loadingTimer !== null) {
+            window.clearTimeout(loadingTimer);
+            loadingTimer = null;
+        }
+    }
+
     function renderError(message) {
+        clearLoadingTimer();
         elements.list.innerHTML = `<div class="matching-review-empty">${escapeHtml(message)}</div>`;
         elements.footer.hidden = true;
     }
 
     function render() {
+        clearLoadingTimer();
+        if (!state.hasLoaded) {
+            return;
+        }
+
         const deferredCount = Array.from(state.resultStates.values())
                 .filter(result => result.type === "DEFERRED")
                 .length;
@@ -351,12 +383,12 @@
                 return;
             }
 
-            const review = state.transactions.find(item => item.transaction.bankTransactionId === transactionId);
-            const candidate = review?.candidates.find(item => Number(item.matchCandidateId) === Number(matchCandidateId));
-            state.resultStates.set(transactionId, {
-                type: "APPLIED",
-                message: `${candidate?.targetName || "선택한 대상"}에 ${formatMoney(review?.transaction.amount)}이 반영되었습니다.`
-            });
+            state.transactions = state.transactions.filter(
+                item => item.transaction.bankTransactionId !== transactionId
+            );
+            state.selectedCandidateIds.delete(transactionId);
+            state.resultStates.delete(transactionId);
+            state.totalCount = Math.max(state.totalCount - 1, 0);
             render();
             notifyProcessed(transactionId, body);
         } catch (error) {

--- a/src/main/resources/static/js/matching/matching-review-modal.js
+++ b/src/main/resources/static/js/matching/matching-review-modal.js
@@ -1,0 +1,503 @@
+(function () {
+    "use strict";
+
+    const PAGE_SIZE = 20;
+    const state = {
+        options: null,
+        page: 0,
+        totalCount: 0,
+        transactions: [],
+        selectedCandidateIds: new Map(),
+        resultStates: new Map(),
+        pendingRejectTransactionId: null,
+        lastFocusedElement: null,
+        hasServerChanges: false,
+        loading: false
+    };
+
+    let elements;
+
+    function initialize() {
+        if (elements) {
+            return true;
+        }
+
+        const overlay = document.getElementById("matching-review-overlay");
+        if (!overlay) {
+            return false;
+        }
+
+        elements = {
+            overlay,
+            title: document.getElementById("matching-review-title"),
+            progress: document.getElementById("matching-review-progress"),
+            message: document.getElementById("matching-review-message"),
+            list: document.getElementById("matching-review-list"),
+            footer: document.getElementById("matching-review-footer"),
+            moreButton: document.getElementById("matching-review-more"),
+            closeButton: document.getElementById("matching-review-close"),
+            confirmOverlay: document.getElementById("matching-review-confirm-overlay"),
+            confirmCancel: document.getElementById("matching-review-confirm-cancel"),
+            confirmSubmit: document.getElementById("matching-review-confirm-submit")
+        };
+
+        elements.closeButton.addEventListener("click", close);
+        elements.moreButton.addEventListener("click", () => loadPage(true));
+        elements.confirmCancel.addEventListener("click", closeRejectConfirm);
+        elements.confirmSubmit.addEventListener("click", rejectPendingTransaction);
+        elements.list.addEventListener("change", handleCandidateSelection);
+        elements.list.addEventListener("click", handleCardAction);
+        document.addEventListener("keydown", handleEscape);
+        return true;
+    }
+
+    async function open(options) {
+        if (!initialize()) {
+            throw new Error("매칭 검토 모달을 찾을 수 없습니다.");
+        }
+
+        state.options = {
+            reviewChannel: options.reviewChannel,
+            targetType: options.targetType || null,
+            aggregateId: options.aggregateId || null,
+            transaction: null
+        };
+        resetState();
+        showModal();
+        await loadPage(false);
+    }
+
+    async function openTransaction(options) {
+        if (!initialize()) {
+            throw new Error("매칭 검토 모달을 찾을 수 없습니다.");
+        }
+
+        state.options = {
+            reviewChannel: "NOTIFICATION",
+            targetType: null,
+            aggregateId: null,
+            transaction: {
+                linkedAccountId: options.linkedAccountId,
+                bankTransactionId: options.bankTransactionId
+            }
+        };
+        resetState();
+        showModal();
+        await loadTransaction();
+    }
+
+    function resetState() {
+        state.page = 0;
+        state.totalCount = 0;
+        state.transactions = [];
+        state.selectedCandidateIds.clear();
+        state.resultStates.clear();
+        state.pendingRejectTransactionId = null;
+        state.hasServerChanges = false;
+        hideMessage();
+    }
+
+    function showModal() {
+        state.lastFocusedElement = document.activeElement;
+        elements.overlay.hidden = false;
+        document.body.classList.add("matching-review-scroll-locked");
+        elements.closeButton.focus();
+        renderLoading();
+    }
+
+    function close() {
+        if (!elements) {
+            return;
+        }
+        elements.overlay.hidden = true;
+        elements.confirmOverlay.hidden = true;
+        document.body.classList.remove("matching-review-scroll-locked");
+        state.lastFocusedElement?.focus?.();
+        if (state.hasServerChanges) {
+            state.hasServerChanges = false;
+            document.dispatchEvent(new CustomEvent("matching-review:closed"));
+        }
+    }
+
+    async function loadPage(append) {
+        if (state.loading) {
+            return;
+        }
+
+        state.loading = true;
+        elements.moreButton.disabled = true;
+        if (!append) {
+            renderLoading();
+        }
+
+        try {
+            const query = new URLSearchParams({
+                reviewChannel: state.options.reviewChannel,
+                page: String(state.page),
+                size: String(PAGE_SIZE)
+            });
+            if (state.options.targetType) {
+                query.set("targetType", state.options.targetType);
+            }
+            if (state.options.aggregateId) {
+                query.set("aggregateId", String(state.options.aggregateId));
+            }
+
+            const response = await authFetch(`/api/matching-reviews?${query}`);
+            const body = await readJsonSafely(response);
+            if (!response.ok) {
+                throw new Error(body?.message || "확인 필요 거래를 불러오지 못했습니다.");
+            }
+
+            state.transactions = append
+                ? state.transactions.concat(body.content || [])
+                : body.content || [];
+            state.totalCount = Number(body.totalCount || 0);
+            state.page = Number(body.page || 0) + 1;
+            render();
+        } catch (error) {
+            console.error("매칭 검토 목록 조회 실패", error);
+            renderError(error.message);
+        } finally {
+            state.loading = false;
+            elements.moreButton.disabled = false;
+        }
+    }
+
+    async function loadTransaction() {
+        const { linkedAccountId, bankTransactionId } = state.options.transaction;
+        try {
+            const response = await authFetch(
+                `/api/linked-accounts/${linkedAccountId}/transactions/${bankTransactionId}/match-candidates`
+            );
+            const body = await readJsonSafely(response);
+            if (!response.ok) {
+                throw new Error(body?.message || "매칭 후보를 불러오지 못했습니다.");
+            }
+            state.transactions = [body];
+            state.totalCount = 1;
+            render();
+        } catch (error) {
+            console.error("매칭 검토 조회 실패", error);
+            renderError(error.message);
+        }
+    }
+
+    function renderLoading() {
+        elements.list.innerHTML = '<div class="matching-review-loading">확인 필요 거래를 불러오는 중입니다.</div>';
+        elements.footer.hidden = true;
+    }
+
+    function renderError(message) {
+        elements.list.innerHTML = `<div class="matching-review-empty">${escapeHtml(message)}</div>`;
+        elements.footer.hidden = true;
+    }
+
+    function render() {
+        const deferredCount = Array.from(state.resultStates.values())
+                .filter(result => result.type === "DEFERRED")
+                .length;
+        const completedCount = state.resultStates.size - deferredCount;
+        elements.title.textContent = state.options.reviewChannel === "NOTIFICATION"
+            ? "정산·차용증 매칭 선택"
+            : `확인이 필요한 거래 ${state.totalCount}건`;
+        elements.progress.textContent = `${completedCount}건 처리 · ${Math.max(state.totalCount - completedCount, 0)}건 남음`;
+
+        if (state.transactions.length === 0) {
+            elements.list.innerHTML = '<div class="matching-review-empty">현재 화면에서 확인할 거래가 없습니다.</div>';
+            elements.footer.hidden = true;
+            return;
+        }
+
+        elements.list.innerHTML = state.transactions
+                .map(renderTransaction)
+                .join("");
+        elements.footer.hidden = state.transactions.length >= state.totalCount;
+    }
+
+    function renderTransaction(review) {
+        const transaction = review.transaction;
+        const result = state.resultStates.get(transaction.bankTransactionId);
+        if (result) {
+            return renderResult(transaction, result);
+        }
+
+        const selectedId = state.selectedCandidateIds.get(transaction.bankTransactionId);
+        const multipleCandidates = review.candidates.length > 1;
+        const candidateHtml = review.candidates
+                .map(candidate => renderCandidate(transaction, candidate, selectedId))
+                .join("");
+
+        return `
+            <article class="matching-review-card" data-transaction-id="${transaction.bankTransactionId}" data-linked-account-id="${transaction.linkedAccountId}">
+                <header class="matching-review-card__header">
+                    <div class="matching-review-card__amount">${formatMoney(transaction.amount)} 입금</div>
+                    <div class="matching-review-card__meta">${escapeHtml(transaction.counterpartyName || "입금자 미상")} · ${formatDateTime(transaction.transactionAt)}${transaction.memo ? ` · ${escapeHtml(transaction.memo)}` : ""}</div>
+                    <div class="matching-review-card__badges">
+                        <span class="matching-review-badge matching-review-badge--warning">확인 필요</span>
+                        ${multipleCandidates ? '<span class="matching-review-badge">복수 후보</span>' : ""}
+                    </div>
+                </header>
+                <div class="matching-review-card__content">
+                    <p class="matching-review-card__instruction">다음 중 반영할 대상을 하나 선택해 주세요.</p>
+                    <div class="matching-review-candidates">${candidateHtml}</div>
+                    <footer class="matching-review-card__actions">
+                        <button type="button" class="matching-review-button matching-review-button--ghost" data-action="later">나중에 하기</button>
+                        <button type="button" class="matching-review-button matching-review-button--secondary" data-action="reject">어느 후보도 아님</button>
+                        <button type="button" class="matching-review-button matching-review-button--primary" data-action="apply" ${selectedId ? "" : "disabled"}>선택하여 반영</button>
+                    </footer>
+                </div>
+            </article>`;
+    }
+
+    function renderCandidate(transaction, candidate, selectedId) {
+        const selected = Number(selectedId) === Number(candidate.matchCandidateId);
+        const difference = Number(transaction.amount) - Number(candidate.expectedRemainingAmount);
+        const differenceClass = difference < 0 ? " is-short" : "";
+        const domainClass = candidate.targetType === "LOAN" ? "loan" : "settlement";
+        const domainLabel = candidate.targetType === "LOAN" ? "차용증" : "정산";
+
+        return `
+            <label class="matching-review-candidate${selected ? " is-selected" : ""}">
+                <input type="radio" name="matching-candidate-${transaction.bankTransactionId}" value="${candidate.matchCandidateId}" ${selected ? "checked" : ""}>
+                <span class="matching-review-candidate__main">
+                    <strong>${escapeHtml(candidate.targetName || `${domainLabel} #${candidate.aggregateId}`)}</strong>
+                    <small><span class="matching-review-badge matching-review-badge--${domainClass}">${domainLabel}</span> 참여자 ${escapeHtml(candidate.participantName || "-")}</small>
+                </span>
+                <span class="matching-review-candidate__money">
+                    <small>예정 잔여금액</small>
+                    <strong>${formatMoney(candidate.expectedRemainingAmount)}</strong>
+                </span>
+                <span class="matching-review-candidate__difference${differenceClass}">
+                    <small>${amountTypeLabel(candidate.amountMatchType)}</small>
+                    <span>${differenceText(difference)}</span>
+                </span>
+            </label>`;
+    }
+
+    function renderResult(transaction, result) {
+        const unmatched = result.type === "UNMATCHED";
+        return `
+            <article class="matching-review-card matching-review-card--result${unmatched ? " is-unmatched" : ""}">
+                <div class="matching-review-result-icon">${unmatched ? "–" : "✓"}</div>
+                <div>
+                    <h3>${unmatched ? "미매칭 처리 완료" : result.type === "DEFERRED" ? "나중에 확인" : "처리 완료"}</h3>
+                    <p>${escapeHtml(result.message)}</p>
+                </div>
+            </article>`;
+    }
+
+    function handleCandidateSelection(event) {
+        const input = event.target.closest('input[type="radio"]');
+        if (!input) {
+            return;
+        }
+        const card = input.closest(".matching-review-card");
+        state.selectedCandidateIds.set(
+            Number(card.dataset.transactionId),
+            Number(input.value)
+        );
+        render();
+    }
+
+    function handleCardAction(event) {
+        const button = event.target.closest("[data-action]");
+        if (!button) {
+            return;
+        }
+        const card = button.closest(".matching-review-card");
+        const transactionId = Number(card.dataset.transactionId);
+        const linkedAccountId = Number(card.dataset.linkedAccountId);
+
+        if (button.dataset.action === "apply") {
+            applyCandidate(transactionId, linkedAccountId, button);
+        } else if (button.dataset.action === "reject") {
+            state.pendingRejectTransactionId = transactionId;
+            elements.confirmOverlay.hidden = false;
+            elements.confirmCancel.focus();
+        } else if (button.dataset.action === "later") {
+            state.resultStates.set(transactionId, {
+                type: "DEFERRED",
+                message: "거래는 확인 필요 상태로 유지되며 나중에 다시 표시됩니다."
+            });
+            render();
+        }
+    }
+
+    async function applyCandidate(transactionId, linkedAccountId, button) {
+        const matchCandidateId = state.selectedCandidateIds.get(transactionId);
+        if (!matchCandidateId) {
+            return;
+        }
+        button.disabled = true;
+
+        try {
+            const response = await authFetch(
+                `/api/linked-accounts/${linkedAccountId}/transactions/${transactionId}/matching-review/apply`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ matchCandidateId })
+                }
+            );
+            const body = await readJsonSafely(response);
+            if (!response.ok) {
+                throw new Error(body?.message || "선택한 후보를 반영하지 못했습니다.");
+            }
+
+            if (body.reviewResult === "CANDIDATE_INVALIDATED") {
+                showMessage("선택한 후보가 더 이상 유효하지 않습니다. 최신 후보를 다시 불러왔습니다.", true);
+                await reloadCurrentView();
+                return;
+            }
+
+            const review = state.transactions.find(item => item.transaction.bankTransactionId === transactionId);
+            const candidate = review?.candidates.find(item => Number(item.matchCandidateId) === Number(matchCandidateId));
+            state.resultStates.set(transactionId, {
+                type: "APPLIED",
+                message: `${candidate?.targetName || "선택한 대상"}에 ${formatMoney(review?.transaction.amount)}이 반영되었습니다.`
+            });
+            render();
+            notifyProcessed(transactionId, body);
+        } catch (error) {
+            console.error("매칭 후보 반영 실패", error);
+            showMessage(error.message, true);
+            button.disabled = false;
+        }
+    }
+
+    async function rejectPendingTransaction() {
+        const transactionId = state.pendingRejectTransactionId;
+        const review = state.transactions.find(item => item.transaction.bankTransactionId === transactionId);
+        if (!review) {
+            closeRejectConfirm();
+            return;
+        }
+
+        elements.confirmSubmit.disabled = true;
+        try {
+            const response = await authFetch(
+                `/api/linked-accounts/${review.transaction.linkedAccountId}/transactions/${transactionId}/matching-review/reject`,
+                { method: "POST" }
+            );
+            const body = await readJsonSafely(response);
+            if (!response.ok) {
+                throw new Error(body?.message || "미매칭 처리하지 못했습니다.");
+            }
+            state.resultStates.set(transactionId, {
+                type: "UNMATCHED",
+                message: "이 거래는 어느 후보에도 반영되지 않았습니다."
+            });
+            closeRejectConfirm();
+            render();
+            notifyProcessed(transactionId, body);
+        } catch (error) {
+            console.error("미매칭 처리 실패", error);
+            showMessage(error.message, true);
+        } finally {
+            elements.confirmSubmit.disabled = false;
+        }
+    }
+
+    async function reloadCurrentView() {
+        state.selectedCandidateIds.clear();
+        state.resultStates.clear();
+        if (state.options.transaction) {
+            await loadTransaction();
+        } else {
+            state.page = 0;
+            await loadPage(false);
+        }
+    }
+
+    function closeRejectConfirm() {
+        state.pendingRejectTransactionId = null;
+        elements.confirmOverlay.hidden = true;
+    }
+
+    function notifyProcessed(transactionId, response) {
+        state.hasServerChanges = true;
+        document.dispatchEvent(new CustomEvent("matching-review:processed", {
+            detail: { bankTransactionId: transactionId, response }
+        }));
+    }
+
+    function showMessage(message, error) {
+        elements.message.textContent = message;
+        elements.message.classList.toggle("is-error", Boolean(error));
+        elements.message.hidden = false;
+    }
+
+    function hideMessage() {
+        if (!elements) {
+            return;
+        }
+        elements.message.hidden = true;
+        elements.message.classList.remove("is-error");
+        elements.message.textContent = "";
+    }
+
+    function handleEscape(event) {
+        if (event.key !== "Escape" || !elements) {
+            return;
+        }
+        if (!elements.confirmOverlay.hidden) {
+            closeRejectConfirm();
+        } else if (!elements.overlay.hidden) {
+            close();
+        }
+    }
+
+    async function readJsonSafely(response) {
+        const text = await response.text();
+        if (!text) {
+            return null;
+        }
+        try {
+            return JSON.parse(text);
+        } catch {
+            return null;
+        }
+    }
+
+    function formatMoney(value) {
+        return `${new Intl.NumberFormat("ko-KR").format(Number(value || 0))}원`;
+    }
+
+    function formatDateTime(value) {
+        if (!value) {
+            return "거래일시 미상";
+        }
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit"
+        }).format(new Date(value));
+    }
+
+    function amountTypeLabel(type) {
+        return ({ EXACT: "정확 일치", PARTIAL: "부분입금", EXCESS: "초과입금" })[type] || "금액 확인";
+    }
+
+    function differenceText(difference) {
+        if (difference === 0) {
+            return "정확히 일치";
+        }
+        return difference > 0
+            ? `${formatMoney(difference)} 초과`
+            : `${formatMoney(Math.abs(difference))} 부족`;
+    }
+
+    function escapeHtml(value) {
+        return String(value ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    window.MatchingReviewModal = { open, openTransaction, close };
+})();

--- a/src/main/resources/static/js/matching/matching-review-modal.js
+++ b/src/main/resources/static/js/matching/matching-review-modal.js
@@ -383,13 +383,14 @@
                 return;
             }
 
-            state.transactions = state.transactions.filter(
-                item => item.transaction.bankTransactionId !== transactionId
-            );
-            state.selectedCandidateIds.delete(transactionId);
-            state.resultStates.delete(transactionId);
-            state.totalCount = Math.max(state.totalCount - 1, 0);
-            render();
+            if (state.options.transaction) {
+                state.transactions = [];
+                state.totalCount = 0;
+                state.hasLoaded = true;
+                render();
+            } else {
+                await reloadCurrentView();
+            }
             notifyProcessed(transactionId, body);
         } catch (error) {
             console.error("매칭 후보 반영 실패", error);

--- a/src/main/resources/static/js/notification/notification-center.js
+++ b/src/main/resources/static/js/notification/notification-center.js
@@ -126,6 +126,24 @@ function initNotificationCenter() {
                         `/settlements/${notification.referenceId}`
                 };
 
+            case "BANK_TRANSACTION_MATCHING_REVIEW":
+                return {
+                    category: "SYSTEM",
+                    iconClass: notification.resolved
+                        ? "icon-gray"
+                        : "icon-orange",
+                    accentClass: notification.resolved
+                        ? ""
+                        : "accent-orange",
+                    ctaLabel: notification.resolved
+                        ? "처리 완료"
+                        : "매칭 확인하기",
+                    ctaUrl: null,
+                    ctaAction: notification.resolved
+                        ? null
+                        : "MATCHING_REVIEW"
+                };
+
             default:
                 return {
                     category: "SYSTEM",
@@ -177,6 +195,18 @@ function initNotificationCenter() {
 
             ctaUrl:
                 view.ctaUrl,
+
+            ctaAction:
+                view.ctaAction || null,
+
+            referenceId:
+                notification.referenceId,
+
+            secondaryReferenceId:
+                notification.secondaryReferenceId,
+
+            resolved:
+                Boolean(notification.resolved),
 
             iconClass:
                 view.iconClass,
@@ -291,6 +321,7 @@ function initNotificationCenter() {
                                     <button
                                         type="button"
                                         class="notif-cta"
+                                        ${notification.resolved ? "disabled" : ""}
                                     >
                                         ${notification.ctaLabel}
                                     </button>
@@ -445,8 +476,31 @@ function initNotificationCenter() {
             ) {
                 window.location.href =
                     notification.ctaUrl;
+                return;
+            }
+
+            if (
+                notification?.ctaAction
+                === "MATCHING_REVIEW"
+            ) {
+                MatchingReviewModal.openTransaction({
+                    bankTransactionId:
+                        notification.referenceId,
+                    linkedAccountId:
+                        notification.secondaryReferenceId
+                }).catch((error) => {
+                    console.error(
+                        "매칭 검토 모달 조회 실패",
+                        error
+                    );
+                });
             }
         }
+    );
+
+    document.addEventListener(
+        "matching-review:processed",
+        fetchNotifications
     );
 
 

--- a/src/main/resources/static/js/settlement/settlement-detail.js
+++ b/src/main/resources/static/js/settlement/settlement-detail.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const refreshButton = document.getElementById("refresh-button");
     const changeAccountButton =
         document.getElementById("change-account-button");
+    let currentLinkedAccountId = null;
 
     if (!settlementId) {
         showToast(
@@ -43,8 +44,14 @@ document.addEventListener("DOMContentLoaded", () => {
         try {
             syncButton.disabled = true;
 
+            if (!currentLinkedAccountId) {
+                throw new Error(
+                    "동기화할 수취 계좌를 확인할 수 없습니다."
+                );
+            }
+
             const result = await requestJson(
-                "/api/transactions/sync",
+                `/api/linked-accounts/${currentLinkedAccountId}/sync`,
                 {
                     method: "POST"
                 }
@@ -56,6 +63,12 @@ document.addEventListener("DOMContentLoaded", () => {
             );
 
             await loadPage();
+
+            await MatchingReviewModal.open({
+                reviewChannel: "TRANSACTION_HISTORY",
+                targetType: "SETTLEMENT",
+                aggregateId: settlementId
+            });
 
         } catch (error) {
             console.error("거래내역 동기화 실패:", error);
@@ -117,10 +130,15 @@ document.addEventListener("DOMContentLoaded", () => {
             setLoading(false);
         }
     }
+
+    document.addEventListener("matching-review:closed", loadPage);
     async function loadSettlementAccount() {
         try {
             const account =
                 await requestSettlementAccount();
+
+            currentLinkedAccountId =
+                account?.linkedAccountId || null;
 
             renderSettlementAccount(
                 account
@@ -133,6 +151,7 @@ document.addEventListener("DOMContentLoaded", () => {
             );
 
             renderSettlementAccount(null);
+            currentLinkedAccountId = null;
         }
     }
 

--- a/src/main/resources/static/js/settlement/settlement-list.js
+++ b/src/main/resources/static/js/settlement/settlement-list.js
@@ -49,6 +49,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
             await loadSettlements();
 
+            await MatchingReviewModal.open({
+                reviewChannel: "TRANSACTION_HISTORY",
+                targetType: "SETTLEMENT"
+            });
+
         } catch (error) {
             console.error(error);
             showToast(error.message || "거래내역 동기화에 실패했습니다.", true);
@@ -162,6 +167,8 @@ document.addEventListener("DOMContentLoaded", () => {
             loadSummary()
         ]);
     }
+
+    document.addEventListener("matching-review:closed", loadSettlements);
 
     async function loadSettlementList() {
         try {

--- a/src/main/resources/templates/contractdashboard/dashboard.html
+++ b/src/main/resources/templates/contractdashboard/dashboard.html
@@ -8,6 +8,7 @@
     </th:block>
     <link rel="stylesheet" th:href="@{/css/contractdashboard/contract-dashboard.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
+    <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
 </head>
 <body class="app-shell-page">
 
@@ -99,9 +100,11 @@
 <footer
         th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block th:replace="~{fragments/matching-review-modal :: matchingReviewModal}"></th:block>
 <th:block
         th:replace="~{fragments/app-shell :: commonScripts}">
 </th:block>
+<script src="/js/matching/matching-review-modal.js"></script>
 <script th:src="@{/js/contractdashboard/contract-dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/contractrepaymentschedule/schedule.html
+++ b/src/main/resources/templates/contractrepaymentschedule/schedule.html
@@ -8,6 +8,7 @@
     </th:block>
     <link rel="stylesheet" th:href="@{/css/contractrepaymentschedule/contractrepaymentschedule.css}">
     <link rel="stylesheet" href="/css/contractchange/site-common.css" />
+    <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
 </head>
 <body class="app-shell-page">
 
@@ -94,9 +95,11 @@
 <footer
         th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
+<th:block th:replace="~{fragments/matching-review-modal :: matchingReviewModal}"></th:block>
 <th:block
         th:replace="~{fragments/app-shell :: commonScripts}">
 </th:block>
+<script src="/js/matching/matching-review-modal.js"></script>
 <script th:src="@{/js/contractrepaymentschedule/contractrepaymentschedule.js}"></script>
 
 

--- a/src/main/resources/templates/fragments/matching-review-modal.html
+++ b/src/main/resources/templates/fragments/matching-review-modal.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="matchingReviewModal">
+    <div id="matching-review-overlay"
+         class="matching-review-overlay"
+         hidden>
+        <section class="matching-review-modal"
+                 role="dialog"
+                 aria-modal="true"
+                 aria-labelledby="matching-review-title">
+            <header class="matching-review-modal__header">
+                <div>
+                    <h2 id="matching-review-title">확인이 필요한 거래</h2>
+                    <p id="matching-review-progress"></p>
+                </div>
+                <button type="button"
+                        id="matching-review-close"
+                        class="matching-review-icon-button"
+                        aria-label="닫기">×</button>
+            </header>
+
+            <div id="matching-review-message"
+                 class="matching-review-message"
+                 role="status"
+                 aria-live="polite"
+                 hidden></div>
+
+            <div id="matching-review-list"
+                 class="matching-review-modal__body"></div>
+
+            <footer id="matching-review-footer"
+                    class="matching-review-modal__footer"
+                    hidden>
+                <button type="button"
+                        id="matching-review-more"
+                        class="matching-review-button matching-review-button--secondary">
+                    더 보기
+                </button>
+            </footer>
+        </section>
+    </div>
+
+    <div id="matching-review-confirm-overlay"
+         class="matching-review-confirm-overlay"
+         hidden>
+        <section class="matching-review-confirm"
+                 role="alertdialog"
+                 aria-modal="true"
+                 aria-labelledby="matching-review-confirm-title">
+            <h3 id="matching-review-confirm-title">어느 후보도 아닌가요?</h3>
+            <p>이 거래를 어느 정산이나 차용증에도 반영하지 않으시겠어요?</p>
+            <small>미매칭 처리하면 현재 확인 목록에서 제외됩니다.</small>
+            <div class="matching-review-confirm__actions">
+                <button type="button"
+                        id="matching-review-confirm-cancel"
+                        class="matching-review-button matching-review-button--secondary">
+                    취소
+                </button>
+                <button type="button"
+                        id="matching-review-confirm-submit"
+                        class="matching-review-button matching-review-button--danger">
+                    미매칭 처리
+                </button>
+            </div>
+        </section>
+    </div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/notification/notification-center.html
+++ b/src/main/resources/templates/notification/notification-center.html
@@ -13,6 +13,7 @@
   <link
           rel="stylesheet"
           href="/css/notification/notification-center.css">
+  <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
 
 </head>
 
@@ -92,9 +93,12 @@
         th:replace="~{fragments/app-shell :: appFooter}">
 </footer>
 
+<th:block th:replace="~{fragments/matching-review-modal :: matchingReviewModal}"></th:block>
+
 <th:block
         th:replace="~{fragments/app-shell :: commonScripts}">
 </th:block>
+<script src="/js/matching/matching-review-modal.js"></script>
 <script
         th:src="@{/js/notification/notification-center.js}"
         src="/js/notification/notification-center.js">

--- a/src/main/resources/templates/settlement/settlement-detail.html
+++ b/src/main/resources/templates/settlement/settlement-detail.html
@@ -14,6 +14,7 @@
   <link
           rel="stylesheet"
           href="/css/settlement/settlement-detail.css">
+  <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
 
 </head>
 <body class="app-shell-page">
@@ -137,9 +138,12 @@
         class="toast">
 </div>
 
+<th:block th:replace="~{fragments/matching-review-modal :: matchingReviewModal}"></th:block>
+
 <th:block
         th:replace="~{fragments/app-shell :: commonScripts}">
 </th:block>
+<script src="/js/matching/matching-review-modal.js"></script>
 <script
         th:src="@{/js/settlement/settlement-detail.js}"
         src="/js/settlement/settlement-detail.js">

--- a/src/main/resources/templates/settlement/settlement-list.html
+++ b/src/main/resources/templates/settlement/settlement-list.html
@@ -9,6 +9,7 @@
     </th:block>
     <link rel="stylesheet" href="/css/settlement/settlement-common.css">
     <link rel="stylesheet" href="/css/settlement/settlement-list.css">
+    <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
 </head>
 <body class="app-shell-page">
 <header th:replace="~{fragments/app-shell :: appHeader('settlement')}"></header>
@@ -113,7 +114,10 @@
 
 <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
+<th:block th:replace="~{fragments/matching-review-modal :: matchingReviewModal}"></th:block>
+
 <th:block th:replace="~{fragments/app-shell :: commonScripts}"></th:block>
+<script src="/js/matching/matching-review-modal.js"></script>
 <script th:src="@{/js/settlement/settlement-list.js}" src="/js/settlement/settlement-list.js"></script>
 </body>
 </html>

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -260,7 +260,9 @@ public class CalendarTest {
     private SettlementListResponse settlement(
             Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
     ) {
-        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, createdAt);
+        return new SettlementListResponse(
+                id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, null, null, createdAt
+        );
     }
 
     private SettlementPaymentStatusResponse paymentStatus(
@@ -305,4 +307,3 @@ public class CalendarTest {
         return new DashboardService.IntegrationDashboardData(dashboard, contexts);
     }
 }
-

--- a/src/test/java/org/teamsai/saibackend/domain/contract/ContractAccountServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contract/ContractAccountServiceTest.java
@@ -348,6 +348,70 @@ class ContractAccountServiceTest {
         }
     }
 
+    @Nested
+    class GetCurrentContractAccount {
+
+        @Test
+        void returnsActiveLinkedAccountForCreditor() {
+            given(loanContractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createContract(ContractStatus.COMPLETED)));
+            given(contractAccountMapper.findActiveAccountByContractId(CONTRACT_ID))
+                    .willReturn(List.of(ContractAccountDTO.builder()
+                            .contractId(CONTRACT_ID)
+                            .linkedAccountId(LINKED_ACCOUNT_ID)
+                            .accountStatus(ContractAccountStatus.ACTIVE)
+                            .build()));
+            given(linkedBankAccountService.getLinkedAccounts(CREDITOR_ID))
+                    .willReturn(List.of(createLinkedAccount(
+                            LINKED_ACCOUNT_ID,
+                            ConnectionStatus.AVAILABLE
+                    )));
+
+            LinkedBankAccountResponse result =
+                    contractAccountService.getCurrentAccount(
+                            CONTRACT_ID,
+                            CREDITOR_ID
+                    );
+
+            assertThat(result.linkedAccountId()).isEqualTo(LINKED_ACCOUNT_ID);
+        }
+
+        @Test
+        void rejectsNonCreditor() {
+            given(loanContractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createContract(ContractStatus.PENDING)));
+
+            assertThatThrownBy(() -> contractAccountService.getCurrentAccount(
+                    CONTRACT_ID,
+                    OTHER_USER_ID
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(LoanContractErrorCode.CONTRACT_ACCESS_DENIED)
+            );
+
+            verify(contractAccountMapper, never())
+                    .findActiveAccountByContractId(any());
+        }
+
+        @Test
+        void rejectsMissingActiveAccount() {
+            given(loanContractMapper.findContractById(CONTRACT_ID))
+                    .willReturn(Optional.of(createContract(ContractStatus.PENDING)));
+            given(contractAccountMapper.findActiveAccountByContractId(CONTRACT_ID))
+                    .willReturn(List.of());
+
+            assertThatThrownBy(() -> contractAccountService.getCurrentAccount(
+                    CONTRACT_ID,
+                    CREDITOR_ID
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(LoanContractErrorCode.CONTRACT_ACCOUNT_NOT_FOUND)
+            );
+        }
+    }
+
     private LinkedBankAccountResponse createLinkedAccount(Long linkedAccountId, ConnectionStatus status) {
         return LinkedBankAccountResponse.builder()
                 .linkedAccountId(linkedAccountId)

--- a/src/test/java/org/teamsai/saibackend/domain/contractdashboard/DashboardServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractdashboard/DashboardServiceTest.java
@@ -83,6 +83,33 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("부분 납부된 회차는 실제 잔여 납부금액으로 대시보드에 표시된다")
+    void getDashboard_usesRemainingPaymentAmountAfterPartialPayment() {
+        LoanContractResponse contract = buildContract(
+                21L, null, ContractStatus.COMPLETED, "부분납부계약", 3L, 1L
+        );
+        RepaymentScheduleDTO schedule = RepaymentScheduleDTO.builder()
+                .status(RepaymentScheduleStatus.PENDING)
+                .totalPaymentDue(BigDecimal.valueOf(50_000))
+                .remainingPrincipal(BigDecimal.valueOf(50_000))
+                .dueDate(LocalDate.now())
+                .remainingPaymentAmount(BigDecimal.valueOf(20_000))
+                .build();
+
+        when(loanContractService.findContractsByUser(USER_ID))
+                .thenReturn(List.of(contract));
+        when(repaymentScheduleService.getSchedulesByContractIds(List.of(21L)))
+                .thenReturn(Map.of(21L, List.of(schedule)));
+
+        DashboardResponse response = dashboardService.getDashboard(
+                USER_ID, null, "ALL", null, 1
+        );
+
+        assertThat(response.getContracts().get(0).getTotalRemainingAmount())
+                .isEqualByComparingTo("20000");
+    }
+
+    @Test
     @DisplayName("빌려준 돈, 빌린 돈, 이번달 상환예정금이 정확히 합산되고 defaultFilter가 결정된다")
     void getDashboard_buildsSummaryCorrectly() {
         LoanContractResponse lentContract = buildContract(30L, null, ContractStatus.COMPLETED, "빌려준계약", 1L, 2L);

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
@@ -93,6 +93,31 @@ class BankMatchingTransactionServiceTest {
     }
 
     @Test
+    @DisplayName("특정 대상 동기화 범위 밖 거래는 PENDING으로 유지한다")
+    void keepsOutOfScopeTransactionPending() {
+        BankTransactionDTO transaction = bankTransaction(101L, "Hong Gil Dong");
+        givenLockedTransaction(transaction);
+        given(paymentObligationMapper.findMatchCandidatesByLinkedAccountIdAndTarget(
+                LINKED_ACCOUNT_ID,
+                transaction.getTransactionAt(),
+                MatchingTargetType.SETTLEMENT,
+                999L
+        )).willReturn(List.of());
+
+        AutoMatchingTransactionResult result = transactionService.process(
+                USER_ID,
+                LINKED_ACCOUNT_ID,
+                transaction,
+                MatchingTargetType.SETTLEMENT,
+                999L
+        );
+
+        assertThat(result).isNull();
+        verify(bankTransactionService, never()).updateStatus(any(), any(), any());
+        verify(autoMatchingService, never()).execute(any(), any());
+    }
+
+    @Test
     @DisplayName("후보를 조회해 자동매칭하고 은행 거래 상태를 변경한다")
     void executesAutoMatchingAndUpdatesStatus() {
         BankTransactionDTO staleTransaction = bankTransaction(

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchCandidateServiceTest.java
@@ -206,6 +206,55 @@ class BankTransactionMatchCandidateServiceTest {
     }
 
     @Test
+    void returnsCandidatesForTransactionPage() {
+        BankTransactionMatchCandidateQueryDTO candidate =
+                BankTransactionMatchCandidateQueryDTO.builder()
+                        .matchCandidateId(1L)
+                        .bankTransactionId(100L)
+                        .targetType(MatchingTargetType.SETTLEMENT)
+                        .targetId(10L)
+                        .aggregateId(20L)
+                        .build();
+
+        when(candidateMapper.findAllForReviewByBankTransactionIds(
+                List.of(100L, 101L),
+                MatchingTargetType.SETTLEMENT,
+                20L
+        )).thenReturn(List.of(candidate));
+
+        List<BankTransactionMatchCandidateQueryDTO> result =
+                candidateService.findAllForReviewByBankTransactionIds(
+                        List.of(100L, 101L),
+                        MatchingTargetType.SETTLEMENT,
+                        20L
+                );
+
+        assertThat(result).containsExactly(candidate);
+    }
+
+    @Test
+    void rejectsEmptyTransactionPage() {
+        assertThatThrownBy(() ->
+                candidateService.findAllForReviewByBankTransactionIds(
+                        List.of(),
+                        null,
+                        null
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(MatchingErrorCode.INVALID_MATCHING_REQUEST)
+        );
+
+        verify(candidateMapper, never())
+                .findAllForReviewByBankTransactionIds(
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any()
+                );
+    }
+
+    @Test
     void returnsCandidateBelongingToBankTransaction() {
         BankTransactionMatchCandidateDTO candidate = dto(1L, 100L);
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
@@ -76,6 +76,8 @@ class BankTransactionMatchingReviewListQueryServiceTest {
                 .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
         assertThat(result.content().get(0).candidates().get(0).aggregateId())
                 .isEqualTo(100L);
+        assertThat(result.content().get(0).candidates().get(0).targetName())
+                .isEqualTo("8월 회식비 정산");
     }
 
     @Test
@@ -125,6 +127,7 @@ class BankTransactionMatchingReviewListQueryServiceTest {
                 .targetType(MatchingTargetType.SETTLEMENT)
                 .targetId(30L)
                 .aggregateId(100L)
+                .targetName("8월 회식비 정산")
                 .participantName("participant")
                 .expectedRemainingAmount(new BigDecimal("10000"))
                 .amountMatchType(MatchingAmountType.PARTIAL)

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
@@ -1,0 +1,134 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateQueryDTO;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewSearchCondition;
+import org.teamsai.saibackend.domain.matching.mapper.BankTransactionMatchingReviewQueryMapper;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchCandidateService;
+import org.teamsai.saibackend.domain.matching.service.BankTransactionMatchingReviewListQueryService;
+import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
+import org.teamsai.saibackend.domain.transaction.dto.response.PageResponse;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionProcessingStatus;
+import org.teamsai.saibackend.domain.transaction.type.BankTransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BankTransactionMatchingReviewListQueryServiceTest {
+
+    @Mock
+    private BankTransactionMatchingReviewQueryMapper reviewQueryMapper;
+    @Mock
+    private BankTransactionMatchCandidateService candidateService;
+
+    private BankTransactionMatchingReviewListQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BankTransactionMatchingReviewListQueryService(
+                reviewQueryMapper,
+                candidateService
+        );
+    }
+
+    @Test
+    void groupsCandidatesByTransactionAndReturnsPage() {
+        MatchingReviewSearchCondition condition =
+                new MatchingReviewSearchCondition(
+                        MatchingReviewChannel.TRANSACTION_HISTORY,
+                        MatchingTargetType.SETTLEMENT,
+                        null,
+                        0,
+                        20
+                );
+        BankTransactionDTO transaction = transaction(10L);
+        BankTransactionMatchCandidateQueryDTO candidate = candidate(10L);
+
+        given(reviewQueryMapper.search(1L, condition))
+                .willReturn(List.of(transaction));
+        given(reviewQueryMapper.count(1L, condition)).willReturn(1L);
+        given(candidateService.findAllForReviewByBankTransactionIds(
+                List.of(10L),
+                MatchingTargetType.SETTLEMENT,
+                null
+        )).willReturn(List.of(candidate));
+
+        PageResponse<org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse> result =
+                service.getReviews(1L, condition);
+
+        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).reviewChannel())
+                .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
+        assertThat(result.content().get(0).candidates().get(0).aggregateId())
+                .isEqualTo(100L);
+    }
+
+    @Test
+    void returnsEmptyPageWithoutCandidateLookup() {
+        MatchingReviewSearchCondition condition =
+                new MatchingReviewSearchCondition(
+                        MatchingReviewChannel.TRANSACTION_HISTORY,
+                        null,
+                        null,
+                        1,
+                        20
+                );
+        given(reviewQueryMapper.search(1L, condition)).willReturn(List.of());
+        given(reviewQueryMapper.count(1L, condition)).willReturn(25L);
+
+        PageResponse<org.teamsai.saibackend.domain.matching.dto.response.BankTransactionMatchingReviewResponse> result =
+                service.getReviews(1L, condition);
+
+        assertThat(result.content()).isEmpty();
+        assertThat(result.totalCount()).isEqualTo(25);
+        assertThat(result.hasPrevious()).isTrue();
+        verify(candidateService, never())
+                .findAllForReviewByBankTransactionIds(
+                        org.mockito.ArgumentMatchers.anyList(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any()
+                );
+    }
+
+    private BankTransactionDTO transaction(Long id) {
+        return BankTransactionDTO.builder()
+                .bankTransactionId(id)
+                .linkedAccountId(2L)
+                .amount(new BigDecimal("5000"))
+                .transactionType(BankTransactionType.DEPOSIT)
+                .processingStatus(BankTransactionProcessingStatus.NEEDS_CHECK)
+                .transactionAt(LocalDateTime.of(2026, 8, 17, 10, 0))
+                .counterpartyName("sender")
+                .syncedAt(LocalDateTime.of(2026, 8, 17, 10, 1))
+                .build();
+    }
+
+    private BankTransactionMatchCandidateQueryDTO candidate(Long transactionId) {
+        return BankTransactionMatchCandidateQueryDTO.builder()
+                .matchCandidateId(20L)
+                .bankTransactionId(transactionId)
+                .targetType(MatchingTargetType.SETTLEMENT)
+                .targetId(30L)
+                .aggregateId(100L)
+                .participantName("participant")
+                .expectedRemainingAmount(new BigDecimal("10000"))
+                .amountMatchType(MatchingAmountType.PARTIAL)
+                .createdAt(LocalDateTime.of(2026, 8, 17, 10, 1))
+                .build();
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
@@ -88,6 +88,8 @@ class BankTransactionMatchingReviewQueryServiceTest {
         assertThat(response.candidates()).hasSize(1);
         assertThat(response.candidates().get(0).matchCandidateId())
                 .isEqualTo(10L);
+        assertThat(response.candidates().get(0).aggregateId())
+                .isEqualTo(100L);
         assertThat(response.candidates().get(0).participantName())
                 .isEqualTo("홍길동");
         assertThat(response.candidates().get(0).amountMatchType())
@@ -248,6 +250,7 @@ class BankTransactionMatchingReviewQueryServiceTest {
                 .bankTransactionId(BANK_TRANSACTION_ID)
                 .targetType(targetType)
                 .targetId(20L + matchCandidateId)
+                .aggregateId(100L)
                 .participantName("홍길동")
                 .expectedRemainingAmount(new BigDecimal("10000.00"))
                 .amountMatchType(amountMatchType)

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
@@ -90,6 +90,8 @@ class BankTransactionMatchingReviewQueryServiceTest {
                 .isEqualTo(10L);
         assertThat(response.candidates().get(0).aggregateId())
                 .isEqualTo(100L);
+        assertThat(response.candidates().get(0).targetName())
+                .isEqualTo("8월 회식비 정산");
         assertThat(response.candidates().get(0).participantName())
                 .isEqualTo("홍길동");
         assertThat(response.candidates().get(0).amountMatchType())
@@ -251,6 +253,7 @@ class BankTransactionMatchingReviewQueryServiceTest {
                 .targetType(targetType)
                 .targetId(20L + matchCandidateId)
                 .aggregateId(100L)
+                .targetName("8월 회식비 정산")
                 .participantName("홍길동")
                 .expectedRemainingAmount(new BigDecimal("10000.00"))
                 .amountMatchType(amountMatchType)

--- a/src/test/java/org/teamsai/saibackend/domain/matching/MatchingReviewSearchConditionTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/MatchingReviewSearchConditionTest.java
@@ -1,0 +1,60 @@
+package org.teamsai.saibackend.domain.matching;
+
+import org.junit.jupiter.api.Test;
+import org.teamsai.saibackend.domain.matching.dto.request.MatchingReviewSearchCondition;
+import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
+import org.teamsai.saibackend.domain.matching.type.MatchingReviewChannel;
+import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
+import org.teamsai.saibackend.global.exception.DomainException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MatchingReviewSearchConditionTest {
+
+    @Test
+    void allowsTransactionHistoryWithoutTargetType() {
+        MatchingReviewSearchCondition condition =
+                new MatchingReviewSearchCondition(
+                        MatchingReviewChannel.TRANSACTION_HISTORY,
+                        null,
+                        null,
+                        -1,
+                        0
+                );
+
+        assertThat(condition.page()).isZero();
+        assertThat(condition.size()).isEqualTo(20);
+    }
+
+    @Test
+    void rejectsAggregateIdWithoutTargetType() {
+        assertInvalid(() -> new MatchingReviewSearchCondition(
+                MatchingReviewChannel.TRANSACTION_HISTORY,
+                null,
+                10L,
+                0,
+                20
+        ));
+    }
+
+    @Test
+    void rejectsDomainFiltersForNotificationChannel() {
+        assertInvalid(() -> new MatchingReviewSearchCondition(
+                MatchingReviewChannel.NOTIFICATION,
+                MatchingTargetType.SETTLEMENT,
+                null,
+                0,
+                20
+        ));
+    }
+
+    private void assertInvalid(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(MatchingErrorCode.INVALID_MATCHING_REQUEST)
+                );
+    }
+}

--- a/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/payment/PaymentObligationMapperTest.java
@@ -114,6 +114,18 @@ class PaymentObligationMapperTest {
                                 new BigDecimal("15000").stripTrailingZeros()
                         )
                 );
+
+        List<MatchingCandidate> scopedResult =
+                paymentObligationMapper.findMatchCandidatesByLinkedAccountIdAndTarget(
+                        LINKED_ACCOUNT_ID,
+                        MATCHING_TRANSACTION_AT,
+                        MatchingTargetType.SETTLEMENT,
+                        9201L
+                );
+
+        assertThat(scopedResult)
+                .extracting(MatchingCandidate::targetId)
+                .containsExactly(9501L);
     }
 
     @Test

--- a/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/settlement/OverdueSettlementServiceIntegrationTest.java
@@ -43,8 +43,12 @@ class OverdueSettlementServiceIntegrationTest {
 
     @AfterEach
     void cleanUp() {
+        jdbcTemplate.update(
+                "DELETE FROM bank_transaction_match_candidate WHERE bank_transaction_id >= 90000"
+        );
         jdbcTemplate.update("DELETE FROM payment_record WHERE bank_transaction_id >= 90000");
         jdbcTemplate.update("DELETE FROM bank_transaction WHERE bank_transaction_id >= 90000");
+        jdbcTemplate.update("DELETE FROM settlement_account WHERE settlement_id >= 90000");
         jdbcTemplate.update("DELETE FROM linked_bank_account WHERE linked_account_id >= 90000");
         jdbcTemplate.update("DELETE FROM payment_obligation WHERE payment_obligation_id >= 90000");
         jdbcTemplate.update("DELETE FROM settlement_participant WHERE participant_id >= 90000");


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #143 

## 🛠 작업 사항

- 확인 필요 거래 자동매칭 및 후보 선택 반영 기능 구현
- 정산,차용증별 거래동기화 범위 제한
- 거래 매칭 검토 모달 화면 연
- 후보 상태 및 동시 처리 예외 보완
## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항

 -  자동매칭이 어려운 거래를 사용자가 직접 선택해 반영할 수 있도록 구현했습니다.
  - 정산·차용증별 거래동기화와 알림에서 후보를 선택할 수 있습니다.
  - 이미 처리된 거래가 중복으로 반영되지 않도록 했습니다.
  - 실제 화면에서 차용증 동기화 과정을 확인하는 작업 본인인증 후 확인해야해서 다음에 진행합니다.
  - 오류 난 테스트 수정/ loancontractservice 1개 테스트 제외 다 통과