### PR TITLE
bug(#188): 정기 정산 생성 시 캘린더 오류 수정

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -440,8 +440,8 @@ public class IntegrationDashboardService {
                 .count();
 
         List<SettlementContext> monthlySettlements = settlements.stream()
-                .filter(context -> context.settlement().dueDate() != null)
-                .filter(context -> YearMonth.from(context.settlement().dueDate()).equals(yearMonth))
+                .filter(context -> effectiveDueDate(context.settlement()) != null)
+                .filter(context -> YearMonth.from(effectiveDueDate(context.settlement())).equals(yearMonth))
                 .toList();
         int completedSettlementCount = (int) monthlySettlements.stream()
                 .filter(context -> isClosed(context.settlement()))

--- a/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/integration/service/IntegrationDashboardService.java
@@ -257,11 +257,11 @@ public class IntegrationDashboardService {
         settlements.stream()
                 .filter(context -> !isClosed(context.settlement()))
                 .filter(context -> context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
-                .filter(context -> context.settlement().dueDate() != null)
-                .filter(context -> YearMonth.from(context.settlement().dueDate()).equals(yearMonth))
+                .filter(context -> effectiveDueDate(context.settlement()) != null)
+                .filter(context -> YearMonth.from(effectiveDueDate(context.settlement())).equals(yearMonth))
                 .forEach(context -> {
                     CalendarDirection direction = directionsByDate.computeIfAbsent(
-                            context.settlement().dueDate(), ignored -> new CalendarDirection()
+                            effectiveDueDate(context.settlement()), ignored -> new CalendarDirection()
                     );
                     direction.inbound |= context.isOwner();
                     direction.outbound |= !context.isOwner();
@@ -324,8 +324,8 @@ public class IntegrationDashboardService {
         return settlements.stream()
                 .filter(context -> !isClosed(context.settlement()))
                 .filter(context -> context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
-                .filter(context -> context.settlement().dueDate() != null)
-                .filter(context -> context.settlement().dueDate().equals(date))
+                .filter(context -> effectiveDueDate(context.settlement()) != null)
+                .filter(context -> effectiveDueDate(context.settlement()).equals(date))
                 .map(context -> DashboardCalendarItemResponse.builder()
                         .targetId(context.settlement().settlementId())
                         .type(PaymentTargetType.SETTLEMENT)
@@ -407,13 +407,13 @@ public class IntegrationDashboardService {
                 .filter(context -> !isClosed(context.settlement()))
                 .filter(context -> context.isOwner()
                         || context.roleRemainingAmount().compareTo(BigDecimal.ZERO) > 0)
-                .filter(context -> context.settlement().dueDate() != null)
-                .filter(context -> !context.settlement().dueDate().isBefore(today))
-                .filter(context -> !context.settlement().dueDate().isAfter(attentionLimit))
+                .filter(context -> effectiveDueDate(context.settlement()) != null)
+                .filter(context -> !effectiveDueDate(context.settlement()).isBefore(today))
+                .filter(context -> !effectiveDueDate(context.settlement()).isAfter(attentionLimit))
                 .map(context -> DashboardAttentionItemResponse.builder()
                         .id(context.settlement().settlementId())
                         .type(DashboardAttentionType.SETTLEMENT_DUE_SOON)
-                        .remainingDays(ChronoUnit.DAYS.between(today, context.settlement().dueDate()))
+                        .remainingDays(ChronoUnit.DAYS.between(today, effectiveDueDate(context.settlement())))
                         .actionUrl("/settlements/" + context.settlement().settlementId())
                         .build())
                 .forEach(items::add);
@@ -472,6 +472,12 @@ public class IntegrationDashboardService {
 
     private boolean isClosed(SettlementListResponse settlement) {
         return "CLOSED".equals(settlement.settlementStatus());
+    }
+
+    private LocalDate effectiveDueDate(SettlementListResponse settlement) {
+        return "RECURRING".equals(settlement.settlementType())
+                ? settlement.cycleDate()
+                : settlement.dueDate();
     }
 
     private record SettlementContext(

--- a/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
+++ b/src/main/java/org/teamsai/saibackend/domain/settlement/dto/response/SettlementListResponse.java
@@ -15,6 +15,7 @@ public record SettlementListResponse(
         LocalDate dueDate,
         LocalDate startDate,
         LocalDate endDate,
+        LocalDate cycleDate,
         @JsonIgnore LocalDateTime createdAt
 ) {
 }

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -128,6 +128,7 @@
         s.due_date AS dueDate,
         rs.start_date AS startDate,
         rs.end_date AS endDate,
+        s.cycle_date AS cycleDate,
         s.created_at AS createdAt
 
         FROM settlement s

--- a/src/main/resources/static/js/contractdashboard/dashboard2.js
+++ b/src/main/resources/static/js/contractdashboard/dashboard2.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const sort = document.getElementById('contract-sort');
     const toast = document.getElementById('toast');
     let rows = [];
+    let currentPage = 1;
 
     const escapeHtml = value => String(value ?? '')
         .replaceAll('&', '&amp;')
@@ -54,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function load() {
-        const url = `/api/dashboard?keyword=${encodeURIComponent(search.value)}&roleFilter=ALL&statusFilter=${status.value}&sortType=${sort.value}&page=1`;
+        const url = `/api/dashboard?keyword=${encodeURIComponent(search.value)}&roleFilter=ALL&statusFilter=${status.value}&sortType=${sort.value}&page=${currentPage}`;
         const response = await authFetch(url);
         if (!response.ok) throw new Error('차용증 조회에 실패했습니다.');
         const data = await response.json();
@@ -64,15 +65,32 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('borrowed-amount').textContent = Number(data.summary?.totalBorrowedAmount || 0).toLocaleString();
         document.getElementById('receivable-count').textContent = `${data.summary?.receivableCount ?? 0}건`;
         document.getElementById('payable-count').textContent = `${data.summary?.payableCount ?? 0}건`;
+        renderPagination(data.currentPage || 1, data.totalPages || 1);
         apply();
     }
 
     search.addEventListener('input', apply);
-    status.addEventListener('change', load);
-    sort.addEventListener('change', load);
+    status.addEventListener('change', () => { currentPage = 1; load(); });
+    sort.addEventListener('change', () => { currentPage = 1; load(); });
     document.getElementById('create-contract-button').addEventListener('click', () => location.href = '/contracts/new');
     document.getElementById('empty-create-button').addEventListener('click', () => location.href = '/contracts/new');
     document.getElementById('sync-button').addEventListener('click', syncTransactions);
+
+    function renderPagination(currentPageNum, totalPages) {
+        const pagination = document.getElementById('pagination');
+        pagination.innerHTML = '';
+
+        for (let i = 1; i <= totalPages; i++) {
+            const btn = document.createElement('button');
+            btn.textContent = i;
+            if (i === currentPageNum) btn.classList.add('is-active');
+            btn.addEventListener('click', () => {
+                currentPage = i;
+                load();
+            });
+            pagination.appendChild(btn);
+        }
+    }
 
     async function syncTransactions() {
         const button = document.getElementById('sync-button');

--- a/src/main/resources/templates/contractdashboard/dashboard2.html
+++ b/src/main/resources/templates/contractdashboard/dashboard2.html
@@ -10,6 +10,8 @@
     <link rel="stylesheet" href="/css/settlement/settlement-common.css">
     <link rel="stylesheet" href="/css/settlement/settlement-list.css">
     <link rel="stylesheet" href="/css/matching/matching-review-modal.css">
+    <link rel="stylesheet" href="/css/contractdashboard/contract-dashboard.css">
+    <link rel="stylesheet" href="/css/contract/contract-form.css">
 </head>
 <body class="app-shell-page">
 <header th:replace="~{fragments/app-shell :: appHeader('contract')}"></header>
@@ -42,7 +44,13 @@
         <div class="settlement-table settlement-table-head contract2-table-head contract2-table-head-wide"><span>계약명</span><span>역할</span><span>거래 금액(원금/잔액)</span><span>다음 상환 예정금액</span><span>다음 상환일</span><span>계약 상태</span><span>만기일</span><span>상세</span></div>
         <div id="contract-list" class="settlement-list"></div>
         <div id="contract-empty-state" class="empty-state" hidden><h2>표시할 계약 없습니다.</h2><p>계약을 만들면 이곳에서 확인할 수 있어요.</p><button id="empty-create-button" class="button button-primary" type="button">첫 계약 만들기</button></div>
+        <div id="pagination" class="pagination"></div>
     </section>
+
+    <p class="disclaimer">
+        * 본 화면에 표시되는 금액과 일정은 각 계약의 내용을 요약하여 참고용으로 안내하는 정보이며, 실제 입금/처리 시점에 따라 표시된 상태와 차이가 있을 수 있습니다. 금액은 원 단위 미만은 반올림하여 표시됩니다.
+    </p>
+
 </main>
 
 <footer th:replace="~{fragments/app-shell :: appFooter}"></footer>

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -322,7 +322,7 @@ public class CalendarTest {
     private SettlementListResponse settlement(
             Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
     ) {
-        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, null, null, createdAt);
+        return new SettlementListResponse(id, title, role, "ETC", "ONE_TIME", "EQUAL", status, dueDate, null, null, null, createdAt);
     }
 
     private DashboardService.IntegrationDashboardData loanData(
@@ -461,6 +461,7 @@ public class CalendarTest {
         SettlementListResponse settlement = new SettlementListResponse(
                 106L, "여행 정산", "OWNER", "TRAVEL", "RECURRING", "CUSTOM",
                 "OPEN", TARGET_DATE, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31),
+                TARGET_DATE,
                 LocalDateTime.now()
         );
         when(settlementQueryService.getSettlementList(USER_ID)).thenReturn(List.of(settlement));

--- a/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/calendar/CalendarTest.java
@@ -460,7 +460,7 @@ public class CalendarTest {
 
         SettlementListResponse settlement = new SettlementListResponse(
                 106L, "여행 정산", "OWNER", "TRAVEL", "RECURRING", "CUSTOM",
-                "OPEN", TARGET_DATE, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31),
+                "OPEN", null, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31),
                 TARGET_DATE,
                 LocalDateTime.now()
         );

--- a/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/integration/IntegrationDashboardServiceTest.java
@@ -383,7 +383,7 @@ class IntegrationDashboardServiceTest {
             Long id, String title, String role, String status, LocalDate dueDate, LocalDateTime createdAt
     ) {
         return new SettlementListResponse(
-                id, title, role, "ETC", "SHARED", "EQUAL", status, dueDate, null, null, createdAt
+                id, title, role, "ETC", "SHARED", "EQUAL", status, dueDate, null, null, null, createdAt
         );
     }
 


### PR DESCRIPTION
## 🛠 작업 사항
- IntegrationDashboardService에 effectiveDueDate() 헬퍼 추가 — settlementType이
  RECURRING이면 cycleDate를, 아니면 dueDate를 사용하도록 분기
- getCalendarDays(), getSettlementCalendarItems(), getAttentionItems() 세 곳
  모두 dueDate 직접 참조를 effectiveDueDate()로 교체
- SettlementMapper.xml findAllByUserId에 s.cycle_date AS cycleDate 추가
  (settlement 테이블 컬럼, recurring_settlement 아님 — 처음엔 테이블을
  잘못 짚어서 두 번 헤맴)
- SettlementListResponse 레코드에 cycleDate 필드 추가에 따라, 관련 테스트
  3곳(CalendarTest 2곳, IntegrationDashboardServiceTest 1곳)의 생성자
  호출부 인자 보정

## ✅ 테스트
- [x] 로컬 서버 테스트 완료 (정기정산 생성 후 캘린더에 표시 확인)
- [x] 핵심 기능 테스트 코드 수정 및 실행 완료
- [x] 기존 기능(공동정산 캘린더 표시)에 영향 없음 확인

## 📌 주의 사항 및 참고사항
- cycle_date 컬럼이 로컬 DB에 없다면 settlement.sql 하단의 ALTER 문 실행 필요