### PR TITLE
bug(#195): 거래 동기화시 정산/차용증 겹치면 알림창에 뜨는 로직 변경

### DIFF
--- a/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewSearchCondition.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/dto/request/MatchingReviewSearchCondition.java
@@ -15,8 +15,7 @@ public record MatchingReviewSearchCondition(
     public MatchingReviewSearchCondition {
         if (reviewChannel == null
                 || aggregateId != null && (aggregateId <= 0 || targetType == null)
-                || reviewChannel == MatchingReviewChannel.NOTIFICATION
-                && (targetType != null || aggregateId != null)) {
+                || reviewChannel == MatchingReviewChannel.NOTIFICATION) {
             throw MatchingErrorCode.INVALID_MATCHING_REQUEST.toException();
         }
 
@@ -32,7 +31,4 @@ public record MatchingReviewSearchCondition(
         return page * size;
     }
 
-    public boolean isNotificationChannel() {
-        return reviewChannel == MatchingReviewChannel.NOTIFICATION;
-    }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.teamsai.saibackend.domain.matching.exception.MatchingErrorCode;
-import org.teamsai.saibackend.domain.matching.dto.BankTransactionMatchCandidateDTO;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingExecutionResult;
 import org.teamsai.saibackend.domain.matching.model.AutoMatchingTransactionResult;
 import org.teamsai.saibackend.domain.matching.model.MatchingCandidate;
@@ -12,8 +11,6 @@ import org.teamsai.saibackend.domain.matching.model.MatchingTransaction;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingProcessStatus;
 import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
-import org.teamsai.saibackend.domain.notification.service.NotificationService;
-import org.teamsai.saibackend.domain.notification.type.NotificationType;
 import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
 import org.teamsai.saibackend.domain.transaction.service.BankTransactionService;
@@ -29,8 +26,6 @@ public class BankMatchingTransactionService {
     private final PaymentObligationMapper paymentObligationMapper;
     private final AutoMatchingService autoMatchingService;
     private final BankTransactionService bankTransactionService;
-    private final BankTransactionMatchCandidateService candidateService;
-    private final NotificationService notificationService;
 
     @Transactional
     public AutoMatchingTransactionResult process(
@@ -83,58 +78,6 @@ public class BankMatchingTransactionService {
         );
 
         return result;
-    }
-
-    private void createMatchingReviewNotificationIfRequired(
-            Long userId,
-            Long linkedAccountId,
-            BankTransactionDTO bankTransaction,
-            AutoMatchingTransactionResult result
-    ) {
-        if (result.processStatus()
-                != AutoMatchingProcessStatus.NEEDS_CHECK) {
-            return;
-        }
-
-        List<BankTransactionMatchCandidateDTO> candidates =
-                candidateService.findAllByBankTransactionId(
-                        bankTransaction.getBankTransactionId()
-                );
-
-        boolean hasSettlement = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.SETTLEMENT);
-        boolean hasLoan = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.LOAN);
-
-        if (!hasSettlement || !hasLoan) {
-            return;
-        }
-
-        notificationService.createIfAbsent(
-                userId,
-                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
-                "입금 거래 확인이 필요합니다.",
-                createNotificationContent(bankTransaction),
-                bankTransaction.getBankTransactionId(),
-                linkedAccountId
-        );
-    }
-
-    private String createNotificationContent(
-            BankTransactionDTO bankTransaction
-    ) {
-        String counterpartyName = bankTransaction.getCounterpartyName();
-
-        if (counterpartyName == null || counterpartyName.isBlank()) {
-            counterpartyName = "입금자 미상";
-        }
-
-        return counterpartyName
-                + "님의 "
-                + bankTransaction.getAmount().toPlainString()
-                + "원 입금에 정산과 차용증 후보가 모두 발견되었습니다.";
     }
 
     private AutoMatchingTransactionResult processMatching(

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankMatchingTransactionService.java
@@ -76,13 +76,6 @@ public class BankMatchingTransactionService {
             return null;
         }
 
-        createMatchingReviewNotificationIfRequired(
-                userId,
-                linkedAccountId,
-                lockedTransaction,
-                result
-        );
-
         bankTransactionService.updateStatus(
                 lockedTransaction.getBankTransactionId(),
                 BankTransactionProcessingStatus.PENDING,

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewListQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewListQueryService.java
@@ -91,15 +91,6 @@ public class BankTransactionMatchingReviewListQueryService {
     private MatchingReviewChannel determineReviewChannel(
             List<BankTransactionMatchCandidateQueryDTO> candidates
     ) {
-        boolean hasSettlement = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.SETTLEMENT);
-        boolean hasLoan = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.LOAN);
-
-        return hasSettlement && hasLoan
-                ? MatchingReviewChannel.NOTIFICATION
-                : MatchingReviewChannel.TRANSACTION_HISTORY;
+        return MatchingReviewChannel.TRANSACTION_HISTORY;
     }
 }

--- a/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
+++ b/src/main/java/org/teamsai/saibackend/domain/matching/service/BankTransactionMatchingReviewQueryService.java
@@ -54,18 +54,6 @@ public class BankTransactionMatchingReviewQueryService {
     private MatchingReviewChannel determineReviewChannel(
             List<BankTransactionMatchCandidateQueryDTO> candidates
     ) {
-        boolean hasSettlement = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.SETTLEMENT);
-
-        boolean hasLoan = candidates.stream()
-                .anyMatch(candidate -> candidate.getTargetType()
-                        == MatchingTargetType.LOAN);
-
-        if (hasSettlement && hasLoan) {
-            return MatchingReviewChannel.NOTIFICATION;
-        }
-
         return MatchingReviewChannel.TRANSACTION_HISTORY;
     }
 }

--- a/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
+++ b/src/main/resources/mapper/matching/BankTransactionMatchingReviewQueryMapper.xml
@@ -113,45 +113,7 @@
             AND available_candidate.candidate_status = 'AVAILABLE'
             <include refid="ReviewCandidateValidity"/>
         )
-        <choose>
-            <when test="condition.notificationChannel">
-                AND EXISTS (
-                    SELECT 1
-                    FROM bank_transaction_match_candidate available_candidate
-                    WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
-                    AND available_candidate.candidate_status = 'AVAILABLE'
-                    AND available_candidate.target_type = 'SETTLEMENT'
-                    <include refid="ReviewCandidateValidity"/>
-                )
-                AND EXISTS (
-                    SELECT 1
-                    FROM bank_transaction_match_candidate available_candidate
-                    WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
-                    AND available_candidate.candidate_status = 'AVAILABLE'
-                    AND available_candidate.target_type = 'LOAN'
-                    <include refid="ReviewCandidateValidity"/>
-                )
-            </when>
-            <otherwise>
-                AND NOT (
-                    EXISTS (
-                        SELECT 1
-                        FROM bank_transaction_match_candidate available_candidate
-                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND available_candidate.candidate_status = 'AVAILABLE'
-                        AND available_candidate.target_type = 'SETTLEMENT'
-                        <include refid="ReviewCandidateValidity"/>
-                    )
-                    AND EXISTS (
-                        SELECT 1
-                        FROM bank_transaction_match_candidate available_candidate
-                        WHERE available_candidate.bank_transaction_id = bt.bank_transaction_id
-                        AND available_candidate.candidate_status = 'AVAILABLE'
-                        AND available_candidate.target_type = 'LOAN'
-                        <include refid="ReviewCandidateValidity"/>
-                    )
-                )
-                <if test="condition.targetType != null">
+        <if test="condition.targetType != null">
                     AND EXISTS (
                         SELECT 1
                         FROM bank_transaction_match_candidate available_candidate
@@ -160,8 +122,8 @@
                         AND available_candidate.target_type = #{condition.targetType}
                         <include refid="ReviewCandidateValidity"/>
                     )
-                </if>
-                <if test="condition.aggregateId != null">
+        </if>
+        <if test="condition.aggregateId != null">
                     AND EXISTS (
                         SELECT 1
                         FROM bank_transaction_match_candidate available_candidate
@@ -184,9 +146,7 @@
                                 THEN schedule.contract_id
                             END = #{condition.aggregateId}
                     )
-                </if>
-            </otherwise>
-        </choose>
+        </if>
     </sql>
 
     <select id="search" resultMap="BankTransactionResultMap">

--- a/src/main/resources/static/js/matching/matching-review-modal.js
+++ b/src/main/resources/static/js/matching/matching-review-modal.js
@@ -76,7 +76,7 @@
         }
 
         state.options = {
-            reviewChannel: "NOTIFICATION",
+            reviewChannel: "TRANSACTION_HISTORY",
             targetType: null,
             aggregateId: null,
             transaction: {

--- a/src/main/resources/static/js/settlement/settlement-create.js
+++ b/src/main/resources/static/js/settlement/settlement-create.js
@@ -121,8 +121,8 @@ document.addEventListener("DOMContentLoaded", () => {
     function updateFormByType() {
         const shared = settlementType === "SHARED";
         updateTotalAmountLabel(shared
-            ? "\uD68C\uCC28\uBCC4 \uCD1D\uAE08\uC561 (\uD544\uC218)"
-            : "\uCD1D \uAE08\uC561 (\uD544\uC218)");
+            ? "\uCD1D \uAE08\uC561 (\uD544\uC218)"
+            : "\uD68C\uCC28\uBCC4 \uCD1D\uAE08\uC561 (\uD544\uC218)");
 
         categorySelect.innerHTML = categoryOptions[settlementType]
             .map(([value, label]) => `<option value="${value}">${label}</option>`)
@@ -160,8 +160,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function updateTotalAmountLabel(labelText) {
         const amountInput = document.getElementById("total-amount");
+        const cardTitle = amountInput?.closest("section")
+            ?.querySelector(".card-title h2");
         const label = amountInput?.closest("label")?.querySelector("span")
             || amountInput?.parentElement?.querySelector("span");
+        if (cardTitle) {
+            cardTitle.textContent = labelText.replace(" (필수)", "");
+        }
         if (label) label.textContent = labelText;
     }
 

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
@@ -21,7 +21,6 @@ import org.teamsai.saibackend.domain.matching.type.AutoMatchingTransactionType;
 import org.teamsai.saibackend.domain.matching.type.MatchingTargetType;
 import org.teamsai.saibackend.domain.payment.mapper.PaymentObligationMapper;
 import org.teamsai.saibackend.domain.notification.service.NotificationService;
-import org.teamsai.saibackend.domain.notification.type.NotificationType;
 import org.teamsai.saibackend.domain.matching.type.MatchingAmountType;
 import org.teamsai.saibackend.domain.transaction.dto.BankTransactionDTO;
 import org.teamsai.saibackend.domain.transaction.exception.BankTransactionErrorCode;
@@ -272,7 +271,7 @@ class BankMatchingTransactionServiceTest {
 
     @Test
     @DisplayName("정산과 차용증 후보가 모두 있으면 매칭 검토 알림을 생성한다")
-    void createsNotificationForCrossDomainCandidates() {
+    void doesNotCreateNotificationForCrossDomainCandidates() {
         BankTransactionDTO transaction = bankTransaction(
                 101L,
                 "Hong Gil Dong"
@@ -287,29 +286,22 @@ class BankMatchingTransactionServiceTest {
                         101L,
                         AutoMatchingProcessStatus.NEEDS_CHECK
                 )));
-        given(candidateService.findAllByBankTransactionId(101L))
-                .willReturn(List.of(
-                        candidateDto(
-                                1L,
-                                MatchingTargetType.SETTLEMENT
-                        ),
-                        candidateDto(2L, MatchingTargetType.LOAN)
-                ));
-
         transactionService.process(
                 USER_ID,
                 LINKED_ACCOUNT_ID,
                 transaction
         );
 
-        verify(notificationService).createIfAbsent(
-                USER_ID,
-                NotificationType.BANK_TRANSACTION_MATCHING_REVIEW,
+        verify(notificationService, never()).createIfAbsent(
+                any(), any(), any(), any(), any(), any()
+        ); /*
+                any(),
+                any(),
                 "입금 거래 확인이 필요합니다.",
                 "Hong Gil Dong님의 10000.00원 입금에 정산과 차용증 후보가 모두 발견되었습니다.",
-                101L,
-                LINKED_ACCOUNT_ID
-        );
+                any(),
+                any()
+        ); */
     }
 
     @Test
@@ -329,12 +321,6 @@ class BankMatchingTransactionServiceTest {
                         101L,
                         AutoMatchingProcessStatus.NEEDS_CHECK
                 )));
-        given(candidateService.findAllByBankTransactionId(101L))
-                .willReturn(List.of(candidateDto(
-                        1L,
-                        MatchingTargetType.SETTLEMENT
-                )));
-
         transactionService.process(
                 USER_ID,
                 LINKED_ACCOUNT_ID,

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankMatchingTransactionServiceTest.java
@@ -414,21 +414,6 @@ class BankMatchingTransactionServiceTest {
         );
     }
 
-    private BankTransactionMatchCandidateDTO candidateDto(
-            Long matchCandidateId,
-            MatchingTargetType targetType
-    ) {
-        return BankTransactionMatchCandidateDTO.builder()
-                .matchCandidateId(matchCandidateId)
-                .bankTransactionId(101L)
-                .targetType(targetType)
-                .targetId(matchCandidateId * 10)
-                .expectedRemainingAmount(new BigDecimal("10000.00"))
-                .amountMatchType(MatchingAmountType.EXACT)
-                .createdAt(LocalDateTime.of(2026, 8, 5, 10, 5))
-                .build();
-    }
-
     private AutoMatchingTransactionResult result(
             Long transactionId,
             AutoMatchingProcessStatus processStatus

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewListQueryServiceTest.java
@@ -107,6 +107,35 @@ class BankTransactionMatchingReviewListQueryServiceTest {
                 );
     }
 
+    @Test
+    void keepsCrossDomainCandidatesInTransactionHistoryChannel() {
+        MatchingReviewSearchCondition condition =
+                new MatchingReviewSearchCondition(
+                        MatchingReviewChannel.TRANSACTION_HISTORY,
+                        null,
+                        null,
+                        0,
+                        20
+                );
+        BankTransactionDTO transaction = transaction(11L);
+        given(reviewQueryMapper.search(1L, condition))
+                .willReturn(List.of(transaction));
+        given(reviewQueryMapper.count(1L, condition)).willReturn(1L);
+        given(candidateService.findAllForReviewByBankTransactionIds(
+                List.of(11L), null, null
+        )).willReturn(List.of(
+                candidate(11L),
+                candidateWithTarget(11L, MatchingTargetType.LOAN)
+        ));
+
+        var result = service.getReviews(1L, condition);
+
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).reviewChannel())
+                .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
+        assertThat(result.content().get(0).candidates()).hasSize(2);
+    }
+
     private BankTransactionDTO transaction(Long id) {
         return BankTransactionDTO.builder()
                 .bankTransactionId(id)
@@ -128,6 +157,24 @@ class BankTransactionMatchingReviewListQueryServiceTest {
                 .targetId(30L)
                 .aggregateId(100L)
                 .targetName("8월 회식비 정산")
+                .participantName("participant")
+                .expectedRemainingAmount(new BigDecimal("10000"))
+                .amountMatchType(MatchingAmountType.PARTIAL)
+                .createdAt(LocalDateTime.of(2026, 8, 17, 10, 1))
+                .build();
+    }
+
+    private BankTransactionMatchCandidateQueryDTO candidateWithTarget(
+            Long transactionId,
+            MatchingTargetType targetType
+    ) {
+        return BankTransactionMatchCandidateQueryDTO.builder()
+                .matchCandidateId(21L)
+                .bankTransactionId(transactionId)
+                .targetType(targetType)
+                .targetId(31L)
+                .aggregateId(101L)
+                .targetName("loan")
                 .participantName("participant")
                 .expectedRemainingAmount(new BigDecimal("10000"))
                 .amountMatchType(MatchingAmountType.PARTIAL)

--- a/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/BankTransactionMatchingReviewQueryServiceTest.java
@@ -129,7 +129,7 @@ class BankTransactionMatchingReviewQueryServiceTest {
                 );
 
         assertThat(response.reviewChannel())
-                .isEqualTo(MatchingReviewChannel.NOTIFICATION);
+                .isEqualTo(MatchingReviewChannel.TRANSACTION_HISTORY);
         assertThat(response.candidates()).hasSize(2);
         verify(bankTransactionQueryService).getTransactionDetail(
                 USER_ID,

--- a/src/test/java/org/teamsai/saibackend/domain/matching/MatchingReviewSearchConditionTest.java
+++ b/src/test/java/org/teamsai/saibackend/domain/matching/MatchingReviewSearchConditionTest.java
@@ -49,6 +49,17 @@ class MatchingReviewSearchConditionTest {
         ));
     }
 
+    @Test
+    void rejectsNotificationChannel() {
+        assertInvalid(() -> new MatchingReviewSearchCondition(
+                MatchingReviewChannel.NOTIFICATION,
+                null,
+                null,
+                0,
+                20
+        ));
+    }
+
     private void assertInvalid(Runnable action) {
         assertThatThrownBy(action::run)
                 .isInstanceOfSatisfying(


### PR DESCRIPTION
## 🔗 연관 이슈

- 이 PR이 해결하는 이슈: #195 

## 🛠 작업 사항

- 거래 동기화시 정산/차용증 겹치면 알림창에 뜨는 로직 변경

## ✅ 테스트

- [x] 로컬 서버 테스트 완료
- [x] 핵심 기능 테스트 코드 작성 및 실행 완료
- [x] 기존 기능에 영향이 없는지 확인

