### PR TITLE
bug(#175): 상환현황 화면 입금일 날짜 포맷을 생성일과 동일하게 통일

### DIFF
--- a/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
+++ b/src/main/resources/static/js/contractrepaymentschedule/contractrepaymentschedule.js
@@ -146,7 +146,7 @@ function renderSchedulePage() {
                 <td>${s.sequence}회차</td>
                 <td>${s.dueDate}</td>
                 <td>${s.totalPaymentDue.toLocaleString(undefined, {maximumFractionDigits: 0})}원</td>
-                <td>${s.paidAt ? s.paidAt : '-'}</td>
+                <td>${s.paidAt ? formatDateTimeKorean(s.paidAt) : '-'}</td>
                 <td><span class="${statusClass}">${statusText}</span></td>
             </tr>
         `;


### PR DESCRIPTION
## 🛠 작업 사항
- 상환현황 상세조회 화면에서 입금일(paidAt) 표기를 생성일과 동일한
  형식(formatDateTimeKorean)으로 통일

## ✅ 테스트
- [x] 로컬 서버 테스트 완료
- [ ] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

## 📌 주의 사항 및 참고사항
- 프론트 표기만 바뀐 것이라 DB/API 변경 없음