### PR TITLE
feat(#156): 계약 변경 요청 권한 확장 (채권자 전용 → 당사자 모두), 캘린더 기능 추가

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.teamsai.saibackend.domain.payment.type.PaymentTargetType;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Getter@Builder
 public class DashboardCalendarItemResponse {
@@ -17,6 +18,15 @@ public class DashboardCalendarItemResponse {
     private String detailUrl;
     private String counterpartyName;
     private String categoryLabel;
-    private String installmentInfo;
+    private String installmentInfo;    
     private boolean overdue;
+
+    private LocalDate maturityDate;
+    private BigDecimal principalAmount;
+    private BigDecimal interestRate;
+
+    private String settlementTypeLabel;
+    private String splitTypeLabel;
+    private LocalDate periodStartDate;
+    private LocalDate periodEndDate;
 }

--- a/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/calendar/response/DashboardCalendarItemResponse.java
@@ -15,4 +15,8 @@ public class DashboardCalendarItemResponse {
     private String subLabel;
     private BigDecimal amount;
     private String detailUrl;
+    private String counterpartyName;
+    private String categoryLabel;
+    private String installmentInfo;
+    private boolean overdue;
 }

--- a/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contract/service/LoanContractService.java
@@ -167,13 +167,13 @@ public class LoanContractService {
 
         LoanContractResponse.LoanContractResponseBuilder enriched = contract.toBuilder()
                 .creditorName(creditor.getName())
-                .creditorBirthDate(creditor.getBirthDate().toString());
+                .creditorBirthDate(creditor.getBirthDate() != null ? creditor.getBirthDate().toString() : null);
 
         if (contract.getDebtorId() != null) {
             var debtor = userService.getMyInfo(contract.getDebtorId());
 
             enriched.debtorName(debtor.getName())
-                    .debtorBirthDate(debtor.getBirthDate().toString());
+                    .debtorBirthDate(debtor.getBirthDate() != null ? debtor.getBirthDate().toString() : null);
         }
 
         return enriched.build();

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/exception/ContractChangeErrorCode.java
@@ -12,12 +12,10 @@ import org.teamsai.saibackend.global.exception.DomainException;
 public enum ContractChangeErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_CONTRACT_PARTY(HttpStatus.FORBIDDEN, "계약 변경 요청은 로그인된 사용자만 요청할 수 있습니다."),
-    NOT_CREDITOR(HttpStatus.FORBIDDEN, "계약 변경 요청은 채권자만 할 수 있습니다."),
     CONTRACT_NOT_COMPLETED(HttpStatus.BAD_REQUEST,"완료된 계약만 변경 요청 할 수 있습니다."),
     DUPLICATE_PENDING_REQUEST(HttpStatus.CONFLICT, "이미 처리 대기 중인 변경 요청이 있습니다."),
     CHANGE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "변경 요청을 찾을 수 없습니다."),
     CONTRACT_ALREADY_SUPERSEDED(HttpStatus.CONFLICT, "이미 변경된 계약입니다. 최신 계약서를 확인해주세요."),
-    NOT_DEBTOR(HttpStatus.FORBIDDEN, "채무자만 접근 가능합니다."),
     ALREADY_BEING_REQUEST(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
     ALREADY_SIGNED(HttpStatus.CONFLICT, "이미 서명을 제출하여 상대방에게 전송된 요청은 취소할 수 없습니다."),
     SIGNATURE_REQUIRED(HttpStatus.BAD_REQUEST, "서명 이미지가 필요합니다.");

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -89,10 +89,6 @@ public class ContractChangeService {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
         }
 
-        if (!isCreditor) {
-            throw ContractChangeErrorCode.NOT_CREDITOR.toException();
-        }
-
         if (contract.getStatus() != ContractStatus.COMPLETED) {
             throw ContractChangeErrorCode.CONTRACT_NOT_COMPLETED.toException();
         }
@@ -203,8 +199,11 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         LoanContractChangeDTO changeRequest = getChangeRequest(changeRequestId);
 
-        if(!contract.getDebtorId().equals(userId)) {
-            throw ContractChangeErrorCode.NOT_DEBTOR.toException();
+        boolean requesterIsCreditor = contract.getCreditorId().equals(changeRequest.getUserId());
+        Long approverId = requesterIsCreditor ? contract.getDebtorId() : contract.getCreditorId();
+
+        if(!approverId.equals(userId)) {
+            throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
         }
 
         if(!changeRequest.getContractId().equals(contractId)) {
@@ -220,11 +219,13 @@ public class ContractChangeService {
             throw ContractChangeErrorCode.ALREADY_BEING_REQUEST.toException();
         }
         try {
+            UserResponse rejectorInfo = userService.getMyInfo(userId);
+
             notificationService.create(
-                    contract.getCreditorId(),
+                    changeRequest.getUserId(),
                     NotificationType.CONTRACT_CHANGE,
                     "계약 변경 요청 반려",
-                    contract.getDebtorName() + "님이 변경 요청을 반려했습니다.",
+                    rejectorInfo.getName() + "님이 변경 요청을 반려했습니다.",
                     contractId
             );
         } catch (Exception e) {
@@ -307,8 +308,11 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         UserResponse requesterInfo = userService.getMyInfo(userId);
 
+        boolean isCreditor = contract.getCreditorId().equals(userId);
+        Long recipientId = isCreditor ? contract.getDebtorId() : contract.getCreditorId();
+
         notificationService.create(
-                contract.getDebtorId(),
+                recipientId,
                 NotificationType.CONTRACT_CHANGE,
                 "계약 변경 요청",
                 requesterInfo.getName() + "님으로부터 계약 내용 변경 요청이 도착했습니다.",

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -83,7 +83,7 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
         boolean isCreditor = contract.getCreditorId().equals(userId);
-        boolean isDebtor = contract.getDebtorId().equals(userId);
+        boolean isDebtor = java.util.Objects.equals(contract.getDebtorId(), userId);
 
         if (!isCreditor && !isDebtor) {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -84,7 +84,7 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
         boolean isCreditor = Objects.equals(contract.getCreditorId(), userId);
-        boolean isDebtor = java.util.Objects.equals(contract.getDebtorId(), userId);
+        boolean isDebtor = Objects.equals(contract.getDebtorId(), userId);
 
         if (!isCreditor && !isDebtor) {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();

--- a/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractchange/service/ContractChangeService.java
@@ -28,6 +28,7 @@ import org.teamsai.saibackend.domain.user.service.UserService;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -82,7 +83,7 @@ public class ContractChangeService {
 
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
-        boolean isCreditor = contract.getCreditorId().equals(userId);
+        boolean isCreditor = Objects.equals(contract.getCreditorId(), userId);
         boolean isDebtor = java.util.Objects.equals(contract.getDebtorId(), userId);
 
         if (!isCreditor && !isDebtor) {
@@ -202,10 +203,10 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         LoanContractChangeDTO changeRequest = getChangeRequest(changeRequestId);
 
-        boolean requesterIsCreditor = contract.getCreditorId().equals(changeRequest.getUserId());
+        boolean requesterIsCreditor = Objects.equals(contract.getCreditorId(), changeRequest.getUserId());
         Long approverId = requesterIsCreditor ? contract.getDebtorId() : contract.getCreditorId();
 
-        if(!approverId.equals(userId)) {
+        if(!Objects.equals(approverId, userId)) {
             throw ContractChangeErrorCode.NOT_CONTRACT_PARTY.toException();
         }
 
@@ -311,17 +312,22 @@ public class ContractChangeService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         UserResponse requesterInfo = userService.getMyInfo(userId);
 
-        boolean isCreditor = contract.getCreditorId().equals(userId);
+        boolean isCreditor = Objects.equals(contract.getCreditorId(), userId);
         Long recipientId = isCreditor ? contract.getDebtorId() : contract.getCreditorId();
 
-        notificationService.create(
-                recipientId,
-                NotificationType.CONTRACT_CHANGE,
-                "계약 변경 요청",
-                requesterInfo.getName() + "님으로부터 계약 내용 변경 요청이 도착했습니다.",
-                contractId,
-                changeRequestId
-        );
+        if(recipientId != null) {
+            notificationService.create(
+                    recipientId,
+                    NotificationType.CONTRACT_CHANGE,
+                    "계약 변경 요청",
+                    requesterInfo.getName() + "님으로부터 계약 내용 변경 요청이 도착했습니다.",
+                    contractId,
+                    changeRequestId
+            );
+        }else{
+            log.warn("계약 변경 요청 알림 발송 실패 - recipientId가 null입니다. contractId={}, changeRequestId={}",
+            contractId, changeRequestId);
+        }
 
         return getChangeRequest(changeRequestId);
     }

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
@@ -7,6 +7,8 @@ import org.teamsai.saibackend.domain.contract.service.LoanContractService;
 import org.teamsai.saibackend.domain.contractchange.service.ContractChangeService;
 import org.teamsai.saibackend.domain.contractdetail.dto.response.ContractDetailResponse;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class ContractDetailService {
@@ -17,7 +19,7 @@ public class ContractDetailService {
     public boolean canRequestChange(Long contractId, Long userId) {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         boolean isCreditor = contract.getCreditorId().equals(userId);
-        boolean isDebtor = contract.getDebtorId().equals(userId);
+        boolean isDebtor = Objects.equals(contract.getDebtorId(), userId);
         return (isCreditor || isDebtor) && !contractChangeService.hasPendingChangeRequest(contractId);
     }
 
@@ -26,7 +28,7 @@ public class ContractDetailService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
         boolean isCreditor = contract.getCreditorId().equals(userId);
-        boolean isDebtor = contract.getDebtorId().equals(userId);
+        boolean isDebtor = Objects.equals(contract.getDebtorId(), userId);
         boolean canRequestChange = (isCreditor || isDebtor) && !contractChangeService.hasPendingChangeRequest(contractId);
 
         String address = isCreditor

--- a/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/contractdetail/service/ContractDetailService.java
@@ -17,7 +17,8 @@ public class ContractDetailService {
     public boolean canRequestChange(Long contractId, Long userId) {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
         boolean isCreditor = contract.getCreditorId().equals(userId);
-        return isCreditor && !contractChangeService.hasPendingChangeRequest(contractId);
+        boolean isDebtor = contract.getDebtorId().equals(userId);
+        return (isCreditor || isDebtor) && !contractChangeService.hasPendingChangeRequest(contractId);
     }
 
 
@@ -25,7 +26,8 @@ public class ContractDetailService {
         LoanContractResponse contract = loanContractService.findContract(contractId, userId);
 
         boolean isCreditor = contract.getCreditorId().equals(userId);
-        boolean canRequestChange = isCreditor && !contractChangeService.hasPendingChangeRequest(contractId);
+        boolean isDebtor = contract.getDebtorId().equals(userId);
+        boolean canRequestChange = (isCreditor || isDebtor) && !contractChangeService.hasPendingChangeRequest(contractId);
 
         String address = isCreditor
                 ? contract.getCreditorAddress()

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -9,7 +9,6 @@ import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardRes
 import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
 import org.teamsai.saibackend.domain.contractdashboard.service.DashboardService;
 import org.teamsai.saibackend.domain.contractdashboard.type.DashboardContractStatus;
-import org.teamsai.saibackend.domain.contractdashboard.type.TransactionCategory;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
 import org.teamsai.saibackend.domain.integration.dto.response.*;
 import org.teamsai.saibackend.domain.integration.type.DashboardAttentionType;
@@ -281,7 +280,6 @@ public class IntegrationDashboardService {
             LocalDate date,
             Long userId
     ) {
-
         Map<Long, Long> totalInstallmentsByContract = loanSchedules.stream()
                 .collect(Collectors.groupingBy(
                         context -> context.contract().getContractId(),
@@ -305,13 +303,13 @@ public class IntegrationDashboardService {
                             .amount(context.schedule().getTotalPaymentDue())
                             .detailUrl("/contracts/" + context.contract().getContractId() + "/schedule")
                             .counterpartyName(isCreditor
-                                        ? context.contract().getDebtorName()
-                                        : context.contract().getCreditorName())
-                            .categoryLabel(isCreditor
-                                        ? TransactionCategory.RECEIVE.getDescription()
-                                        : TransactionCategory.PAY.getDescription())
+                                    ? context.contract().getDebtorName()
+                                    : context.contract().getCreditorName())
                             .installmentInfo(context.schedule().getSequence() + "/" + totalInstallments + "회차")
                             .overdue(date.isBefore(today))
+                            .maturityDate(context.contract().getMaturityDate())
+                            .principalAmount(context.contract().getPrincipalAmount())
+                            .interestRate(context.contract().getInterestRate())
                             .build();
                 })
                 .toList();
@@ -321,7 +319,6 @@ public class IntegrationDashboardService {
             List<SettlementContext> settlements,
             LocalDate date
     ) {
-
         LocalDate today = LocalDate.now();
 
         return settlements.stream()
@@ -337,10 +334,21 @@ public class IntegrationDashboardService {
                         .amount(context.roleRemainingAmount())
                         .detailUrl("/settlements/" + context.settlement().settlementId())
                         .categoryLabel(context.settlement().settlementCategory())
-                        .installmentInfo(null)
                         .overdue(date.isBefore(today))
+                        .settlementTypeLabel(settlementTypeLabel(context.settlement().settlementType()))
+                        .splitTypeLabel(splitTypeLabel(context.settlement().splitType()))
+                        .periodStartDate(context.settlement().startDate())
+                        .periodEndDate(context.settlement().endDate())
                         .build())
                 .toList();
+    }
+
+    private String settlementTypeLabel(String settlementType) {
+        return "RECURRING".equals(settlementType) ? "정기정산" : "공동정산";
+    }
+
+    private String splitTypeLabel(String splitType) {
+        return "CUSTOM".equals(splitType) ? "직접입력" : "균등";
     }
 
     public List<DashboardCalendarItemResponse> getCalendarDayDetail(Long userId, LocalDate date) {

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -9,6 +9,7 @@ import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardRes
 import org.teamsai.saibackend.domain.contractdashboard.dto.response.DashboardSummaryResponse;
 import org.teamsai.saibackend.domain.contractdashboard.service.DashboardService;
 import org.teamsai.saibackend.domain.contractdashboard.type.DashboardContractStatus;
+import org.teamsai.saibackend.domain.contractdashboard.type.TransactionCategory;
 import org.teamsai.saibackend.domain.contractrepaymentschedule.type.RepaymentScheduleStatus;
 import org.teamsai.saibackend.domain.integration.dto.response.*;
 import org.teamsai.saibackend.domain.integration.type.DashboardAttentionType;
@@ -26,6 +27,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -279,11 +281,22 @@ public class IntegrationDashboardService {
             LocalDate date,
             Long userId
     ) {
+
+        Map<Long, Long> totalInstallmentsByContract = loanSchedules.stream()
+                .collect(Collectors.groupingBy(
+                        context -> context.contract().getContractId(),
+                        Collectors.counting()
+                ));
+
+        LocalDate today = LocalDate.now();
+
         return loanSchedules.stream()
                 .filter(context -> context.schedule().getStatus() == RepaymentScheduleStatus.PENDING)
                 .filter(context -> date.equals(context.schedule().getDueDate()))
                 .map(context -> {
                     boolean isCreditor = userId.equals(context.contract().getCreditorId());
+                    Long totalInstallments = totalInstallmentsByContract.get(context.contract().getContractId());
+
                     return DashboardCalendarItemResponse.builder()
                             .targetId(context.contract().getContractId())
                             .type(PaymentTargetType.LOAN)
@@ -291,6 +304,14 @@ public class IntegrationDashboardService {
                             .subLabel(isCreditor ? "수취예정" : "납부예정")
                             .amount(context.schedule().getTotalPaymentDue())
                             .detailUrl("/contracts/" + context.contract().getContractId() + "/schedule")
+                            .counterpartyName(isCreditor
+                                        ? context.contract().getDebtorName()
+                                        : context.contract().getCreditorName())
+                            .categoryLabel(isCreditor
+                                        ? TransactionCategory.RECEIVE.getDescription()
+                                        : TransactionCategory.PAY.getDescription())
+                            .installmentInfo(context.schedule().getSequence() + "/" + totalInstallments + "회차")
+                            .overdue(date.isBefore(today))
                             .build();
                 })
                 .toList();
@@ -300,6 +321,9 @@ public class IntegrationDashboardService {
             List<SettlementContext> settlements,
             LocalDate date
     ) {
+
+        LocalDate today = LocalDate.now();
+
         return settlements.stream()
                 .filter(context -> !isClosed(context.settlement()))
                 .filter(context -> context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
@@ -312,6 +336,9 @@ public class IntegrationDashboardService {
                         .subLabel(context.isOwner() ? "받을 돈" : "낼 돈")
                         .amount(context.roleRemainingAmount())
                         .detailUrl("/settlements/" + context.settlement().settlementId())
+                        .categoryLabel(context.settlement().settlementCategory())
+                        .installmentInfo(null)
+                        .overdue(date.isBefore(today))
                         .build())
                 .toList();
     }

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -137,6 +137,7 @@
         lc.previous_contract_id AS previousContractId,
         lc.creditor_id        AS creditorId,
         lc.debtor_id          AS debtorId,
+        lc.relation_type      AS relationType,
         creditor.name         AS creditorName,
         debtor.name           AS debtorName,
         lc.creditor_address   AS creditorAddress,

--- a/src/main/resources/mapper/contract/LoanContractMapper.xml
+++ b/src/main/resources/mapper/contract/LoanContractMapper.xml
@@ -137,7 +137,8 @@
         lc.previous_contract_id AS previousContractId,
         lc.creditor_id        AS creditorId,
         lc.debtor_id          AS debtorId,
-        lc.relation_type      AS relationType,
+        creditor.name         AS creditorName,
+        debtor.name           AS debtorName,
         lc.creditor_address   AS creditorAddress,
         lc.creditor_signature AS creditorSignature,
         lc.debtor_address     AS debtorAddress,
@@ -153,6 +154,8 @@
         lc.status             AS status,
         lc.created_at         AS createdAt
         FROM loan_contract lc
+        LEFT JOIN users creditor ON lc.creditor_id = creditor.user_id
+        LEFT JOIN users debtor ON lc.debtor_id = debtor.user_id
         WHERE lc.creditor_id = #{userId} OR lc.debtor_id = #{userId}
         ORDER BY lc.created_at DESC
     </select>

--- a/src/main/resources/static/css/calendar/calendar.css
+++ b/src/main/resources/static/css/calendar/calendar.css
@@ -242,14 +242,73 @@
 }
 
 .detail-item {
+    border: 1px solid #eee;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.detail-item-header {
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 16px;
     padding: 16px 18px;
-    border: 1px solid #eee;
-    border-radius: 10px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+}
+
+.detail-item-header:hover {
+    background: #f7f9fc;
+}
+
+.detail-item-header[aria-expanded="true"] {
+    background: #f7f9fc;
+}
+
+.detail-item-expand {
+    margin: 0;
+    padding: 0 18px 16px;
+    border-top: 1px solid #f0f0f0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.detail-item-expand[hidden] {
+    display: none;
+}
+
+.detail-expand-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    padding-top: 12px;
+}
+
+.detail-expand-row dt {
+    color: #999;
+}
+
+.detail-expand-row dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.detail-view-link {
+    align-self: flex-end;
+    margin-top: 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #3b6de0;
     text-decoration: none;
-    color: inherit;
+}
+
+.detail-view-link:hover {
+    text-decoration: underline;
 }
 
 .detail-item:hover {
@@ -261,17 +320,24 @@
     flex-direction: column;
     gap: 4px;
     align-items: flex-start;
+    min-width: 0;
+    flex: 1 1 auto;
 }
 
 .detail-item-top {
     display: flex;
     align-items: center;
     gap: 8px;
+    white-space: nowrap;
 }
 
 .detail-item-meta {
     font-size: 13px;
     color: #999;
+    white-space: nowrap;
+    overflow-x: auto;
+    max-width: 100%;
+    padding-bottom: 2px;
 }
 
 .badge-overdue {
@@ -311,8 +377,8 @@
 }
 
 .detail-amount {
-    font-size: 17px;
-    font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .empty-state {
@@ -320,4 +386,22 @@
     font-size: 15px;
     padding: 20px 0;
     text-align: center;
+}
+
+.detail-item-meta::-webkit-scrollbar {
+    height: 4px;
+}
+
+.direction-label {
+    font-weight: 600;
+}
+
+.detail-item.is-receivable .direction-label,
+.detail-item.is-receivable .detail-amount {
+    color: #2f9e6b;
+}
+
+.detail-item.is-payable .direction-label,
+.detail-item.is-payable .detail-amount {
+    color: #d8583a;
 }

--- a/src/main/resources/static/css/calendar/calendar.css
+++ b/src/main/resources/static/css/calendar/calendar.css
@@ -258,8 +258,34 @@
 
 .detail-item-main {
     display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+}
+
+.detail-item-top {
+    display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
+}
+
+.detail-item-meta {
+    font-size: 13px;
+    color: #999;
+}
+
+.badge-overdue {
+    background: #fdeceb;
+    color: #c0392b;
+}
+
+.detail-item.is-overdue {
+    border-color: #f3c6c1;
+    background: #fffaf9;
+}
+
+.detail-item.is-overdue .detail-amount {
+    color: #c0392b;
 }
 
 .badge {
@@ -282,11 +308,6 @@
 .detail-title {
     font-size: 16px;
     font-weight: 500;
-}
-
-.detail-sub {
-    font-size: 14px;
-    color: #888;
 }
 
 .detail-amount {

--- a/src/main/resources/static/js/calendar/calendar.js
+++ b/src/main/resources/static/js/calendar/calendar.js
@@ -1,12 +1,4 @@
 (function () {
-    function authHeaders(extra) {
-        const token = sessionStorage.getItem("accessToken");
-        return Object.assign(
-            token ? { Authorization: `Bearer ${token}` } : {},
-            extra || {}
-        );
-    }
-
     function escapeHtml(value) {
         return String(value ?? "")
             .replace(/&/g, "&amp;")
@@ -77,9 +69,16 @@
         daysGrid.innerHTML = '<p class="empty-state">달력을 불러오는 중이에요...</p>';
 
         const yearMonth = toYearMonth(viewYear, viewMonth);
-        const res = await fetch(`/api/integration/dashboard?yearMonth=${yearMonth}`, {
-            headers: authHeaders()
-        });
+
+        let res;
+        try {
+            res = await authFetch(`/api/integration/dashboard?yearMonth=${yearMonth}`, {
+                method: "GET"
+            });
+        } catch (e) {
+            daysGrid.innerHTML = '<p class="empty-state">달력을 불러오지 못했어요.</p>';
+            return;
+        }
 
         if (!res.ok) {
             daysGrid.innerHTML = '<p class="empty-state">달력을 불러오지 못했어요.</p>';
@@ -190,9 +189,16 @@
         detailDate.textContent = dateStr.replaceAll('-', '. ') + '.';
         detailList.innerHTML = '<p class="empty-state">일정을 불러오는 중이에요...</p>';
 
-        const res = await fetch(`/api/dashboard/calendar/${dateStr}`, {
-            headers: authHeaders()
-        });
+        let res;
+        try {
+            res = await authFetch(`/api/dashboard/calendar/${dateStr}`, {
+                method: "GET"
+            });
+        } catch (e) {
+            currentItems = [];
+            detailList.innerHTML = '<p class="empty-state">일정을 불러오지 못했어요. 다시 로그인해보세요.</p>';
+            return;
+        }
 
         if (!res.ok) {
             currentItems = [];
@@ -223,12 +229,22 @@
             const badgeLabel = item.type === 'LOAN' ? '대여' : '정산';
             const amount = Number(item.amount).toLocaleString(undefined, { maximumFractionDigits: 0 });
 
+            const metaParts = [];
+            if (item.subLabel) metaParts.push(escapeHtml(item.subLabel));
+            if (item.counterpartyName) metaParts.push(escapeHtml(item.counterpartyName));
+            if (item.installmentInfo) metaParts.push(escapeHtml(item.installmentInfo));
+            if (item.categoryLabel) metaParts.push(escapeHtml(item.categoryLabel));
+            const metaText = metaParts.join(' · ');
+
             return `
-                <a class="detail-item" href="${escapeHtml(item.detailUrl)}">
+                <a class="detail-item${item.overdue ? ' is-overdue' : ''}" href="${escapeHtml(item.detailUrl)}">
                     <div class="detail-item-main">
-                        <span class="badge ${badgeClass}">${badgeLabel}</span>
-                        <span class="detail-title">${escapeHtml(item.title)}</span>
-                        <span class="detail-sub">${escapeHtml(item.subLabel)}</span>
+                        <div class="detail-item-top">
+                            <span class="badge ${badgeClass}">${badgeLabel}</span>
+                            <span class="detail-title">${escapeHtml(item.title)}</span>
+                            ${item.overdue ? '<span class="badge badge-overdue">연체</span>' : ''}
+                        </div>
+                        <div class="detail-item-meta">${metaText}</div>
                     </div>
                     <span class="detail-amount">${amount}원</span>
                 </a>

--- a/src/main/resources/static/js/calendar/calendar.js
+++ b/src/main/resources/static/js/calendar/calendar.js
@@ -214,6 +214,10 @@
         renderDetailList();
     }
 
+    function formatDate(dateStr) {
+        return dateStr ? dateStr.replaceAll('-', '.') : '';
+    }
+
     function renderDetailList() {
         const items = currentFilter === 'ALL'
             ? currentItems
@@ -224,33 +228,82 @@
             return;
         }
 
-        detailList.innerHTML = items.map(item => {
+        detailList.innerHTML = items.map((item, index) => {
             const badgeClass = item.type === 'LOAN' ? 'badge-loan' : 'badge-settlement';
             const badgeLabel = item.type === 'LOAN' ? '대여' : '정산';
             const amount = Number(item.amount).toLocaleString(undefined, { maximumFractionDigits: 0 });
+            const isReceivable = item.subLabel === '수취예정' || item.subLabel === '받을 돈';
+            const directionClass = isReceivable ? 'is-receivable' : 'is-payable';
 
             const metaParts = [];
-            if (item.subLabel) metaParts.push(escapeHtml(item.subLabel));
+
             if (item.counterpartyName) metaParts.push(escapeHtml(item.counterpartyName));
             if (item.installmentInfo) metaParts.push(escapeHtml(item.installmentInfo));
-            if (item.categoryLabel) metaParts.push(escapeHtml(item.categoryLabel));
+            if (item.type === 'LOAN' && item.maturityDate) {
+                metaParts.push(`만기 ${formatDate(item.maturityDate)}`);
+            }
+            if (item.type === 'SETTLEMENT' && item.categoryLabel) {
+                metaParts.push(escapeHtml(item.categoryLabel));
+            }
             const metaText = metaParts.join(' · ');
 
+            const expandRows = [];
+            if (item.type === 'LOAN') {
+                if (item.principalAmount != null) {
+                    expandRows.push(['원금', `${Number(item.principalAmount).toLocaleString()}원`]);
+                }
+                if (item.interestRate != null) {
+                    expandRows.push(['이자율', `${item.interestRate}%`]);
+                }
+            } else {
+                if (item.settlementTypeLabel) expandRows.push(['유형', escapeHtml(item.settlementTypeLabel)]);
+                if (item.splitTypeLabel) expandRows.push(['정산방식', escapeHtml(item.splitTypeLabel)]);
+                if (item.periodStartDate && item.periodEndDate) {
+                    expandRows.push(['기간', `${formatDate(item.periodStartDate)} ~ ${formatDate(item.periodEndDate)}`]);
+                }
+            }
+
+            const expandHtml = expandRows.length > 0
+                ? expandRows.map(([label, value]) =>
+                    `<div class="detail-expand-row"><dt>${label}</dt><dd>${value}</dd></div>`
+                ).join('')
+                : '<p class="empty-state">추가 정보가 없어요.</p>';
+
             return `
-                <a class="detail-item${item.overdue ? ' is-overdue' : ''}" href="${escapeHtml(item.detailUrl)}">
-                    <div class="detail-item-main">
-                        <div class="detail-item-top">
-                            <span class="badge ${badgeClass}">${badgeLabel}</span>
-                            <span class="detail-title">${escapeHtml(item.title)}</span>
-                            ${item.overdue ? '<span class="badge badge-overdue">연체</span>' : ''}
+                <div class="detail-item ${directionClass}${item.overdue ? ' is-overdue' : ''}" data-index="${index}">
+                    <button type="button" class="detail-item-header" aria-expanded="false">
+                        <div class="detail-item-main">
+                             <div class="detail-item-top">
+                                 <span class="badge ${badgeClass}">${badgeLabel}</span>
+                                 <span class="detail-title">${escapeHtml(item.title)}</span>
+                                 ${item.overdue ? '<span class="badge badge-overdue">연체</span>' : ''}
+                             </div>
+                         <div class="detail-item-meta">
+                            <span class="direction-label">${escapeHtml(item.subLabel)}</span>${metaText ? ' · ' + metaText : ''}
+                         </div>
                         </div>
-                        <div class="detail-item-meta">${metaText}</div>
-                    </div>
-                    <span class="detail-amount">${amount}원</span>
-                </a>
-            `;
+                        <span class="detail-amount">${amount}원</span>
+                    </button>
+                <dl class="detail-item-expand" hidden>
+                    ${expandHtml}
+                    <a class="detail-view-link" href="${escapeHtml(item.detailUrl)}">상세보기 →</a>
+                </dl>
+            </div>
+        `;
         }).join('');
     }
+
+    detailList.addEventListener('click', (e) => {
+        const header = e.target.closest('.detail-item-header');
+        if (!header) return;
+
+        const item = header.closest('.detail-item');
+        const expand = item.querySelector('.detail-item-expand');
+        const isOpen = header.getAttribute('aria-expanded') === 'true';
+
+        header.setAttribute('aria-expanded', String(!isOpen));
+        expand.hidden = isOpen;
+    });
 
     prevMonthBtn.addEventListener('click', () => {
         viewMonth -= 1;

--- a/src/main/resources/templates/calendar/calendar.html
+++ b/src/main/resources/templates/calendar/calendar.html
@@ -2,31 +2,20 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>일정 캘린더</title>
-    <link rel="stylesheet" th:href="@{/css/calendar/calendar.css}">
-    <link rel="stylesheet" href="/css/contractchange/site-common.css" />
+    <th:block
+            th:replace="~{fragments/app-shell :: commonStyles}">
+    </th:block>
+    <link rel="stylesheet" th:href="@{/css/calendar/calendar.css}" href="../../static/css/calendar/calendar.css" />
 </head>
-<body>
+<body class="app-shell-page">
 
-<header class="site-header">
-    <div class="header-inner">
-        <a class="brand" href="/">사이원장</a>
-        <nav class="main-nav" aria-label="주요 메뉴">
-            <a href="#">서비스 소개</a>
-            <a href="/dashboard">금전거래대차</a>
-            <a href="/settlements">정산</a>
-            <a class="active" href="/calendar">거래 일정</a>
-        </nav>
-        <div class="header-actions">
-            <button class="icon-button" type="button" aria-label="알림">♧</button>
-            <a class="profile-link" href="/mypage" aria-label="마이페이지">
-                <span class="profile-avatar">사</span>
-            </a>
-        </div>
-    </div>
+<header
+        th:replace="~{fragments/app-shell :: appHeader('calendar')}">
 </header>
 
-<div class="calendar-page">
+<main class="calendar-page">
 
     <div class="calendar-main">
         <div class="calendar-header">
@@ -83,8 +72,15 @@
         </div>
     </div>
 
-</div>
+</main>
 
-<script th:src="@{/js/calendar/calendar.js}"></script>
+<footer
+        th:replace="~{fragments/app-shell :: appFooter}">
+</footer>
+
+<th:block
+        th:replace="~{fragments/app-shell :: commonScripts}">
+</th:block>
+<script th:src="@{/js/calendar/calendar.js}" src="../../static/js/calendar/calendar.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/contractchange/contract-edit-complete.html
+++ b/src/main/resources/templates/contractchange/contract-edit-complete.html
@@ -22,7 +22,7 @@
         <h1 class="success-title">계약 변경 요청이 전송되었습니다.</h1>
         <div class="success-icon" aria-hidden="true">📨</div>
         <p class="success-description">
-            상대방(채무자)이 승인하면 변경된 조건으로 계약이 적용됩니다.<br>
+            상대방이 승인하면 변경된 조건으로 계약이 적용됩니다.<br>
             승인 전까지는 기존 계약 내용이 그대로 유지됩니다.
         </p>
     </header>

--- a/src/main/resources/templates/fragments/app-shell.html
+++ b/src/main/resources/templates/fragments/app-shell.html
@@ -61,7 +61,7 @@
         <a
                 class="app-nav__link"
                 th:classappend="${activeMenu == 'calendar'} ? ' is-active' : ''"
-                href="#">
+                th:href="@{/calendar}">
             캘린더
         </a>
 

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -120,7 +120,7 @@ public class CalendarTest {
     @Test
     void 정산_참여자는_낼_돈으로_표시된다() {
         when(contractDashboardService.getIntegrationDashboardData(USER_ID))
-                .thenReturn(loanData(null, null));
+                .thenReturn(loanData(null, List.of()));
 
         SettlementListResponse settlement = settlement(
                 100L, "회식비 정산", "MEMBER", "OPEN", TARGET_DATE, LocalDateTime.now()
@@ -148,7 +148,7 @@ public class CalendarTest {
     @Test
     void 마감된_정산은_결과에서_제외된다() {
         when(contractDashboardService.getIntegrationDashboardData(USER_ID))
-                .thenReturn(loanData(null, null));
+                .thenReturn(loanData(null, List.of()));
 
         SettlementListResponse settlement = settlement(
                 101L, "종료된 정산", "OWNER", "CLOSED", TARGET_DATE, LocalDateTime.now()
@@ -232,12 +232,21 @@ public class CalendarTest {
     private LoanContractResponse buildContract(
             Long contractId, Long creditorId, Long debtorId, String alias
     ) {
+        return buildContract(contractId, creditorId, debtorId, alias, "채권자", "채무자");
+    }
+
+    private LoanContractResponse buildContract(
+            Long contractId, Long creditorId, Long debtorId, String alias,
+            String creditorName, String debtorName
+    ) {
         return LoanContractResponse.builder()
                 .contractId(contractId)
                 .status(ContractStatus.COMPLETED)
                 .contractAlias(alias)
                 .creditorId(creditorId)
                 .debtorId(debtorId)
+                .creditorName(creditorName)
+                .debtorName(debtorName)
                 .principalAmount(BigDecimal.valueOf(1_000_000))
                 .interestRate(BigDecimal.valueOf(5))
                 .repaymentType(RepaymentMethod.EQUAL_PRINCIPAL_AND_INTEREST)
@@ -249,7 +258,14 @@ public class CalendarTest {
     private RepaymentScheduleDTO buildSchedule(
             LocalDate dueDate, RepaymentScheduleStatus status, long amount
     ) {
+        return buildSchedule(dueDate, status, amount, 1);
+    }
+
+    private RepaymentScheduleDTO buildSchedule(
+            LocalDate dueDate, RepaymentScheduleStatus status, long amount, int sequence
+    ) {
         return RepaymentScheduleDTO.builder()
+                .sequence(sequence)
                 .dueDate(dueDate)
                 .status(status)
                 .totalPaymentDue(BigDecimal.valueOf(amount))
@@ -257,10 +273,24 @@ public class CalendarTest {
                 .build();
     }
 
-    private SettlementListResponse settlement(
-            Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
+    private DashboardService.IntegrationDashboardData loanData(
+            LoanContractResponse contract, List<RepaymentScheduleDTO> schedules
     ) {
-        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, createdAt);
+        DashboardResponse dashboard = DashboardResponse.builder()
+                .summary(DashboardSummaryResponse.builder()
+                        .totalLentAmount(BigDecimal.ZERO)
+                        .totalBorrowedAmount(BigDecimal.ZERO)
+                        .build())
+                .contracts(List.of())
+                .build();
+
+        List<DashboardService.LoanScheduleContext> contexts = contract == null
+                ? List.of()
+                : schedules.stream()
+                .map(schedule -> new DashboardService.LoanScheduleContext(contract, schedule))
+                .toList();
+
+        return new DashboardService.IntegrationDashboardData(dashboard, contexts);
     }
 
     private SettlementPaymentStatusResponse paymentStatus(
@@ -287,6 +317,12 @@ public class CalendarTest {
                 .build();
     }
 
+    private SettlementListResponse settlement(
+            Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
+    ) {
+        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, null, null, createdAt);
+    }
+
     private DashboardService.IntegrationDashboardData loanData(
             LoanContractResponse contract, RepaymentScheduleDTO schedule
     ) {
@@ -303,6 +339,116 @@ public class CalendarTest {
                 : List.of(new DashboardService.LoanScheduleContext(contract, schedule));
 
         return new DashboardService.IntegrationDashboardData(dashboard, contexts);
+    }
+
+    @Test
+    void 대여_항목에는_상대방_이름과_구분_라벨이_채워진다() {
+        LoanContractResponse contract = buildContract(20L, USER_ID, 2L, "생활비 대출", "김채권", "이채무");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getCounterpartyName()).isEqualTo("이채무");
+        assertThat(item.getCategoryLabel()).isEqualTo("수취");
+    }
+
+    @Test
+    void 채무자_입장에서는_상대방이_채권자이고_구분은_납부다() {
+        LoanContractResponse contract = buildContract(21L, 2L, USER_ID, "차량구입 대출", "김채권", "이채무");
+        RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 350_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getCounterpartyName()).isEqualTo("김채권");
+        assertThat(item.getCategoryLabel()).isEqualTo("납부");
+    }
+
+    @Test
+    void 대여_항목의_회차_정보는_계약의_전체_스케줄_개수_기준으로_계산된다() {
+        LoanContractResponse contract = buildContract(22L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule1 = buildSchedule(TARGET_DATE.minusMonths(1), RepaymentScheduleStatus.PAID, 600_000, 1);
+        RepaymentScheduleDTO schedule2 = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 600_000, 2);
+        RepaymentScheduleDTO schedule3 = buildSchedule(TARGET_DATE.plusMonths(1), RepaymentScheduleStatus.PENDING, 600_000, 3);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, List.of(schedule1, schedule2, schedule3)));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getInstallmentInfo()).isEqualTo("2/3회차");
+    }
+
+    @Test
+    void 조회_날짜가_오늘보다_과거면_연체로_표시된다() {
+        LocalDate pastDate = LocalDate.now().minusDays(5);
+        LoanContractResponse contract = buildContract(23L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(pastDate, RepaymentScheduleStatus.PENDING, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, pastDate);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).isOverdue()).isTrue();
+    }
+
+    @Test
+    void 조회_날짜가_오늘이거나_미래면_연체가_아니다() {
+        LocalDate futureDate = LocalDate.now().plusDays(5);
+        LoanContractResponse contract = buildContract(24L, USER_ID, 2L, "생활비 대출");
+        RepaymentScheduleDTO schedule = buildSchedule(futureDate, RepaymentScheduleStatus.PENDING, 600_000);
+
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(contract, schedule));
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of());
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, futureDate);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).isOverdue()).isFalse();
+    }
+
+    @Test
+    void 정산_항목의_구분_라벨은_settlementCategory_값을_그대로_사용하고_회차와_상대방은_없다() {
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(null, List.of()));
+
+        SettlementListResponse settlement = settlement(
+                105L, "여행 정산", "OWNER", "OPEN", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(105L, USER_ID))
+                .thenReturn(paymentStatus(105L, BigDecimal.valueOf(10_000), BigDecimal.valueOf(10_000)));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getCategoryLabel()).isEqualTo("ETC");
+        assertThat(item.getInstallmentInfo()).isNull();
+        assertThat(item.getCounterpartyName()).isNull();
     }
 }
 

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -344,7 +344,7 @@ public class CalendarTest {
     }
 
     @Test
-    void 대여_항목에는_상대방_이름과_구분_라벨이_채워진다() {
+    void 대여_항목에는_상대방_이름과_만기일_원금_이자율이_채워진다() {
         LoanContractResponse contract = buildContract(20L, USER_ID, 2L, "생활비 대출", "김채권", "이채무");
         RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 600_000);
 
@@ -358,11 +358,13 @@ public class CalendarTest {
         assertThat(result).hasSize(1);
         DashboardCalendarItemResponse item = result.get(0);
         assertThat(item.getCounterpartyName()).isEqualTo("이채무");
-        assertThat(item.getCategoryLabel()).isEqualTo("수취");
+        assertThat(item.getMaturityDate()).isEqualTo(LocalDate.of(2027, 6, 14));
+        assertThat(item.getPrincipalAmount()).isEqualByComparingTo("1000000");
+        assertThat(item.getInterestRate()).isEqualByComparingTo("5");
     }
 
     @Test
-    void 채무자_입장에서는_상대방이_채권자이고_구분은_납부다() {
+    void 채무자_입장에서는_상대방이_채권자이다() {
         LoanContractResponse contract = buildContract(21L, 2L, USER_ID, "차량구입 대출", "김채권", "이채무");
         RepaymentScheduleDTO schedule = buildSchedule(TARGET_DATE, RepaymentScheduleStatus.PENDING, 350_000);
 
@@ -374,9 +376,7 @@ public class CalendarTest {
                 integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
 
         assertThat(result).hasSize(1);
-        DashboardCalendarItemResponse item = result.get(0);
-        assertThat(item.getCounterpartyName()).isEqualTo("김채권");
-        assertThat(item.getCategoryLabel()).isEqualTo("납부");
+        assertThat(result.get(0).getCounterpartyName()).isEqualTo("김채권");
     }
 
     @Test
@@ -451,5 +451,51 @@ public class CalendarTest {
         assertThat(item.getCategoryLabel()).isEqualTo("ETC");
         assertThat(item.getInstallmentInfo()).isNull();
         assertThat(item.getCounterpartyName()).isNull();
+    }
+
+    @Test
+    void 정산_항목에는_유형과_정산방식과_기간이_채워진다() {
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(null, List.of()));
+
+        SettlementListResponse settlement = new SettlementListResponse(
+                106L, "여행 정산", "OWNER", "TRAVEL", "RECURRING", "CUSTOM",
+                "OPEN", TARGET_DATE, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31),
+                LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(106L, USER_ID))
+                .thenReturn(paymentStatus(106L, BigDecimal.valueOf(10_000), BigDecimal.valueOf(10_000)));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getSettlementTypeLabel()).isEqualTo("정기정산");
+        assertThat(item.getSplitTypeLabel()).isEqualTo("직접입력");
+        assertThat(item.getPeriodStartDate()).isEqualTo(LocalDate.of(2026, 8, 1));
+        assertThat(item.getPeriodEndDate()).isEqualTo(LocalDate.of(2026, 8, 31));
+    }
+
+    @Test
+    void 정산_항목의_유형과_정산방식_기본값은_공동정산과_균등이다() {
+        when(contractDashboardService.getIntegrationDashboardData(USER_ID))
+                .thenReturn(loanData(null, List.of()));
+
+        SettlementListResponse settlement = settlement(
+                107L, "회식비 정산", "OWNER", "OPEN", TARGET_DATE, LocalDateTime.now()
+        );
+        when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));
+        when(settlementPaymentStatusService.getPaymentStatus(107L, USER_ID))
+                .thenReturn(paymentStatus(107L, BigDecimal.valueOf(10_000), BigDecimal.valueOf(10_000)));
+
+        List<DashboardCalendarItemResponse> result =
+                integrationDashboardService.getCalendarDayDetail(USER_ID, TARGET_DATE);
+
+        assertThat(result).hasSize(1);
+        DashboardCalendarItemResponse item = result.get(0);
+        assertThat(item.getSettlementTypeLabel()).isEqualTo("공동정산");
+        assertThat(item.getSplitTypeLabel()).isEqualTo("균등");
     }
 }

--- a/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractchange/ContractChangeServiceTest.java
@@ -219,27 +219,24 @@ class ContractChangeServiceTest {
         }
 
         @Test
-        @DisplayName("채무자가 요청하면 예외가 발생하고 저장하지 않는다")
-        void requestChangeFailsWhenRequesterIsDebtor() {
+        @DisplayName("채무자가 요청해도 정상적으로 저장된다")
+        void requestChangeSucceedsWhenRequesterIsDebtor() {
             LoanContractResponse contract = LoanContractResponse.builder()
                     .contractId(CONTRACT_ID)
                     .status(ContractStatus.COMPLETED)
                     .creditorId(888L)
-                    .debtorId(USER_ID)   // ← 요청자가 채무자인 경우
+                    .debtorId(USER_ID)
                     .build();
 
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
                     .willReturn(contract);
+            given(contractChangeMapper.findByContractId(CONTRACT_ID))
+                    .willReturn(List.of());
 
-            assertThatThrownBy(() -> contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID))
-                    .isInstanceOfSatisfying(
-                            DomainException.class,
-                            exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(ContractChangeErrorCode.NOT_CREDITOR)
-                    );
+            contractChangeService.requestChange(CONTRACT_ID, changeRequest(), USER_ID);
 
-            verify(contractChangeMapper, never()).insert(any());
-            verify(loanContractService, never()).insertChangedContract(any());
+            verify(contractChangeMapper).insert(any());
+            verify(loanContractService).insertChangedContract(any());
         }
     }
 
@@ -251,10 +248,11 @@ class ContractChangeServiceTest {
         private static final Long V2_CONTRACT_ID = 2L;
         private static final String RETURN_REASON = "이율이 너무 높습니다";
 
-        private LoanContractChangeDTO pendingChangeRequest() {
+        private LoanContractChangeDTO pendingChangeRequest(Long requesterId) {
             return LoanContractChangeDTO.builder()
                     .changeRequestId(CHANGE_REQUEST_ID)
                     .contractId(CONTRACT_ID)
+                    .userId(requesterId)
                     .status(ChangeRequestStatus.PENDING)
                     .build();
         }
@@ -268,16 +266,38 @@ class ContractChangeServiceTest {
         }
 
         @Test
-        @DisplayName("채무자가 PENDING 요청을 반려하면 사유를 저장하고 v2를 CHANGE_REJECTED로 바꾼다")
-        void rejectChangeSuccess() {
-            given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID))
+        @DisplayName("채무자가 요청한 건을 채권자가 반려할 수 있다")
+        void rejectChangeSuccessWhenRequesterIsDebtor() {
+            given(loanContractService.findContract(CONTRACT_ID, USER_ID))
                     .willReturn(createContract(ContractStatus.COMPLETED));
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
-                    .willReturn(Optional.of(pendingChangeRequest()));
+                    .willReturn(Optional.of(pendingChangeRequest(DEBTOR_ID)));
             given(contractChangeMapper.updateStatusWithReturnReason(CHANGE_REQUEST_ID, ChangeRequestStatus.REJECTED, RETURN_REASON))
                     .willReturn(1);
             given(loanContractService.findPendingContractByPreviousId(CONTRACT_ID))
                     .willReturn(Optional.of(pendingV2()));
+            given(userService.getMyInfo(USER_ID))
+                    .willReturn(UserResponse.builder().name("채권자").build());
+
+            contractChangeService.rejectChange(CONTRACT_ID, CHANGE_REQUEST_ID, RETURN_REASON, USER_ID);
+
+            verify(contractChangeMapper)
+                    .updateStatusWithReturnReason(CHANGE_REQUEST_ID, ChangeRequestStatus.REJECTED, RETURN_REASON);
+        }
+
+        @Test
+        @DisplayName("채권자가 요청한 건을 채무자가 반려하면 사유를 저장하고 v2를 REJECTED로 바꾼다")
+        void rejectChangeSuccess() {
+            given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID))
+                    .willReturn(createContract(ContractStatus.COMPLETED));
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(pendingChangeRequest(USER_ID)));
+            given(contractChangeMapper.updateStatusWithReturnReason(CHANGE_REQUEST_ID, ChangeRequestStatus.REJECTED, RETURN_REASON))
+                    .willReturn(1);
+            given(loanContractService.findPendingContractByPreviousId(CONTRACT_ID))
+                    .willReturn(Optional.of(pendingV2()));
+            given(userService.getMyInfo(DEBTOR_ID))
+                    .willReturn(UserResponse.builder().name("채무자").build());
 
             contractChangeService.rejectChange(CONTRACT_ID, CHANGE_REQUEST_ID, RETURN_REASON, DEBTOR_ID);
 
@@ -292,14 +312,14 @@ class ContractChangeServiceTest {
             given(loanContractService.findContract(CONTRACT_ID, USER_ID))
                     .willReturn(createContract(ContractStatus.COMPLETED));
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
-                    .willReturn(Optional.of(pendingChangeRequest()));
+                    .willReturn(Optional.of(pendingChangeRequest(USER_ID)));
 
             assertThatThrownBy(() ->
                     contractChangeService.rejectChange(CONTRACT_ID, CHANGE_REQUEST_ID, RETURN_REASON, USER_ID))
                     .isInstanceOfSatisfying(
                             DomainException.class,
                             exception -> assertThat(exception.getErrorCode())
-                                    .isEqualTo(ContractChangeErrorCode.NOT_DEBTOR)
+                                    .isEqualTo(ContractChangeErrorCode.NOT_CONTRACT_PARTY)
                     );
 
             verify(contractChangeMapper, never()).updateStatusWithReturnReason(any(), any(), any());
@@ -312,6 +332,7 @@ class ContractChangeServiceTest {
             LoanContractChangeDTO otherContractRequest = LoanContractChangeDTO.builder()
                     .changeRequestId(CHANGE_REQUEST_ID)
                     .contractId(999L)
+                    .userId(USER_ID)
                     .status(ChangeRequestStatus.PENDING)
                     .build();
 
@@ -335,6 +356,7 @@ class ContractChangeServiceTest {
             LoanContractChangeDTO approvedRequest = LoanContractChangeDTO.builder()
                     .changeRequestId(CHANGE_REQUEST_ID)
                     .contractId(CONTRACT_ID)
+                    .userId(USER_ID)
                     .status(ChangeRequestStatus.APPROVED)
                     .build();
 
@@ -377,7 +399,7 @@ class ContractChangeServiceTest {
             given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID))
                     .willReturn(createContract(ContractStatus.COMPLETED));
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
-                    .willReturn(Optional.of(pendingChangeRequest()));
+                    .willReturn(Optional.of(pendingChangeRequest(USER_ID)));
             given(contractChangeMapper.updateStatusWithReturnReason(CHANGE_REQUEST_ID, ChangeRequestStatus.REJECTED, RETURN_REASON))
                     .willReturn(0);
 
@@ -413,8 +435,33 @@ class ContractChangeServiceTest {
         }
 
         @Test
-        @DisplayName("요청 등록 당사자가 대기 중인 요청에 서명하면 서명을 저장하고 상대방에게 알림을 보낸다")
-        void submitRequesterSignatureSuccess() {
+        @DisplayName("채무자가 요청자면 서명 후 채권자에게 알림이 간다")
+        void submitRequesterSignatureSuccessWhenRequesterIsDebtor() {
+            MultipartFile signature = mock(MultipartFile.class);
+
+            given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
+                    .willReturn(Optional.of(changeRequestDTO(ChangeRequestStatus.PENDING, DEBTOR_ID, CONTRACT_ID)));
+            given(fileService.saveSignatureFile(CHANGE_REQUEST_ID, signature))
+                    .willReturn(SAVED_PATH);
+            given(contractChangeMapper.updateRequesterSignature(CHANGE_REQUEST_ID, SAVED_PATH))
+                    .willReturn(1);
+            given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID))
+                    .willReturn(createContract(ContractStatus.COMPLETED));
+            given(userService.getMyInfo(DEBTOR_ID))
+                    .willReturn(UserResponse.builder().name("채무자").build());
+
+            contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, DEBTOR_ID, signature);
+
+            verify(notificationService).create(
+                    eq(USER_ID),
+                    eq(NotificationType.CONTRACT_CHANGE),
+                    any(), any(), eq(CONTRACT_ID), eq(CHANGE_REQUEST_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("채권자가 요청자면 서명 후 채무자에게 알림이 간다")
+        void submitRequesterSignatureSuccessWhenRequesterIsCreditor() {
             MultipartFile signature = mock(MultipartFile.class);
 
             given(contractChangeMapper.findByChangeRequestId(CHANGE_REQUEST_ID))
@@ -430,15 +477,10 @@ class ContractChangeServiceTest {
 
             contractChangeService.submitRequesterSignature(CONTRACT_ID, CHANGE_REQUEST_ID, USER_ID, signature);
 
-            verify(fileService).saveSignatureFile(CHANGE_REQUEST_ID, signature);
-            verify(contractChangeMapper).updateRequesterSignature(CHANGE_REQUEST_ID, SAVED_PATH);
             verify(notificationService).create(
                     eq(DEBTOR_ID),
                     eq(NotificationType.CONTRACT_CHANGE),
-                    any(),
-                    any(),
-                    eq(CONTRACT_ID),
-                    eq(CHANGE_REQUEST_ID)
+                    any(), any(), eq(CONTRACT_ID), eq(CHANGE_REQUEST_ID)
             );
         }
 

--- a/src/test/java/org/teamsai/saibackend/domain/contractdetail/ContractDetailServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/contractdetail/ContractDetailServiceTest.java
@@ -70,11 +70,39 @@ class ContractDetailServiceTest {
         }
 
         @Test
-        @DisplayName("채무자면 PENDING 요청 여부와 상관없이 false를 반환한다")
-        void falseWhenDebtor() {
+        @DisplayName("채무자이고 PENDING 요청이 없으면 true를 반환한다")
+        void trueWhenDebtorAndNoPendingRequest() {
             given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID)).willReturn(contract());
+            given(contractChangeService.hasPendingChangeRequest(CONTRACT_ID)).willReturn(false);
 
             boolean result = contractDetailService.canRequestChange(CONTRACT_ID, DEBTOR_ID);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("채무자여도 PENDING 요청이 있으면 false를 반환한다")
+        void falseWhenDebtorButHasPendingRequest() {
+            given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID)).willReturn(contract());
+            given(contractChangeService.hasPendingChangeRequest(CONTRACT_ID)).willReturn(true);
+
+            boolean result = contractDetailService.canRequestChange(CONTRACT_ID, DEBTOR_ID);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("당사자가 아니면 PENDING 요청 여부와 상관없이 false를 반환한다")
+        void falseWhenNotContractParty() {
+            LoanContractResponse contract = LoanContractResponse.builder()
+                    .contractId(CONTRACT_ID)
+                    .creditorId(CREDITOR_ID)
+                    .debtorId(DEBTOR_ID)
+                    .build();
+
+            given(loanContractService.findContract(CONTRACT_ID, 999L)).willReturn(contract);
+
+            boolean result = contractDetailService.canRequestChange(CONTRACT_ID, 999L);
 
             assertThat(result).isFalse();
         }
@@ -101,12 +129,13 @@ class ContractDetailServiceTest {
         @DisplayName("채무자로 조회하면 채무자 주소를 반환하고 isCreditor는 false다")
         void returnsDebtorAddressForDebtor() {
             given(loanContractService.findContract(CONTRACT_ID, DEBTOR_ID)).willReturn(contract());
+            given(contractChangeService.hasPendingChangeRequest(CONTRACT_ID)).willReturn(false);
 
             ContractDetailResponse result = contractDetailService.getCheck(CONTRACT_ID, DEBTOR_ID);
 
             assertThat(result.getAddress()).isEqualTo("서울시 채무자로 1");
             assertThat(result.isCreditor()).isFalse();
-            assertThat(result.isCanRequestChange()).isFalse();
+            assertThat(result.isCanRequestChange()).isTrue();
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
- 이 PR이 해결하는 이슈: #156

## 🛠 작업 사항

### 1. 계약 변경 요청 권한 확장
- `requestChange()`: 채권자 전용 체크(`NOT_CREDITOR`) 제거, 당사자(채권자/채무자)면 요청 가능
- `submitRequesterSignature()`: 알림 수신자를 `isCreditor ? debtorId : creditorId`로 동적 결정
- `rejectChange()`: 반려 권한을 "요청자가 아닌 당사자(승인권자)" 기준으로 변경, 반려 알림도 실제 요청자에게 동적 발송
- `ContractDetailService.canRequestChange()`/`getCheck()`: `debtor_id`가 nullable로 바뀐 것에 대응해 `Objects.equals()`로 null-safe 처리 (NPE 수정)

### 2. 권한 확장 과정에서 발견한 파생 버그 수정
- `LoanContractMapper.findContractsByUser()`: `users` 테이블 JOIN 및 `creditorName`/`debtorName` 조회가 누락돼 있던 것 수정 (대시보드/캘린더에서 상대방 이름이 항상 비어있던 원인)
- `LoanContractService.withPartyInfo()`: `creditor.getBirthDate().toString()` / `debtor.getBirthDate().toString()`에서 생년월일 미입력 계정일 때 나던 NPE 수정

### 3. 캘린더 상세 항목 확장
- 날짜 클릭 시 뜨는 상세 목록에 상대방 이름, 회차 정보, 만기일/원금/이자율(대여), 정산 유형(공동정산/정기정산)·정산방식·기간(정산), 연체 여부 추가
- 클릭 시 인라인으로 펼쳐지는 UX + "상세보기" 링크로 각 상세 페이지 이동
- 받을 돈/낼 돈 방향을 색상(초록/주황)으로 구분

### 4. 화면 연결 정리 (신규 화면 공통 가이드 준수)
- `calendar.html`을 가이드 이전 방식(직접 만든 헤더/푸터)에서 `app-shell` 프래그먼트 기반으로 교체
- `calendar.js`의 수동 `fetch()` + `sessionStorage` 토큰 처리를 `authFetch()`로 전환
- 상단 네비게이션 "캘린더" 메뉴 링크가 `href="#"`로 비어있던 것을 `/calendar`로 연결

## ✅ 테스트
- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료 (`ContractChangeServiceTest`, `ContractDetailServiceTest`, `CalendarTest` 신규 케이스 포함)
- [x] 기존 기능에 영향이 없는지 확인 (전체 테스트 중 이 PR 범위 실패 0건)

## 📌 주의 사항 및 참고사항
- `ContractChangeErrorCode`의 `NOT_CREDITOR`/`NOT_DEBTOR`는 더 이상 이 서비스 내에서 안 쓰임. 다른 곳 참조 여부 확인 후 정리 필요